### PR TITLE
Fix missing access-verified recheck after Firebase auth wait in inter…

### DIFF
--- a/interview-questions.html
+++ b/interview-questions.html
@@ -1845,7 +1845,11 @@
           console.warn('[INTERVIEW-Q] Auth ready timeout in checkAuthentication:', e);
         }
       }
-      
+      // Recheck: head guard may have verified access during the Firebase wait
+      if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
+        return true;
+      }
+
       // Use navigation system's authentication check for consistency
       if (window.JobHackAINavigation) {
         const authState = window.JobHackAINavigation.getAuthState();


### PR DESCRIPTION
…view-questions.html

Add recheck of window.__JOBHACKAI_ACCESS_VERIFIED__ after awaiting FirebaseAuthManager.waitForAuthReady() in checkAuthentication, matching the pattern already used in resume-feedback-pro.html. Without this, if the head guard's async path sets the flag during the 3-second Firebase wait, the function falls through to its own auth check which may incorrectly show "Login Required" to an authenticated user.

https://claude.ai/code/session_01M956gN5Cxo3oHeMpCyjHaP

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small guard-condition change that only affects the login-required rendering path by preventing a race where the head auth guard verifies access during the Firebase wait.
> 
> **Overview**
> Prevents a race in `interview-questions.html` where `checkAuthentication()` could fall through to its own auth check after `FirebaseAuthManager.waitForAuthReady()` and incorrectly render the **Login Required** screen.
> 
> The function now rechecks `window.__JOBHACKAI_ACCESS_VERIFIED__` immediately after the Firebase wait and returns early if the head guard verified access in the meantime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 435a95cf5fc95f8d38635ecad51163d263af2b22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->