### PR TITLE
Fix race condition in access control verification

### DIFF
--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1536,6 +1536,12 @@
     }
     
     async function enforceAccessControl(allowedPlans) {
+      // Skip if head guard already verified access (prevents race-condition redirects)
+      if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
+        console.log('[RESUME-FEEDBACK] enforceAccessControl: skipping, head guard already verified access');
+        return;
+      }
+
       // TRI-STATE FIX: Wait for Firebase auth to be ready before redirecting
       // This prevents race conditions where Firebase is still initializing
       let isAuthenticated, plan;
@@ -1545,7 +1551,13 @@
         try {
           console.log('[RESUME-FEEDBACK] Waiting for Firebase auth to be ready before access control check...');
           const user = await window.FirebaseAuthManager.waitForAuthReady(8000);
-          
+
+          // Re-check after async wait — head guard may have verified during the wait
+          if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
+            console.log('[RESUME-FEEDBACK] enforceAccessControl: head guard verified during auth wait');
+            return;
+          }
+
           // Prefer Firebase user result over navigation state (navigation may not have synced yet)
           if (window.JobHackAINavigation) {
             const authState = window.JobHackAINavigation.getAuthState();


### PR DESCRIPTION
## Summary
Added guards to prevent race condition redirects in the `enforceAccessControl` function by checking if the head guard has already verified access before proceeding with access control checks.

## Key Changes
- Added initial check for `window.__JOBHACKAI_ACCESS_VERIFIED__` flag at the start of `enforceAccessControl` to skip redundant verification
- Added re-check after the async Firebase auth wait completes, since the head guard may have verified access during the wait period
- Added console logging to track when access verification is skipped due to head guard verification

## Implementation Details
The fix addresses a race condition where both the head guard and the `enforceAccessControl` function could attempt to redirect users simultaneously. By checking the `__JOBHACKAI_ACCESS_VERIFIED__` flag at two critical points:
1. **Before async operations** - prevents unnecessary processing if already verified
2. **After async wait** - accounts for verification that may occur during the Firebase auth initialization wait

This ensures a single source of truth for access control verification and prevents conflicting redirects.

https://claude.ai/code/session_01Nd1rs91U529ypnjBxsKS72

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-side access control/redirect flow; incorrect flag state or timing could inadvertently allow/deny access, though changes are narrowly scoped to guard conditions and logging.
> 
> **Overview**
> Prevents duplicate/racing access-control redirects in `resume-feedback-pro.html` by short-circuiting `enforceAccessControl` when a global `window.__JOBHACKAI_ACCESS_VERIFIED__` flag indicates the head guard already verified access.
> 
> Adds a second flag re-check immediately after the async `waitForAuthReady` completes to avoid redirects if verification happens during the Firebase auth initialization wait, and includes additional console logging for these skip paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13d117aa3c83ee257332f6355807eb0eab227edb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->