### PR TITLE
Remove upgrade banner display for unauthorized users

### DIFF
--- a/interview-questions.html
+++ b/interview-questions.html
@@ -4496,10 +4496,8 @@ function initIQPage(){
           mockBtn?.setAttribute('data-locked','true');
         }
       } else {
-        // Lock input and show upgrade prompt
+        // Page guard already redirects unauthorized users; never show upgrade banner.
         roleInput.disabled = true;
-        upgradeBtn.style.display = 'block';
-        lockDiv.style.display = 'block';
         if (mockLock) mockLock.style.display = 'inline-flex';
         mockBtn?.setAttribute('data-locked','true');
       }


### PR DESCRIPTION
## Summary
Updated the unauthorized user handling logic to remove the display of the upgrade banner and lock notification, since page-level guards already redirect unauthorized users before they reach this code path.

## Key Changes
- Removed `upgradeBtn.style.display = 'block'` statement that was unnecessarily showing the upgrade button
- Removed `lockDiv.style.display = 'block'` statement that was unnecessarily showing the lock notification
- Updated the comment to clarify that page guards handle unauthorized user redirection, making the upgrade banner display redundant

## Implementation Details
The code path for unauthorized users (the `else` block) now only disables the role input and sets the mock lock state, since the page-level guard ensures unauthorized users never actually reach this code execution point. This removes dead code and simplifies the logic.

https://claude.ai/code/session_016YMfdo7GqcMF8bwLyKKPJo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that removes a redundant upsell/lock display path for unauthorized users; core auth/plan enforcement remains handled by existing page guards and redirects.
> 
> **Overview**
> Removes the unauthorized-user UI fallback in `updateInterviewUIForPlan()` so the page no longer shows the `#iq-upgrade` button or `#iq-lock` banner when a user lacks access.
> 
> The unauthorized branch now only disables the role input and keeps the Mock Interview CTA locked, relying on the existing page-level access guard to redirect instead of presenting an upgrade prompt.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0896a97030b18efdc16471190ca5e541683c2b28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->