### PR TITLE
Release: develop -> main — GDPR, lifecycle, feedback, auth, security hardening

### DIFF
--- a/404.html
+++ b/404.html
@@ -164,6 +164,7 @@
     })();
   </script>
   <!-- Load Firebase auth (required for navigation auth state detection) -->
+  <script src="/js/plan-cache.js"></script>
   <script type="module" src="/js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="/js/navigation.js?v=20260208-1"></script>

--- a/account-setting.html
+++ b/account-setting.html
@@ -654,6 +654,7 @@
   </script>
   
   <!-- Account Settings Functionality -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <script type="module" src="js/firestore-profiles.js"></script>
   <script>

--- a/app/src/pages/dashboard.tsx
+++ b/app/src/pages/dashboard.tsx
@@ -284,21 +284,32 @@ export default function Dashboard() {
         // SECURITY: Do NOT store user-email in localStorage - email available via Firebase auth
         try { localStorage.setItem('user-authenticated', 'true'); } catch (_) {}
 
-        // Default plan
+        // Read plan from PlanCache (populated by firebase-auth.js) or localStorage.
+        // Do NOT call /api/plan/me here — firebase-auth.js already fetched it via PlanCache.
         let plan = 'free';
         let trialEndsAt = '';
         let token = '';
         try {
           token = await u.getIdToken();
-          const r = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${token}` } });
-          if (r.ok) {
-            const data = await r.json();
-            plan = data?.plan || 'free';
-            trialEndsAt = data?.trialEndsAt || '';
-            try {
-              localStorage.setItem('user-plan', plan);
-              if (trialEndsAt) localStorage.setItem('trial-ends-at', trialEndsAt);
-            } catch (_) {}
+          // Try PlanCache first (deduplicated, already fetched by firebase-auth.js)
+          const w = window as any;
+          if (w.PlanCache) {
+            const cached = w.PlanCache.getCachedPlan();
+            if (cached && cached.plan) {
+              plan = cached.plan;
+              trialEndsAt = cached.trialEndsAt || '';
+            } else {
+              // PlanCache exists but hasn't been populated yet — fetch through it
+              const result = await w.PlanCache.getPlan(token);
+              if (result) {
+                plan = result.plan || 'free';
+                trialEndsAt = result.trialEndsAt || '';
+              }
+            }
+          } else {
+            // PlanCache not loaded (unlikely in HTML dashboard) — read localStorage
+            plan = localStorage.getItem('user-plan') || 'free';
+            trialEndsAt = localStorage.getItem('trial-ends-at') || '';
           }
         } catch (_) {}
 

--- a/app/tests/e2e/full-app-check.spec.js
+++ b/app/tests/e2e/full-app-check.spec.js
@@ -32,6 +32,7 @@ async function forceAuthenticatedPlan(page, plan = 'pro') {
       localStorage.setItem('dev-plan', planValue);
       // Signal to all page guards that access is pre-verified for testing
       window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+      window.__JOBHACKAI_VERIFIED_PLAN__ = planValue;
     } catch {
       // no-op
     }

--- a/cookies.html
+++ b/cookies.html
@@ -290,6 +290,7 @@
   </footer>
 
   <!-- Load Firebase auth (ensures logged-in nav renders) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/cover-letter-generator.html
+++ b/cover-letter-generator.html
@@ -285,6 +285,7 @@
   <script src="js/main.js" type="module"></script>
   <script src="js/analytics.js" type="module"></script>
   <!-- Load Firebase auth for token retrieval -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/dashboard.html
+++ b/dashboard.html
@@ -1305,15 +1305,20 @@
         }
       } catch (_) {}
       
-      // Fetch trial data from D1 via /api/plan/me (source of truth)
+      // Fetch trial data from D1 via PlanCache (deduplicated)
       let trialEndsAtFromAPI = null;
       try {
         const firebaseToken = await getFirebaseIdToken();
-        if (firebaseToken) {
+        if (firebaseToken && window.PlanCache) {
+          const result = await window.PlanCache.getPlan(firebaseToken);
+          if (result && result.trialEndsAt) {
+            trialEndsAtFromAPI = result.trialEndsAt;
+            console.log('✅ Fetched trial end date from PlanCache:', result.trialEndsAt);
+          }
+        } else if (firebaseToken) {
           const planResponse = await fetch('/api/plan/me', {
             headers: { 'Authorization': `Bearer ${firebaseToken}` }
           });
-          
           if (planResponse.ok) {
             const planData = await planResponse.json();
             if (planData.trialEndsAt) {
@@ -1376,13 +1381,19 @@
         try {
           const firebaseToken = await getFirebaseIdToken();
           if (!firebaseToken) return;
-          
-          const planResponse = await fetch('/api/plan/me', {
-            headers: { 'Authorization': `Bearer ${firebaseToken}` }
-          });
-          
-          if (planResponse.ok) {
-            const planData = await planResponse.json();
+
+          let planData = null;
+          if (window.PlanCache) {
+            const result = await window.PlanCache.getPlan(firebaseToken, true);
+            if (result) planData = result;
+          } else {
+            const planResponse = await fetch('/api/plan/me', {
+              headers: { 'Authorization': `Bearer ${firebaseToken}` }
+            });
+            if (planResponse.ok) planData = await planResponse.json();
+          }
+
+          if (planData) {
             const newPlan = planData.plan || 'free';
             
             // Check if plan changed
@@ -1498,13 +1509,18 @@
           try {
             const firebaseToken = await getFirebaseIdToken();
             if (!firebaseToken) return;
-            
-            const planResponse = await fetch('/api/plan/me', {
-              headers: { 'Authorization': `Bearer ${firebaseToken}` }
-            });
-            
-            if (planResponse.ok) {
-              const planData = await planResponse.json();
+
+            let planData = null;
+            if (window.PlanCache) {
+              planData = await window.PlanCache.getPlan(firebaseToken, true);
+            } else {
+              const planResponse = await fetch('/api/plan/me', {
+                headers: { 'Authorization': `Bearer ${firebaseToken}` }
+              });
+              if (planResponse.ok) planData = await planResponse.json();
+            }
+
+            if (planData) {
               
               // Check if plan changed (trial expired) - CRITICAL: always check this
               if (planData.plan !== 'trial' && planState.currentPlan === 'trial') {
@@ -1638,12 +1654,15 @@
       try {
         const user = window.FirebaseAuthManager?.getCurrentUser?.();
         if (!user) return null;
-        
+
         const idToken = await user.getIdToken();
+        if (window.PlanCache) {
+          return await window.PlanCache.getPlan(idToken);
+        }
         const res = await fetch('/api/plan/me', {
           headers: { Authorization: `Bearer ${idToken}` }
         });
-        
+
         if (!res.ok) return null;
         return await res.json();
       } catch (e) {
@@ -2602,15 +2621,24 @@
           // Fallback to plan/me if billing-status didn't work
           if (plan === 'free') {
             try {
-              const planRes = await fetch('/api/plan/me', {
-                headers: { Authorization: `Bearer ${idToken}` }
-              });
-              if (planRes.ok) {
-                const planData = await planRes.json();
-                if (planData.plan && planData.plan !== 'free') {
-                  plan = planData.plan;
+              if (window.PlanCache) {
+                const result = await window.PlanCache.getPlan(idToken);
+                if (result && result.plan && result.plan !== 'free') {
+                  plan = result.plan;
                   localStorage.setItem('user-plan', plan);
-                  console.log('✅ [ATS-UPLOAD] Plan from plan/me:', plan);
+                  console.log('✅ [ATS-UPLOAD] Plan from PlanCache:', plan);
+                }
+              } else {
+                const planRes = await fetch('/api/plan/me', {
+                  headers: { Authorization: `Bearer ${idToken}` }
+                });
+                if (planRes.ok) {
+                  const planData = await planRes.json();
+                  if (planData.plan && planData.plan !== 'free') {
+                    plan = planData.plan;
+                    localStorage.setItem('user-plan', plan);
+                    console.log('✅ [ATS-UPLOAD] Plan from plan/me:', plan);
+                  }
                 }
               }
             } catch (planError) {
@@ -2846,15 +2874,24 @@
               
               // Fallback to plan/me if billing-status didn't work or returned free
               if (userPlan === 'free') {
-                const planRes = await fetch('/api/plan/me', {
-                  headers: { Authorization: `Bearer ${idToken}` }
-                });
-                if (planRes.ok) {
-                  const planData = await planRes.json();
-                  if (planData.plan && planData.plan !== 'free') {
-                    userPlan = planData.plan;
-                    localStorage.setItem('user-plan', planData.plan);
-                    console.log('✅ [ATS-UPLOAD] Plan from plan/me:', planData.plan);
+                if (window.PlanCache) {
+                  const result = await window.PlanCache.getPlan(idToken);
+                  if (result && result.plan && result.plan !== 'free') {
+                    userPlan = result.plan;
+                    localStorage.setItem('user-plan', result.plan);
+                    console.log('✅ [ATS-UPLOAD] Plan from PlanCache:', result.plan);
+                  }
+                } else {
+                  const planRes = await fetch('/api/plan/me', {
+                    headers: { Authorization: `Bearer ${idToken}` }
+                  });
+                  if (planRes.ok) {
+                    const planData = await planRes.json();
+                    if (planData.plan && planData.plan !== 'free') {
+                      userPlan = planData.plan;
+                      localStorage.setItem('user-plan', planData.plan);
+                      console.log('✅ [ATS-UPLOAD] Plan from plan/me:', planData.plan);
+                    }
                   }
                 }
               }

--- a/dashboard.html
+++ b/dashboard.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="css/header.css">
   <link rel="stylesheet" href="css/footer.css">
   <script src="js/components/usage-indicator.js"></script>
+  <script src="js/plan-cache.js"></script>
   <script type="module">
     import authManager, { AUTH_PENDING } from './js/firebase-auth.js?v=20260207-2';
     document.documentElement.classList.add('auth-pending');

--- a/help.html
+++ b/help.html
@@ -619,6 +619,7 @@
   </footer>
 
   <!-- Load Firebase auth (ensures logged-in nav renders) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/index.html
+++ b/index.html
@@ -259,6 +259,7 @@
   </script>
 
   <!-- Load Firebase auth (required for navigation auth state detection) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -1933,7 +1933,7 @@
     }
 
     // --- USER PLAN LOGIC (delegated to shared page-access-control.js) ---
-    const IQ_ALLOWED_PLANS = window.PageAccessControl.PAID_PLANS;
+    const IQ_ALLOWED_PLANS = window.PageAccessControl ? window.PageAccessControl.PAID_PLANS : ['trial', 'essential', 'pro', 'premium'];
 
     function getUserPlan() {
       return window.PageAccessControl.getCurrentUserPlan(IQ_ALLOWED_PLANS, '[INTERVIEW-Q]');

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -4639,7 +4639,7 @@ function initIQPage(){
             console.log('[INTERVIEW-Q] Deferred re-verify: updating verified plan to', apiPlan);
             window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
             updateInterviewUIForPlan();
-            document.dispatchEvent(new CustomEvent('planChanged', { detail: { plan: apiPlan } }));
+            window.dispatchEvent(new CustomEvent('planChanged', { detail: { plan: apiPlan } }));
           }
         } catch (e) {
           console.warn('[INTERVIEW-Q] Deferred re-verify error:', e);

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -1935,10 +1935,6 @@
     // --- USER PLAN LOGIC (delegated to shared page-access-control.js) ---
     const IQ_ALLOWED_PLANS = window.PageAccessControl.PAID_PLANS;
 
-    function getVerifiedCachedPlan() {
-      return window.PageAccessControl.getVerifiedCachedPlan(IQ_ALLOWED_PLANS);
-    }
-
     function getUserPlan() {
       return window.PageAccessControl.getCurrentUserPlan(IQ_ALLOWED_PLANS, '[INTERVIEW-Q]');
     }

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -4496,10 +4496,8 @@ function initIQPage(){
           mockBtn?.setAttribute('data-locked','true');
         }
       } else {
-        // Lock input and show upgrade prompt
+        // Page guard already redirects unauthorized users; never show upgrade banner.
         roleInput.disabled = true;
-        upgradeBtn.style.display = 'block';
-        lockDiv.style.display = 'block';
         if (mockLock) mockLock.style.display = 'inline-flex';
         mockBtn?.setAttribute('data-locked','true');
       }

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -4619,7 +4619,10 @@ function initIQPage(){
     // --- DEFERRED RE-VERIFICATION ---
     // When the head guard granted access via the sync fast path (localStorage only),
     // schedule an async API check to catch stale/expired plans.
+    var _deferredReVerifyScheduled = false;
     function deferredPlanReVerify() {
+      if (_deferredReVerifyScheduled) return;
+      _deferredReVerifyScheduled = true;
       setTimeout(async function() {
         try {
           if (!window.JobHackAINavigation) return;
@@ -4663,6 +4666,7 @@ function initIQPage(){
       }
       if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
         console.log('[INTERVIEW-Q] enforceAccess: head guard verified after', waited, 'ms');
+        deferredPlanReVerify();
         return;
       }
 

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -4701,6 +4701,7 @@ function initIQPage(){
         window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
         window.__JOBHACKAI_VERIFIED_PLAN__ = userPlan;
         console.log('[INTERVIEW-Q] enforceAccess: fallback granted access, flag set');
+        deferredPlanReVerify();
       }
     }
     

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -1946,16 +1946,13 @@
     function getUserPlan() {
       const verifiedCachedPlan = getVerifiedCachedPlan();
 
-      // During early hydration on dev, navigation can briefly report visitor/free
-      // before auth/plan reconciliation finishes even though the head guard already
-      // verified a paid plan from cache. Prefer the verified cached plan in that window.
       if (window.JobHackAINavigation && typeof window.JobHackAINavigation.getEffectivePlan === 'function') {
         const effectivePlan = window.JobHackAINavigation.getEffectivePlan();
-        if (verifiedCachedPlan && (!effectivePlan || effectivePlan === 'undefined' || effectivePlan === 'visitor' || effectivePlan === 'free')) {
-          return verifiedCachedPlan;
-        }
-        if (!effectivePlan || effectivePlan === 'undefined') {
-          return localStorage.getItem('user-plan') || verifiedCachedPlan || 'free';
+        // Only use verifiedCachedPlan when navigation hasn't hydrated yet
+        // (undefined/visitor). Once navigation reports a real plan (including 'free'),
+        // trust it — it reflects the authoritative state (e.g. expired trial).
+        if (!effectivePlan || effectivePlan === 'undefined' || effectivePlan === 'visitor') {
+          return verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';
         }
         return effectivePlan;
       }
@@ -4619,11 +4616,40 @@ function initIQPage(){
       }
     }
     
+    // --- DEFERRED RE-VERIFICATION ---
+    // When the head guard granted access via the sync fast path (localStorage only),
+    // schedule an async API check to catch stale/expired plans.
+    function deferredPlanReVerify() {
+      setTimeout(async function() {
+        try {
+          if (!window.JobHackAINavigation) return;
+          if (typeof window.JobHackAINavigation.fetchPlanFromAPI !== 'function') return;
+          var apiPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
+          if (!apiPlan) return;
+          var allowedPlans = ['trial', 'essential', 'pro', 'premium'];
+          if (!allowedPlans.includes(apiPlan)) {
+            console.warn('[INTERVIEW-Q] Deferred re-verify: plan is now', apiPlan, '— revoking access');
+            window.__JOBHACKAI_ACCESS_VERIFIED__ = false;
+            window.__JOBHACKAI_VERIFIED_PLAN__ = null;
+            window.location.href = 'pricing-a.html?plan=essential';
+          } else if (apiPlan !== window.__JOBHACKAI_VERIFIED_PLAN__) {
+            console.log('[INTERVIEW-Q] Deferred re-verify: updating verified plan to', apiPlan);
+            window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
+          }
+        } catch (e) {
+          console.warn('[INTERVIEW-Q] Deferred re-verify error:', e);
+        }
+      }, 2000);
+    }
+
     // --- PAGE ACCESS CONTROL (Second check after navigation system) ---
     // Skip if the head guard already verified access (prevents race condition redirects)
     async function enforceAccess() {
       if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
-        console.log('[INTERVIEW-Q] enforceAccess: skipping, head guard already verified access');
+        console.log('[INTERVIEW-Q] enforceAccess: head guard set flag, scheduling deferred re-verification');
+        // Head guard's sync fast path uses only localStorage (no API call).
+        // Schedule a deferred re-verification so stale cached plans get caught.
+        deferredPlanReVerify();
         return;
       }
 

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -1947,6 +1947,9 @@
         if (verifiedCachedPlan && (!effectivePlan || effectivePlan === 'visitor' || effectivePlan === 'free')) {
           return verifiedCachedPlan;
         }
+        if (!effectivePlan || effectivePlan === 'undefined') {
+          return localStorage.getItem('user-plan') || verifiedCachedPlan || 'free';
+        }
         return effectivePlan;
       }
 

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -1927,13 +1927,30 @@
     }
 
     // --- USER PLAN LOGIC ---
+    const IQ_ALLOWED_PLANS = ['trial', 'essential', 'pro', 'premium'];
+
+    function getVerifiedCachedPlan() {
+      const cachedPlan = localStorage.getItem('user-plan');
+      return window.__JOBHACKAI_ACCESS_VERIFIED__ && IQ_ALLOWED_PLANS.includes(cachedPlan)
+        ? cachedPlan
+        : null;
+    }
+
     function getUserPlan() {
-      // Use navigation system's plan detection for consistency
-      if (window.JobHackAINavigation) {
-        return window.JobHackAINavigation.getEffectivePlan();
-      } else {
-        return localStorage.getItem('user-plan') || 'free';
+      const verifiedCachedPlan = getVerifiedCachedPlan();
+
+      // During early hydration on dev, navigation can briefly report visitor/free
+      // before auth/plan reconciliation finishes even though the head guard already
+      // verified a paid plan from cache. Prefer the verified cached plan in that window.
+      if (window.JobHackAINavigation && typeof window.JobHackAINavigation.getEffectivePlan === 'function') {
+        const effectivePlan = window.JobHackAINavigation.getEffectivePlan();
+        if (verifiedCachedPlan && (!effectivePlan || effectivePlan === 'visitor' || effectivePlan === 'free')) {
+          return verifiedCachedPlan;
+        }
+        return effectivePlan;
       }
+
+      return verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';
     }
     
     const user = {
@@ -4052,7 +4069,7 @@
       }
     }
     async function iqHandleMock(useSaved){
-      const plan=(window.JobHackAINavigation?.getEffectivePlan?.()||localStorage.getItem('user-plan')||'free');
+      const plan = getUserPlan();
       const role = ($IQ('#iq-role')?.value?.trim()||iqState.set?.role||'');
       
       // Get selected questions (from saved/favorites)

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -1951,7 +1951,7 @@
       // verified a paid plan from cache. Prefer the verified cached plan in that window.
       if (window.JobHackAINavigation && typeof window.JobHackAINavigation.getEffectivePlan === 'function') {
         const effectivePlan = window.JobHackAINavigation.getEffectivePlan();
-        if (verifiedCachedPlan && (!effectivePlan || effectivePlan === 'visitor' || effectivePlan === 'free')) {
+        if (verifiedCachedPlan && (!effectivePlan || effectivePlan === 'undefined' || effectivePlan === 'visitor' || effectivePlan === 'free')) {
           return verifiedCachedPlan;
         }
         if (!effectivePlan || effectivePlan === 'undefined') {

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -4700,6 +4700,8 @@ function initIQPage(){
       } else {
         window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
         window.__JOBHACKAI_VERIFIED_PLAN__ = userPlan;
+        document.documentElement.classList.remove('auth-pending');
+        document.documentElement.classList.remove('plan-pending');
         console.log('[INTERVIEW-Q] enforceAccess: fallback granted access, flag set');
         deferredPlanReVerify();
       }

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -4644,6 +4644,7 @@ function initIQPage(){
   <script src="js/stripe-integration.js"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>
   <!-- Load Firebase auth as ES module (required for API authentication) - MUST load before inactivity-tracker -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Inactivity tracker - auto-logout after 30 minutes of inactivity -->
   <script src="js/inactivity-tracker.js?v=20250115-1"></script>

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -4640,6 +4640,9 @@ function initIQPage(){
         } else {
           window.location.href = 'pricing-a.html?plan=essential';
         }
+      } else {
+        window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+        console.log('[INTERVIEW-Q] enforceAccess: fallback granted access, flag set');
       }
     }
     

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -1936,7 +1936,8 @@
     const IQ_ALLOWED_PLANS = window.PageAccessControl ? window.PageAccessControl.PAID_PLANS : ['trial', 'essential', 'pro', 'premium'];
 
     function getUserPlan() {
-      return window.PageAccessControl.getCurrentUserPlan(IQ_ALLOWED_PLANS, '[INTERVIEW-Q]');
+      if (window.PageAccessControl) return window.PageAccessControl.getCurrentUserPlan(IQ_ALLOWED_PLANS, '[INTERVIEW-Q]');
+      return localStorage.getItem('user-plan') || 'free';
     }
 
     const user = {
@@ -4602,11 +4603,11 @@ function initIQPage(){
     };
 
     function deferredPlanReVerify() {
-      window.PageAccessControl.deferredPlanReVerify(_iqAccessOpts);
+      if (window.PageAccessControl) window.PageAccessControl.deferredPlanReVerify(_iqAccessOpts);
     }
 
     async function enforceAccess() {
-      await window.PageAccessControl.enforceAccess(_iqAccessOpts);
+      if (window.PageAccessControl) await window.PageAccessControl.enforceAccess(_iqAccessOpts);
     }
     
     // Initialize page when DOM is ready

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>html.auth-pending,html.plan-pending{visibility:hidden}</style>
   <script src="js/static-auth-guard.js?v=20260125-1"></script>
+  <script src="js/page-access-control.js?v=20260331-1"></script>
   <script>
     // --- IMMEDIATE PAGE ACCESS CONTROL ---
     // Wait for Firebase auth AND plan fetch before checking (prevents false redirects)
@@ -42,19 +43,21 @@
         return;
       }
 
-      // Helper: wait for an object to appear on window
-      function waitForGlobal(name, timeout) {
-        if (window[name]) return Promise.resolve(true);
-        var deadline = Date.now() + timeout;
-        return new Promise(function (resolve) {
-          var interval = setInterval(function () {
-            if (window[name] || Date.now() >= deadline) {
-              clearInterval(interval);
-              resolve(!!window[name]);
-            }
-          }, 50);
-        });
-      }
+      // Helper: delegate to shared module
+      var waitForGlobal = window.PageAccessControl
+        ? window.PageAccessControl.waitForGlobal
+        : function(name, timeout) {
+            if (window[name]) return Promise.resolve(true);
+            var deadline = Date.now() + timeout;
+            return new Promise(function (resolve) {
+              var interval = setInterval(function () {
+                if (window[name] || Date.now() >= deadline) {
+                  clearInterval(interval);
+                  resolve(!!window[name]);
+                }
+              }, 50);
+            });
+          };
 
       // Step 1: Wait for FirebaseAuthManager to load (max 3s)
       await waitForGlobal('FirebaseAuthManager', 3000);
@@ -1929,37 +1932,17 @@
       }
     }
 
-    // --- USER PLAN LOGIC ---
-    const IQ_ALLOWED_PLANS = ['trial', 'essential', 'pro', 'premium'];
+    // --- USER PLAN LOGIC (delegated to shared page-access-control.js) ---
+    const IQ_ALLOWED_PLANS = window.PageAccessControl.PAID_PLANS;
 
     function getVerifiedCachedPlan() {
-      const verifiedPlan = window.__JOBHACKAI_VERIFIED_PLAN__;
-      if (window.__JOBHACKAI_ACCESS_VERIFIED__ && IQ_ALLOWED_PLANS.includes(verifiedPlan)) {
-        return verifiedPlan;
-      }
-      const cachedPlan = localStorage.getItem('user-plan');
-      return window.__JOBHACKAI_ACCESS_VERIFIED__ && IQ_ALLOWED_PLANS.includes(cachedPlan)
-        ? cachedPlan
-        : null;
+      return window.PageAccessControl.getVerifiedCachedPlan(IQ_ALLOWED_PLANS);
     }
 
     function getUserPlan() {
-      const verifiedCachedPlan = getVerifiedCachedPlan();
-
-      if (window.JobHackAINavigation && typeof window.JobHackAINavigation.getEffectivePlan === 'function') {
-        const effectivePlan = window.JobHackAINavigation.getEffectivePlan();
-        // Only use verifiedCachedPlan when navigation hasn't hydrated yet
-        // (undefined/visitor). Once navigation reports a real plan (including 'free'),
-        // trust it — it reflects the authoritative state (e.g. expired trial).
-        if (!effectivePlan || effectivePlan === 'undefined' || effectivePlan === 'visitor') {
-          return verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';
-        }
-        return effectivePlan;
-      }
-
-      return verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';
+      return window.PageAccessControl.getCurrentUserPlan(IQ_ALLOWED_PLANS, '[INTERVIEW-Q]');
     }
-    
+
     const user = {
       plan: getUserPlan()
     };
@@ -4614,97 +4597,20 @@ function initIQPage(){
       }
     }
     
-    // --- DEFERRED RE-VERIFICATION ---
-    // When the head guard granted access via the sync fast path (localStorage only),
-    // schedule an async API check to catch stale/expired plans.
-    var _deferredReVerifyScheduled = false;
+    // --- DEFERRED RE-VERIFICATION & PAGE ACCESS CONTROL ---
+    // Delegated to shared page-access-control.js
+    var _iqAccessOpts = {
+      allowedPlans: IQ_ALLOWED_PLANS,
+      logPrefix: '[INTERVIEW-Q]',
+      onPlanChanged: function () { updateInterviewUIForPlan(); }
+    };
+
     function deferredPlanReVerify() {
-      if (_deferredReVerifyScheduled) return;
-      _deferredReVerifyScheduled = true;
-      setTimeout(async function() {
-        try {
-          if (!window.JobHackAINavigation) return;
-          if (typeof window.JobHackAINavigation.fetchPlanFromAPI !== 'function') return;
-          var apiPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-          if (!apiPlan) return;
-          var allowedPlans = ['trial', 'essential', 'pro', 'premium'];
-          if (!allowedPlans.includes(apiPlan)) {
-            console.warn('[INTERVIEW-Q] Deferred re-verify: plan is now', apiPlan, '— revoking access');
-            window.__JOBHACKAI_ACCESS_VERIFIED__ = false;
-            window.__JOBHACKAI_VERIFIED_PLAN__ = null;
-            window.location.href = 'pricing-a.html?plan=essential';
-          } else if (apiPlan !== window.__JOBHACKAI_VERIFIED_PLAN__) {
-            console.log('[INTERVIEW-Q] Deferred re-verify: updating verified plan to', apiPlan);
-            window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
-            updateInterviewUIForPlan();
-            window.dispatchEvent(new CustomEvent('planChanged', { detail: { plan: apiPlan } }));
-          }
-        } catch (e) {
-          console.warn('[INTERVIEW-Q] Deferred re-verify error:', e);
-        }
-      }, 2000);
+      window.PageAccessControl.deferredPlanReVerify(_iqAccessOpts);
     }
 
-    // --- PAGE ACCESS CONTROL (Second check after navigation system) ---
-    // Skip if the head guard already verified access (prevents race condition redirects)
     async function enforceAccess() {
-      if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
-        console.log('[INTERVIEW-Q] enforceAccess: head guard set flag, scheduling deferred re-verification');
-        // Head guard's sync fast path uses only localStorage (no API call).
-        // Schedule a deferred re-verification so stale cached plans get caught.
-        deferredPlanReVerify();
-        return;
-      }
-
-      // Wait for head guard async path to complete before checking independently.
-      // Head guard awaits FirebaseAuthManager (3s) + waitForAuthReady (5s) + API fetch,
-      // so allow up to 10s for it to set __JOBHACKAI_ACCESS_VERIFIED__.
-      var waited = 0;
-      while (!window.__JOBHACKAI_ACCESS_VERIFIED__ && waited < 10000) {
-        await new Promise(function(r) { setTimeout(r, 200); });
-        waited += 200;
-      }
-      if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
-        console.log('[INTERVIEW-Q] enforceAccess: head guard verified after', waited, 'ms');
-        deferredPlanReVerify();
-        return;
-      }
-
-      // Head guard timed out or denied — do independent fallback check
-      var authState, userPlan;
-
-      if (window.JobHackAINavigation) {
-        authState = window.JobHackAINavigation.getAuthState();
-        userPlan = window.JobHackAINavigation.getEffectivePlan();
-      } else {
-        var hasLocalStorageAuth = localStorage.getItem('user-authenticated') === 'true';
-        var hasFirebaseKeys = Object.keys(localStorage).some(function (k) {
-          return k.startsWith('firebase:authUser:') &&
-            localStorage.getItem(k) &&
-            localStorage.getItem(k) !== 'null' &&
-            localStorage.getItem(k).length > 10;
-        });
-        // SECURITY: Require BOTH signals (matches head fast path + static-auth-guard.js)
-        authState = { isAuthenticated: hasLocalStorageAuth && hasFirebaseKeys };
-        userPlan = localStorage.getItem('user-plan') || 'free';
-      }
-
-      var allowedPlans = ['trial', 'essential', 'pro', 'premium'];
-
-      if (!authState.isAuthenticated || !allowedPlans.includes(userPlan)) {
-        if (!authState.isAuthenticated) {
-          window.location.href = 'login.html';
-        } else {
-          window.location.href = 'pricing-a.html?plan=essential';
-        }
-      } else {
-        window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
-        window.__JOBHACKAI_VERIFIED_PLAN__ = userPlan;
-        document.documentElement.classList.remove('auth-pending');
-        document.documentElement.classList.remove('plan-pending');
-        console.log('[INTERVIEW-Q] enforceAccess: fallback granted access, flag set');
-        deferredPlanReVerify();
-      }
+      await window.PageAccessControl.enforceAccess(_iqAccessOpts);
     }
     
     // Initialize page when DOM is ready

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -4638,6 +4638,8 @@ function initIQPage(){
           } else if (apiPlan !== window.__JOBHACKAI_VERIFIED_PLAN__) {
             console.log('[INTERVIEW-Q] Deferred re-verify: updating verified plan to', apiPlan);
             window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
+            updateInterviewUIForPlan();
+            document.dispatchEvent(new CustomEvent('planChanged', { detail: { plan: apiPlan } }));
           }
         } catch (e) {
           console.warn('[INTERVIEW-Q] Deferred re-verify error:', e);

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -36,6 +36,7 @@
       if (hasLocalAuth && hasFBKeys && allowedPlans.includes(cachedPlan)) {
         console.log('✅ [INTERVIEW-Q] Sync fast path: access granted for cached plan:', cachedPlan);
         window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+        window.__JOBHACKAI_VERIFIED_PLAN__ = cachedPlan;
         document.documentElement.classList.remove('auth-pending');
         document.documentElement.classList.remove('plan-pending');
         return;
@@ -98,6 +99,7 @@
         document.documentElement.classList.remove('auth-pending');
         document.documentElement.classList.remove('plan-pending');
         window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+        window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
         return;
       }
 
@@ -135,6 +137,7 @@
       document.documentElement.classList.remove('auth-pending');
       document.documentElement.classList.remove('plan-pending');
       window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+      window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
       console.log('✅ [INTERVIEW-Q] Access granted for plan:', plan);
     })();
   </script>
@@ -1930,6 +1933,10 @@
     const IQ_ALLOWED_PLANS = ['trial', 'essential', 'pro', 'premium'];
 
     function getVerifiedCachedPlan() {
+      const verifiedPlan = window.__JOBHACKAI_VERIFIED_PLAN__;
+      if (window.__JOBHACKAI_ACCESS_VERIFIED__ && IQ_ALLOWED_PLANS.includes(verifiedPlan)) {
+        return verifiedPlan;
+      }
       const cachedPlan = localStorage.getItem('user-plan');
       return window.__JOBHACKAI_ACCESS_VERIFIED__ && IQ_ALLOWED_PLANS.includes(cachedPlan)
         ? cachedPlan
@@ -4662,6 +4669,7 @@ function initIQPage(){
         }
       } else {
         window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+        window.__JOBHACKAI_VERIFIED_PLAN__ = userPlan;
         console.log('[INTERVIEW-Q] enforceAccess: fallback granted access, flag set');
       }
     }

--- a/js/firebase-auth.js
+++ b/js/firebase-auth.js
@@ -93,6 +93,7 @@ function clearAuthCookies() {
 }
 
 // --- DIRECT PLAN FETCH FROM D1 VIA API (navigation-independent) ---
+// Routes through PlanCache when available to deduplicate concurrent requests.
 async function fetchPlanFromAPI() {
   try {
     const user = auth.currentUser;
@@ -105,6 +106,14 @@ async function fetchPlanFromAPI() {
       console.log('🔍 fetchPlanFromAPI: no idToken');
       return null;
     }
+    // Use PlanCache to deduplicate concurrent /api/plan/me calls
+    if (window.PlanCache) {
+      const result = await window.PlanCache.getPlan(idToken);
+      const plan = result && result.plan;
+      console.log(`📊 fetchPlanFromAPI (via PlanCache): plan="${plan}"`);
+      return plan || null;
+    }
+    // Fallback: direct fetch if PlanCache not loaded yet
     console.log(`🔍 fetchPlanFromAPI: calling /api/plan/me for uid=${user.uid}`);
     const res = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
     if (!res.ok) {
@@ -115,7 +124,6 @@ async function fetchPlanFromAPI() {
     console.log(`📊 fetchPlanFromAPI: API returned plan="${data?.plan}"`);
     return data?.plan || null;
   } catch (e) {
-    // API fetch failed - this is non-critical, will fallback to 'free'
     console.log('ℹ️ Direct plan API fetch unavailable, will use fallback:', e.message || 'network error');
     return null;
   }
@@ -701,74 +709,34 @@ class AuthManager {
           actualPlan = pendingSelection === 'trial' ? 'pending' : pendingSelection;
           console.log('✅ Using fresh plan selection in auth listener:', actualPlan);
         } else {
-          // FIX: Wait for auth to be ready before fetching plan to prevent race condition
+          // Fetch plan via centralized PlanCache (deduplicates concurrent requests)
           let kvPlan = null;
           try {
-            // Wait for Firebase auth to be fully ready (max 3 seconds)
-            console.log('🔄 Waiting for Firebase auth to be ready before plan fetching...');
-            await this.waitForAuthReady(3000);
-            
-            if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-              kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-              if (kvPlan) console.log('✅ Fetched plan via navigation system:', kvPlan);
-            }
-            // Fallback: fetch directly from API if navigation not ready
-            if (!kvPlan) {
+            const idToken = await user.getIdToken();
+            if (window.PlanCache) {
+              const result = await window.PlanCache.getPlan(idToken);
+              kvPlan = result && result.plan;
+              if (kvPlan) console.log('✅ Fetched plan via PlanCache:', kvPlan);
+            } else {
               kvPlan = await fetchPlanFromAPI();
-              if (kvPlan) console.log('✅ Fetched plan directly from API (navigation not ready):', kvPlan);
+              if (kvPlan) console.log('✅ Fetched plan directly from API (PlanCache not loaded):', kvPlan);
             }
           } catch (e) {
             console.warn('Could not fetch plan from API:', e);
-            // Add retry mechanism for failed API fetches
-            try {
-              console.log('🔄 Retrying plan fetch after 1 second...');
-              await new Promise(resolve => setTimeout(resolve, 1000));
-              if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-                kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-              }
-              if (!kvPlan) {
-                kvPlan = await fetchPlanFromAPI();
-              }
-              if (kvPlan) console.log('✅ Retry successful, fetched plan:', kvPlan);
-            } catch (retryError) {
-              console.warn('Retry also failed:', retryError);
-            }
           }
-          
+
           if (kvPlan && kvPlan !== 'free') {
             actualPlan = kvPlan;
             console.log('✅ Retrieved user plan from D1 (via API):', actualPlan);
-          } else {
-            // API fetch returned null or 'free' - try Firestore as fallback (but NOT email-based lookup)
+          } else if (!kvPlan) {
+            // API fetch returned null - try Firestore as fallback (but NOT email-based lookup)
             const profileResult = await UserProfileManager.getProfile(user.uid);
             if (profileResult.success && profileResult.profile) {
               actualPlan = profileResult.profile.plan || 'free';
               console.log('✅ Retrieved user plan from Firestore (API fallback):', actualPlan);
             } else {
-              // All sources unavailable - default to 'free' (D1 is source of truth, no email-based fallback)
               actualPlan = 'free';
-              console.log('ℹ️ Using default plan (API/Firestore unavailable). D1 is source of truth - no email-based fallback.');
-              // FIX: Add delayed retry for plan reconciliation
-              console.log('🔄 Scheduling delayed plan reconciliation in 5 seconds...');
-              setTimeout(async () => {
-                try {
-                  console.log('🔄 Attempting delayed plan reconciliation...');
-                  const delayedPlan = await window.JobHackAINavigation?.fetchPlanFromAPI?.();
-                    if (delayedPlan && delayedPlan !== 'free') {
-                    console.log('✅ Delayed reconciliation successful:', delayedPlan);
-                    localStorage.setItem('user-plan', delayedPlan);
-                    localStorage.setItem('dev-plan', delayedPlan);
-                    if (window.JobHackAINavigation && typeof window.JobHackAINavigation.scheduleUpdateNavigation === 'function') {
-                      window.JobHackAINavigation.scheduleUpdateNavigation(true);
-                    } else if (window.JobHackAINavigation && typeof window.JobHackAINavigation.updateNavigation === 'function') {
-                      // fallback
-                      window.JobHackAINavigation.updateNavigation();
-                    }
-                  }
-                } catch (e) {
-                  console.warn('Delayed reconciliation failed:', e);
-                }
-              }, 5000);
+              console.log('ℹ️ Using default plan (API/Firestore unavailable). D1 is source of truth.');
             }
           }
         }
@@ -811,8 +779,15 @@ class AuthManager {
               actualPlan = selectedPlan === 'trial' ? 'pending' : selectedPlan;
               console.log('✅ Using newly selected plan for LinkedIn sign-in (same-window):', actualPlan);
             } else {
-              // Fetch plan from API using token
-              const kvPlan = await apiFetchJSON('/api/plan/me');
+              // Fetch plan from API using PlanCache (deduplicated)
+              const idToken = getIdTokenSync();
+              let kvPlan = null;
+              if (window.PlanCache && idToken) {
+                const result = await window.PlanCache.getPlan(idToken);
+                kvPlan = result && result.plan ? result : null;
+              } else {
+                kvPlan = await apiFetchJSON('/api/plan/me');
+              }
               if (kvPlan?.plan) {
                 actualPlan = kvPlan.plan;
                 console.log('✅ Fetched plan from API during LinkedIn sign-in (same-window):', actualPlan);
@@ -875,7 +850,14 @@ class AuthManager {
         } else {
           // Normal token restoration (page refresh) - just fetch plan and set state
           try {
-            const kvPlan = await apiFetchJSON('/api/plan/me');
+            const idToken = getIdTokenSync();
+            let kvPlan = null;
+            if (window.PlanCache && idToken) {
+              const result = await window.PlanCache.getPlan(idToken);
+              kvPlan = result && result.plan ? result : null;
+            } else {
+              kvPlan = await apiFetchJSON('/api/plan/me');
+            }
             const actualPlan = kvPlan?.plan || 'free';
             if (window.JobHackAINavigation) {
               window.JobHackAINavigation.setAuthState(true, actualPlan);
@@ -1018,50 +1000,33 @@ class AuthManager {
       // FIX: Wait for auth to be ready before fetching plan to prevent race condition
       let kvPlan = null;
       try {
-        // Wait for Firebase auth to be fully ready (max 3 seconds)
-        console.log('🔄 Waiting for Firebase auth to be ready during sign-in...');
-        await this.waitForAuthReady(3000);
-        
-        if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-          kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-          if (kvPlan) console.log('✅ Fetched plan via navigation system during sign-in:', kvPlan);
-        }
-        // Fallback: fetch directly from API if navigation not ready
-        if (!kvPlan) {
+        const idToken = await user.getIdToken();
+        if (window.PlanCache) {
+          // Invalidate cache on fresh sign-in so we get the latest plan
+          window.PlanCache.invalidate();
+          const result = await window.PlanCache.getPlan(idToken);
+          kvPlan = result && result.plan;
+          if (kvPlan) console.log('✅ Fetched plan via PlanCache during sign-in:', kvPlan);
+        } else {
           kvPlan = await fetchPlanFromAPI();
           if (kvPlan) console.log('✅ Fetched plan directly from API during sign-in:', kvPlan);
         }
       } catch (e) {
         console.warn('Could not fetch plan from API during sign-in:', e);
-        // Add retry mechanism for failed API fetches
-        try {
-          console.log('🔄 Retrying plan fetch during sign-in after 1 second...');
-          await new Promise(resolve => setTimeout(resolve, 1000));
-          if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-            kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-          }
-          if (!kvPlan) {
-            kvPlan = await fetchPlanFromAPI();
-          }
-          if (kvPlan) console.log('✅ Retry successful during sign-in, fetched plan:', kvPlan);
-        } catch (retryError) {
-          console.warn('Retry also failed during sign-in:', retryError);
-        }
       }
-      
+
       if (kvPlan && kvPlan !== 'free') {
         actualPlan = kvPlan;
         console.log('✅ Retrieved user plan from D1 (via API) during sign-in:', actualPlan);
-      } else {
-        // API fetch returned null or 'free' - try Firestore as fallback (but NOT email-based lookup)
+      } else if (!kvPlan) {
+        // API fetch returned null - try Firestore as fallback (but NOT email-based lookup)
         const profileResult = await UserProfileManager.getProfile(user.uid);
         if (profileResult.success && profileResult.profile) {
           actualPlan = profileResult.profile.plan || 'free';
           console.log('✅ Retrieved user plan from Firestore during sign-in (API fallback):', actualPlan);
         } else {
-          // All sources unavailable - default to 'free' (D1 is source of truth, no email-based fallback)
           actualPlan = 'free';
-          console.log('ℹ️ All plan sources failed during sign-in, defaulting to free. D1 is source of truth - no email-based fallback.');
+          console.log('ℹ️ All plan sources failed during sign-in, defaulting to free.');
         }
       }
 
@@ -1105,57 +1070,34 @@ class AuthManager {
       actualPlan = selectedPlan === 'trial' ? 'pending' : selectedPlan;
       console.log('✅ Using newly selected plan for Google sign-in:', actualPlan);
     } else {
-      // FIX: Wait for auth to be ready before fetching plan to prevent race condition
+      // Fetch plan via PlanCache (deduplicated)
       let kvPlan = null;
       try {
-        if (this._redirectProcessing) {
-          console.log('🔄 Redirect sign-in detected; skipping waitForAuthReady to avoid delay');
+        const idToken = await user.getIdToken();
+        if (window.PlanCache) {
+          window.PlanCache.invalidate(); // Fresh sign-in, get latest
+          const result = await window.PlanCache.getPlan(idToken);
+          kvPlan = result && result.plan;
+          if (kvPlan) console.log('✅ Fetched plan via PlanCache during Google sign-in:', kvPlan);
         } else {
-          // Wait for Firebase auth to be fully ready (max 3 seconds)
-          console.log('🔄 Waiting for Firebase auth to be ready during Google sign-in...');
-          await this.waitForAuthReady(3000);
-        }
-        
-        if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-          kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-          if (kvPlan) console.log('✅ Fetched plan via navigation system during Google sign-in:', kvPlan);
-        }
-        // Fallback: fetch directly from API if navigation not ready
-        if (!kvPlan) {
           kvPlan = await fetchPlanFromAPI();
           if (kvPlan) console.log('✅ Fetched plan directly from API during Google sign-in:', kvPlan);
         }
       } catch (e) {
         console.warn('Could not fetch plan from API during Google sign-in:', e);
-        // Add retry mechanism for failed API fetches
-        try {
-          console.log('🔄 Retrying plan fetch during Google sign-in after 1 second...');
-          await new Promise(resolve => setTimeout(resolve, 1000));
-          if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-            kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-          }
-          if (!kvPlan) {
-            kvPlan = await fetchPlanFromAPI();
-          }
-          if (kvPlan) console.log('✅ Retry successful during Google sign-in, fetched plan:', kvPlan);
-        } catch (retryError) {
-          console.warn('Retry also failed during Google sign-in:', retryError);
-        }
       }
-      
+
       if (kvPlan && kvPlan !== 'free') {
         actualPlan = kvPlan;
         console.log('✅ Retrieved user plan from D1 (via API) during Google sign-in:', actualPlan);
-      } else {
-        // API fetch returned null or 'free' - try Firestore as fallback (but NOT email-based lookup)
+      } else if (!kvPlan) {
         const profileResult = await UserProfileManager.getProfile(user.uid);
         if (profileResult.success && profileResult.profile) {
           actualPlan = profileResult.profile.plan || 'free';
           console.log('✅ Retrieved user plan from Firestore during Google sign-in (API fallback):', actualPlan);
         } else {
-          // All sources unavailable - default to 'free' (D1 is source of truth, no email-based fallback)
           actualPlan = 'free';
-          console.log('ℹ️ All plan sources failed during Google sign-in, defaulting to free. D1 is source of truth - no email-based fallback.');
+          console.log('ℹ️ All plan sources failed during Google sign-in, defaulting to free.');
         }
       }
     }
@@ -1333,17 +1275,23 @@ class AuthManager {
               actualPlan = selectedPlan === 'trial' ? 'pending' : selectedPlan;
               console.log('✅ Using newly selected plan for LinkedIn sign-in:', actualPlan);
             } else {
-              // Fetch plan from API using token
+              // Fetch plan from API using PlanCache (deduplicated)
               let kvPlan = null;
               try {
-                kvPlan = await apiFetchJSON('/api/plan/me');
+                const idToken = getIdTokenSync();
+                if (window.PlanCache && idToken) {
+                  window.PlanCache.invalidate(); // Fresh sign-in, get latest
+                  const result = await window.PlanCache.getPlan(idToken);
+                  kvPlan = result && result.plan ? result : null;
+                } else {
+                  kvPlan = await apiFetchJSON('/api/plan/me');
+                }
                 if (kvPlan?.plan) {
                   actualPlan = kvPlan.plan;
                   console.log('✅ Fetched plan from API during LinkedIn sign-in:', actualPlan);
                 }
               } catch (e) {
                 console.warn('Could not fetch plan from API during LinkedIn sign-in:', e);
-                // Try Firestore as fallback
                 try {
                   const profileResult = await UserProfileManager.getProfile(uid);
                   if (profileResult.success && profileResult.profile) {

--- a/js/firebase-auth.js
+++ b/js/firebase-auth.js
@@ -783,6 +783,7 @@ class AuthManager {
               const idToken = getIdTokenSync();
               let kvPlan = null;
               if (window.PlanCache && idToken) {
+                window.PlanCache.invalidate();
                 const result = await window.PlanCache.getPlan(idToken);
                 kvPlan = result && result.plan ? result : null;
               } else {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -2569,88 +2569,25 @@ async function initializeNavigation() {
 //   document.body.appendChild(switcher);
 //   navLog('debug', 'Quick plan switcher appended to body');
 
-  // CRITICAL FIX: For authenticated users, fetch plan before rendering navigation
-  // This prevents race condition where navigation shows wrong plan initially
+  // For authenticated users, read plan from PlanCache or localStorage.
+  // The authoritative /api/plan/me fetch is handled by firebase-auth.js via PlanCache
+  // (which deduplicates concurrent requests). Navigation just reads the cached result.
   if (authState.isAuthenticated && window.FirebaseAuthManager?.getCurrentUser) {
-    navLog('info', 'Authenticated user detected, fetching plan before navigation render');
+    navLog('info', 'Authenticated user detected, reading plan for navigation render');
     try {
-      const user = window.FirebaseAuthManager.getCurrentUser();
-      if (user) {
-        const token = await user.getIdToken();
-        // Fetch plan from API first
-        const planRes = await fetch('/api/plan/me', {
-          headers: { Authorization: `Bearer ${token}` }
-        });
-        if (planRes.ok) {
-          const planData = await planRes.json();
-          if (planData.plan) {
-            navLog('info', 'Fetched plan from API, updating localStorage', planData.plan);
-            localStorage.setItem('user-plan', planData.plan);
-            localStorage.setItem('dev-plan', planData.plan);
-            
-            // If plan is free, double-check with billing-status as fallback
-            if (planData.plan === 'free') {
-              navLog('info', 'Plan is free, checking billing-status as fallback');
-              const billingRes = await fetch('/api/billing-status?force=1', {
-                headers: { Authorization: `Bearer ${token}` }
-              });
-              if (billingRes.ok) {
-                const billingData = await billingRes.json();
-                if (billingData.ok && billingData.plan && billingData.plan !== 'free') {
-                  navLog('info', 'Found plan from billing-status fallback, updating', billingData.plan);
-                  localStorage.setItem('user-plan', billingData.plan);
-                  localStorage.setItem('dev-plan', billingData.plan);
-                  // Sync to D1 asynchronously (via sync-stripe-plan which writes to D1)
-                  fetch('/api/sync-stripe-plan', {
-                    method: 'POST',
-                    headers: { Authorization: `Bearer ${token}` }
-                  }).catch(err => navLog('warn', 'Failed to sync plan to D1 (non-critical):', err));
-                }
-              }
-            }
-          } else {
-            // plan/me returned successfully but without plan field - use billing-status as fallback
-            navLog('info', 'plan/me response missing plan field, checking billing-status as fallback');
-            const billingRes = await fetch('/api/billing-status?force=1', {
-              headers: { Authorization: `Bearer ${token}` }
-            });
-            if (billingRes.ok) {
-              const billingData = await billingRes.json();
-              if (billingData.ok && billingData.plan) {
-                navLog('info', 'Found plan from billing-status fallback (plan/me missing plan)', billingData.plan);
-                localStorage.setItem('user-plan', billingData.plan);
-                localStorage.setItem('dev-plan', billingData.plan);
-                // Sync to KV asynchronously
-                fetch('/api/sync-stripe-plan', {
-                  method: 'POST',
-                  headers: { Authorization: `Bearer ${token}` }
-                }).catch(err => navLog('warn', 'Failed to sync plan to KV (non-critical):', err));
-              }
-            }
-          }
-        } else {
-          // plan/me failed - use billing-status as fallback
-          navLog('info', 'plan/me request failed, checking billing-status as fallback');
-          const billingRes = await fetch('/api/billing-status?force=1', {
-            headers: { Authorization: `Bearer ${token}` }
-          });
-          if (billingRes.ok) {
-            const billingData = await billingRes.json();
-            if (billingData.ok && billingData.plan) {
-              navLog('info', 'Found plan from billing-status fallback (plan/me failed)', billingData.plan);
-              localStorage.setItem('user-plan', billingData.plan);
-              localStorage.setItem('dev-plan', billingData.plan);
-              // Sync to KV asynchronously
-              fetch('/api/sync-stripe-plan', {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${token}` }
-              }).catch(err => navLog('warn', 'Failed to sync plan to KV (non-critical):', err));
-            }
-          }
-        }
+      // Check PlanCache first (populated by firebase-auth.js during auth init)
+      const cached = window.PlanCache && window.PlanCache.getCachedPlan();
+      if (cached && cached.plan) {
+        navLog('info', 'Using plan from PlanCache:', cached.plan);
+        localStorage.setItem('user-plan', cached.plan);
+        localStorage.setItem('dev-plan', cached.plan);
+      } else {
+        // PlanCache not populated yet — use localStorage (set by firebase-auth.js)
+        const lsPlan = localStorage.getItem('user-plan');
+        navLog('info', 'PlanCache not yet populated, using localStorage plan:', lsPlan || 'free');
       }
     } catch (planError) {
-      navLog('warn', 'Plan fetch failed (non-critical), continuing with navigation render:', planError);
+      navLog('warn', 'Plan read failed (non-critical), continuing with navigation render:', planError);
     }
   }
   
@@ -2828,21 +2765,13 @@ async function initializeNavigation() {
 }
 
 // --- Plan Reconciliation from D1 via API ---
+// Routes through PlanCache to deduplicate concurrent /api/plan/me requests.
+// Retains billing-status fallback for D1/Stripe sync mismatches.
 async function fetchPlanFromAPI() {
   try {
-    // DEFENSIVE GUARD: Ensure FirebaseAuthManager is loaded
     if (!window.FirebaseAuthManager) {
       console.log('🔍 fetchPlanFromAPI: FirebaseAuthManager not loaded yet, skipping');
       return null;
-    }
-
-    // DEFENSIVE GUARD: Wait for auth to be ready if it's still initializing
-    if (window.FirebaseAuthManager.waitForAuthReady) {
-      try {
-        await window.FirebaseAuthManager.waitForAuthReady(1000); // Short timeout
-      } catch (e) {
-        console.log('🔍 fetchPlanFromAPI: Auth ready timeout, continuing anyway');
-      }
     }
 
     const currentUser = window.FirebaseAuthManager?.getCurrentUser?.();
@@ -2850,67 +2779,63 @@ async function fetchPlanFromAPI() {
       console.log('🔍 fetchPlanFromAPI: No current user available');
       return null;
     }
-    
+
     const idToken = await currentUser.getIdToken?.();
     if (!idToken) {
       console.log('🔍 fetchPlanFromAPI: No ID token available');
       return null;
     }
-    
-    console.log('🔍 fetchPlanFromAPI: Fetching plan from D1 via API...');
-    const r = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
-    if (!r.ok) {
-      console.warn(`🔍 fetchPlanFromAPI: API returned ${r.status} ${r.statusText}`);
-      return null;
+
+    // Use PlanCache to deduplicate concurrent /api/plan/me calls
+    let plan = null;
+    if (window.PlanCache) {
+      const result = await window.PlanCache.getPlan(idToken);
+      plan = result && result.plan ? result.plan : null;
+      console.log('🔍 fetchPlanFromAPI (via PlanCache):', plan);
+    } else {
+      console.log('🔍 fetchPlanFromAPI: Fetching plan from D1 via API...');
+      const r = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
+      if (!r.ok) {
+        console.warn(`🔍 fetchPlanFromAPI: API returned ${r.status} ${r.statusText}`);
+        return null;
+      }
+      const data = await r.json();
+      plan = data.plan || 'free';
+      if (data.trialEndsAt) {
+        localStorage.setItem('trial-ends-at', data.trialEndsAt);
+      } else {
+        localStorage.removeItem('trial-ends-at');
+      }
     }
-    
-    const data = await r.json();
-    console.log('🔍 fetchPlanFromAPI: API response:', data);
-    
-    let plan = data.plan || 'free';
-    
-    // CRITICAL FIX: If plan is 'free' but user is authenticated, check billing-status as fallback
-    // This handles cases where D1 is out of sync with Stripe (shouldn't happen, but safety net)
+
+    if (!plan) return null;
+
+    // Billing-status fallback: if D1 says 'free' but Stripe may disagree
     if (plan === 'free' && currentUser) {
       console.log('🔍 fetchPlanFromAPI: Plan is free, checking billing-status as fallback...');
       try {
-        const billingRes = await fetch('/api/billing-status?force=1', { 
-          headers: { Authorization: `Bearer ${idToken}` } 
+        const billingRes = await fetch('/api/billing-status?force=1', {
+          headers: { Authorization: `Bearer ${idToken}` }
         });
         if (billingRes.ok) {
           const billingData = await billingRes.json();
           if (billingData.ok && billingData.plan && billingData.plan !== 'free') {
             console.log(`🔄 fetchPlanFromAPI: Found plan ${billingData.plan} from billing-status, syncing to D1...`);
             plan = billingData.plan;
-            // Sync to D1 (via sync-stripe-plan which writes to D1)
-            try {
-              const syncRes = await fetch('/api/sync-stripe-plan', {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${idToken}` }
-              });
-              if (syncRes.ok) {
-                console.log('✅ fetchPlanFromAPI: Plan synced to D1');
-              }
-            } catch (syncError) {
-              console.warn('⚠️ fetchPlanFromAPI: Failed to sync plan to D1:', syncError);
-            }
+            if (window.PlanCache) window.PlanCache.setCachedPlan(plan);
+            fetch('/api/sync-stripe-plan', {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${idToken}` }
+            }).catch(err => console.warn('⚠️ fetchPlanFromAPI: Failed to sync plan to D1:', err));
           }
         }
       } catch (billingError) {
         console.warn('⚠️ fetchPlanFromAPI: Failed to check billing-status:', billingError);
       }
     }
-    
-    // Store trial end date if available
-    if (data.trialEndsAt) {
-      localStorage.setItem('trial-ends-at', data.trialEndsAt);
-    } else {
-      localStorage.removeItem('trial-ends-at');
-    }
-    
-    // Update localStorage with correct plan
+
     localStorage.setItem('user-plan', plan);
-    console.log(`✅ fetchPlanFromAPI: Successfully fetched plan from D1: ${plan}`);
+    console.log(`✅ fetchPlanFromAPI: Successfully fetched plan: ${plan}`);
     return plan;
   } catch (error) {
     console.warn('❌ fetchPlanFromAPI: Error fetching plan:', error);
@@ -2931,31 +2856,16 @@ async function reconcilePlanFromAPI() {
     return;
   }
   
-  // FIX: Add retry mechanism for plan reconciliation
-  let plan = null;
-  let retryCount = 0;
-  const maxRetries = 3;
-  
   console.log('🔍 reconcilePlanFromAPI: Starting plan reconciliation from D1...');
-  
-  while (!plan && retryCount < maxRetries) {
-    try {
-      plan = await fetchPlanFromAPI();
-      if (plan) {
-        console.log(`✅ Plan reconciliation successful on attempt ${retryCount + 1}:`, plan);
-        break;
-      }
-    } catch (error) {
-      console.warn(`⚠️ Plan reconciliation attempt ${retryCount + 1} failed:`, error);
-    }
-    
-    retryCount++;
-    if (retryCount < maxRetries) {
-      console.log(`🔄 Retrying plan reconciliation in ${retryCount * 1000}ms...`);
-      await new Promise(resolve => setTimeout(resolve, retryCount * 1000));
-    }
+
+  // Single attempt — PlanCache handles deduplication; no retry cascade needed
+  let plan = null;
+  try {
+    plan = await fetchPlanFromAPI();
+  } catch (error) {
+    console.warn('⚠️ Plan reconciliation failed:', error);
   }
-  
+
   const current = localStorage.getItem('user-plan');
   if (plan && plan !== current) {
     console.log(`🔄 Updating plan from ${current} to ${plan}`);
@@ -2964,7 +2874,7 @@ async function reconcilePlanFromAPI() {
     scheduleUpdateNavigation(true);
     try { new BroadcastChannel('auth').postMessage({ type: 'plan-update', plan: plan }); } catch (_) {}
   } else if (!plan) {
-    console.warn('⚠️ Plan reconciliation failed after all retries, keeping current plan:', current);
+    console.warn('⚠️ Plan reconciliation failed, keeping current plan:', current);
   }
 }
 

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -2822,7 +2822,11 @@ async function fetchPlanFromAPI() {
           if (billingData.ok && billingData.plan && billingData.plan !== 'free') {
             console.log(`🔄 fetchPlanFromAPI: Found plan ${billingData.plan} from billing-status, syncing to D1...`);
             plan = billingData.plan;
-            if (window.PlanCache) window.PlanCache.setCachedPlan(plan);
+            if (window.PlanCache) {
+              const cachedPlan = window.PlanCache.getCachedPlan();
+              const trialEndsAt = cachedPlan ? cachedPlan.trialEndsAt : localStorage.getItem('trial-ends-at');
+              window.PlanCache.setCachedPlan(plan, trialEndsAt);
+            }
             fetch('/api/sync-stripe-plan', {
               method: 'POST',
               headers: { Authorization: `Bearer ${idToken}` }

--- a/js/page-access-control.js
+++ b/js/page-access-control.js
@@ -102,7 +102,7 @@ window.PageAccessControl = (function () {
           console.warn(logPrefix, 'Deferred re-verify: plan is now', apiPlan, '— revoking access');
           window.__JOBHACKAI_ACCESS_VERIFIED__ = false;
           window.__JOBHACKAI_VERIFIED_PLAN__ = null;
-          window.location.href = 'pricing-a.html?plan=essential';
+          window.location.href = opts.deniedRedirect || 'pricing-a.html?plan=essential';
         } else if (apiPlan !== window.__JOBHACKAI_VERIFIED_PLAN__) {
           console.log(logPrefix, 'Deferred re-verify: updating verified plan to', apiPlan);
           window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
@@ -170,7 +170,7 @@ window.PageAccessControl = (function () {
       if (!isAuthenticated) {
         window.location.href = 'login.html';
       } else {
-        window.location.href = 'pricing-a.html?plan=essential';
+        window.location.href = opts.deniedRedirect || 'pricing-a.html?plan=essential';
       }
     } else {
       window.__JOBHACKAI_ACCESS_VERIFIED__ = true;

--- a/js/page-access-control.js
+++ b/js/page-access-control.js
@@ -1,0 +1,200 @@
+// Shared page-level access control for protected pages
+// Consolidates auth/plan gating logic previously duplicated across
+// interview-questions.html and resume-feedback-pro.html.
+// Version: 1.0.0
+window.PageAccessControl = (function () {
+  'use strict';
+
+  var VALID_PLANS = ['visitor', 'free', 'trial', 'essential', 'pro', 'premium'];
+  var PAID_PLANS  = ['trial', 'essential', 'pro', 'premium'];
+
+  // ---- helpers ----
+
+  function waitForGlobal(name, timeout) {
+    if (window[name]) return Promise.resolve(true);
+    var deadline = Date.now() + timeout;
+    return new Promise(function (resolve) {
+      var interval = setInterval(function () {
+        if (window[name] || Date.now() >= deadline) {
+          clearInterval(interval);
+          resolve(!!window[name]);
+        }
+      }, 50);
+    });
+  }
+
+  // ---- plan utilities ----
+
+  function getVerifiedCachedPlan(allowedPlans) {
+    allowedPlans = allowedPlans || PAID_PLANS;
+    var verifiedPlan = window.__JOBHACKAI_VERIFIED_PLAN__;
+    if (window.__JOBHACKAI_ACCESS_VERIFIED__ && allowedPlans.indexOf(verifiedPlan) !== -1) {
+      return verifiedPlan;
+    }
+    var cachedPlan = localStorage.getItem('user-plan');
+    return window.__JOBHACKAI_ACCESS_VERIFIED__ && allowedPlans.indexOf(cachedPlan) !== -1
+      ? cachedPlan
+      : null;
+  }
+
+  function getCurrentUserPlan(allowedPlans, logPrefix) {
+    allowedPlans = allowedPlans || PAID_PLANS;
+    logPrefix = logPrefix || '[PAGE-ACCESS]';
+    var verifiedCachedPlan = getVerifiedCachedPlan(allowedPlans);
+
+    var plan = 'free';
+    if (window.JobHackAINavigation && typeof window.JobHackAINavigation.getEffectivePlan === 'function') {
+      plan = window.JobHackAINavigation.getEffectivePlan();
+      // Only use verifiedCachedPlan when navigation hasn't hydrated yet
+      // (undefined/visitor). Once navigation reports a real plan (including 'free'),
+      // trust it — it reflects the authoritative state (e.g. expired trial).
+      if (!plan || plan === 'undefined' || plan === 'visitor') {
+        plan = verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';
+      }
+    } else {
+      plan = verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';
+    }
+
+    // Validate plan value to prevent corrupted data (e.g., "central")
+    if (VALID_PLANS.indexOf(plan) === -1) {
+      var oldPlan = plan;
+      console.warn(logPrefix, 'Invalid plan detected:', plan, '- resetting to free');
+      plan = 'free';
+      localStorage.setItem('user-plan', 'free');
+      var devPlan = localStorage.getItem('dev-plan');
+      if (devPlan && VALID_PLANS.indexOf(devPlan) === -1) {
+        localStorage.setItem('dev-plan', 'free');
+      }
+      console.log(logPrefix, 'Plan cleanup completed:', {
+        oldPlan: oldPlan,
+        newPlan: 'free',
+        localStoragePlan: localStorage.getItem('user-plan'),
+        devPlan: localStorage.getItem('dev-plan')
+      });
+    }
+
+    return plan;
+  }
+
+  // ---- deferred re-verification ----
+
+  // When the head guard granted access via the sync fast path (localStorage only),
+  // schedule an async API check to catch stale/expired plans.
+  var _deferredReVerifyScheduled = false;
+
+  // opts.allowedPlans  – array of plan slugs that grant access (default PAID_PLANS)
+  // opts.onPlanChanged – callback(newPlan) when API reports a different (still valid) plan
+  // opts.logPrefix     – string prefix for console messages
+  function deferredPlanReVerify(opts) {
+    if (_deferredReVerifyScheduled) return;
+    _deferredReVerifyScheduled = true;
+    opts = opts || {};
+    var allowedPlans = opts.allowedPlans || PAID_PLANS;
+    var logPrefix    = opts.logPrefix || '[PAGE-ACCESS]';
+
+    setTimeout(async function () {
+      try {
+        if (!window.JobHackAINavigation) return;
+        if (typeof window.JobHackAINavigation.fetchPlanFromAPI !== 'function') return;
+        var apiPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
+        if (!apiPlan) return;
+        if (allowedPlans.indexOf(apiPlan) === -1) {
+          console.warn(logPrefix, 'Deferred re-verify: plan is now', apiPlan, '— revoking access');
+          window.__JOBHACKAI_ACCESS_VERIFIED__ = false;
+          window.__JOBHACKAI_VERIFIED_PLAN__ = null;
+          window.location.href = 'pricing-a.html?plan=essential';
+        } else if (apiPlan !== window.__JOBHACKAI_VERIFIED_PLAN__) {
+          console.log(logPrefix, 'Deferred re-verify: updating verified plan to', apiPlan);
+          window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
+          if (typeof opts.onPlanChanged === 'function') opts.onPlanChanged(apiPlan);
+          window.dispatchEvent(new CustomEvent('planChanged', { detail: { plan: apiPlan } }));
+        }
+      } catch (e) {
+        console.warn(logPrefix, 'Deferred re-verify error:', e);
+      }
+    }, 2000);
+  }
+
+  // Allow re-scheduling after a page-level plan change (e.g. upgrade)
+  function resetDeferredReVerify() {
+    _deferredReVerifyScheduled = false;
+  }
+
+  // ---- page access enforcement ----
+
+  // opts.allowedPlans  – array of plan slugs that grant access (default PAID_PLANS)
+  // opts.onPlanChanged – forwarded to deferredPlanReVerify
+  // opts.logPrefix     – string prefix for console messages
+  async function enforceAccess(opts) {
+    opts = opts || {};
+    var allowedPlans = opts.allowedPlans || PAID_PLANS;
+    var logPrefix    = opts.logPrefix || '[PAGE-ACCESS]';
+
+    // Fast path: head guard already verified
+    if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
+      console.log(logPrefix, 'enforceAccess: head guard set flag, scheduling deferred re-verification');
+      deferredPlanReVerify(opts);
+      return;
+    }
+
+    // Wait for head guard async path to complete before checking independently.
+    // Head guard awaits FirebaseAuthManager (3s) + waitForAuthReady (5s) + API fetch,
+    // so allow up to 10s for it to set __JOBHACKAI_ACCESS_VERIFIED__.
+    var waited = 0;
+    while (!window.__JOBHACKAI_ACCESS_VERIFIED__ && waited < 10000) {
+      await new Promise(function (r) { setTimeout(r, 200); });
+      waited += 200;
+    }
+    if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
+      console.log(logPrefix, 'enforceAccess: head guard verified after', waited, 'ms');
+      deferredPlanReVerify(opts);
+      return;
+    }
+
+    // Head guard timed out or denied — do independent fallback check
+    var isAuthenticated, plan;
+
+    if (window.JobHackAINavigation) {
+      var authState = window.JobHackAINavigation.getAuthState();
+      isAuthenticated = authState && authState.isAuthenticated;
+      plan = window.JobHackAINavigation.getEffectivePlan();
+    } else {
+      var hasLocalStorageAuth = localStorage.getItem('user-authenticated') === 'true';
+      var hasFirebaseKeys = Object.keys(localStorage).some(function (k) {
+        return k.startsWith('firebase:authUser:') &&
+          localStorage.getItem(k) &&
+          localStorage.getItem(k) !== 'null' &&
+          localStorage.getItem(k).length > 10;
+      });
+      // SECURITY: Require BOTH signals (matches head fast path + static-auth-guard.js)
+      isAuthenticated = hasLocalStorageAuth && hasFirebaseKeys;
+      plan = localStorage.getItem('user-plan') || 'free';
+    }
+
+    if (!isAuthenticated || allowedPlans.indexOf(plan) === -1) {
+      if (!isAuthenticated) {
+        window.location.href = 'login.html';
+      } else {
+        window.location.href = 'pricing-a.html?plan=essential';
+      }
+    } else {
+      window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+      window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
+      document.documentElement.classList.remove('auth-pending');
+      document.documentElement.classList.remove('plan-pending');
+      console.log(logPrefix, 'enforceAccess: fallback granted access, flag set');
+      deferredPlanReVerify(opts);
+    }
+  }
+
+  return {
+    VALID_PLANS: VALID_PLANS,
+    PAID_PLANS: PAID_PLANS,
+    waitForGlobal: waitForGlobal,
+    getVerifiedCachedPlan: getVerifiedCachedPlan,
+    getCurrentUserPlan: getCurrentUserPlan,
+    deferredPlanReVerify: deferredPlanReVerify,
+    resetDeferredReVerify: resetDeferredReVerify,
+    enforceAccess: enforceAccess
+  };
+})();

--- a/js/page-access-control.js
+++ b/js/page-access-control.js
@@ -115,11 +115,6 @@ window.PageAccessControl = (function () {
     }, 2000);
   }
 
-  // Allow re-scheduling after a page-level plan change (e.g. upgrade)
-  function resetDeferredReVerify() {
-    _deferredReVerifyScheduled = false;
-  }
-
   // ---- page access enforcement ----
 
   // opts.allowedPlans  – array of plan slugs that grant access (default PAID_PLANS)
@@ -194,7 +189,6 @@ window.PageAccessControl = (function () {
     getVerifiedCachedPlan: getVerifiedCachedPlan,
     getCurrentUserPlan: getCurrentUserPlan,
     deferredPlanReVerify: deferredPlanReVerify,
-    resetDeferredReVerify: resetDeferredReVerify,
     enforceAccess: enforceAccess
   };
 })();

--- a/js/plan-cache.js
+++ b/js/plan-cache.js
@@ -9,6 +9,7 @@
   var _cached = null;   // { plan, trialEndsAt }
   var _cachedAt = 0;
   var _inflight = null; // Promise | null
+  var _generation = 0;  // Incremented on invalidate to discard stale in-flight results
   var CACHE_TTL = 30000; // 30 seconds
 
   function doFetch(token) {
@@ -28,9 +29,10 @@
       localStorage.setItem('user-plan', result.plan || 'free');
       if (result.trialEndsAt) {
         localStorage.setItem('trial-ends-at', result.trialEndsAt);
-      } else {
-        localStorage.removeItem('trial-ends-at');
       }
+      // Do NOT remove trial-ends-at when absent — a previous API call
+      // may have set it correctly and callers like billing-status fallback
+      // may not have trialEndsAt available.
     } catch (_) { /* localStorage may be unavailable */ }
   }
 
@@ -48,18 +50,19 @@
       // Deduplicate in-flight requests — all callers share the same promise
       if (_inflight) return _inflight;
 
+      var gen = ++_generation;
       _inflight = doFetch(token)
         .then(function (result) {
-          if (result) {
+          if (gen === _generation && result) {
             _cached = result;
             _cachedAt = Date.now();
             persistToLocalStorage(result);
           }
-          _inflight = null;
+          if (gen === _generation) _inflight = null;
           return result;
         })
         .catch(function (err) {
-          _inflight = null;
+          if (gen === _generation) _inflight = null;
           console.warn('[PlanCache] fetch failed:', err);
           return null;
         });
@@ -85,19 +88,8 @@
     invalidate: function () {
       _cached = null;
       _cachedAt = 0;
-      
-      // Store the current in-flight promise to prevent race conditions
-      var oldInflight = _inflight;
       _inflight = null;
-      
-      // If there was an in-flight request, chain a handler to prevent it from
-      // updating the cache when it completes
-      if (oldInflight) {
-        oldInflight.then(function() {
-          // Do nothing with the result - prevent the old promise's result
-          // from overwriting our freshly invalidated cache
-        });
-      }
+      ++_generation; // Ensures any in-flight fetch won't overwrite cache when it resolves
     }
   };
 })();

--- a/js/plan-cache.js
+++ b/js/plan-cache.js
@@ -1,0 +1,91 @@
+// Centralized plan cache with request deduplication.
+// Every subsystem (firebase-auth.js, navigation.js, page-access-control.js,
+// dashboard.tsx) MUST fetch the user plan through window.PlanCache to avoid
+// redundant /api/plan/me calls. The cache deduplicates in-flight requests
+// and keeps results fresh for CACHE_TTL milliseconds.
+(function () {
+  'use strict';
+
+  var _cached = null;   // { plan, trialEndsAt }
+  var _cachedAt = 0;
+  var _inflight = null; // Promise | null
+  var CACHE_TTL = 30000; // 30 seconds
+
+  function doFetch(token) {
+    return fetch('/api/plan/me', {
+      headers: { Authorization: 'Bearer ' + token }
+    }).then(function (res) {
+      if (!res.ok) return null;
+      return res.json().then(function (data) {
+        return { plan: (data && data.plan) || null, trialEndsAt: (data && data.trialEndsAt) || null };
+      });
+    });
+  }
+
+  function persistToLocalStorage(result) {
+    if (!result) return;
+    try {
+      localStorage.setItem('user-plan', result.plan || 'free');
+      if (result.trialEndsAt) {
+        localStorage.setItem('trial-ends-at', result.trialEndsAt);
+      } else {
+        localStorage.removeItem('trial-ends-at');
+      }
+    } catch (_) { /* localStorage may be unavailable */ }
+  }
+
+  window.PlanCache = {
+    // Main entry point. Returns { plan, trialEndsAt } or null.
+    // Deduplicates concurrent calls automatically.
+    getPlan: function (token, forceRefresh) {
+      if (!token) return Promise.resolve(null);
+
+      // Return cached result if still fresh
+      if (!forceRefresh && _cached && (Date.now() - _cachedAt) < CACHE_TTL) {
+        return Promise.resolve(_cached);
+      }
+
+      // Deduplicate in-flight requests — all callers share the same promise
+      if (_inflight) return _inflight;
+
+      _inflight = doFetch(token)
+        .then(function (result) {
+          if (result) {
+            _cached = result;
+            _cachedAt = Date.now();
+            persistToLocalStorage(result);
+          }
+          _inflight = null;
+          return result;
+        })
+        .catch(function (err) {
+          _inflight = null;
+          console.warn('[PlanCache] fetch failed:', err);
+          return null;
+        });
+
+      return _inflight;
+    },
+
+    // Read-only access to the last fetched value (no network call).
+    getCachedPlan: function () {
+      return _cached;
+    },
+
+    // Manually seed the cache (e.g. after checkout redirect sets plan via
+    // billing-status). Prevents a redundant /api/plan/me round-trip.
+    setCachedPlan: function (plan, trialEndsAt) {
+      _cached = { plan: plan, trialEndsAt: trialEndsAt || null };
+      _cachedAt = Date.now();
+      persistToLocalStorage(_cached);
+    },
+
+    // Clear cache so the next getPlan() will hit the network.
+    // Call after checkout, plan upgrade/downgrade, or manual sync.
+    invalidate: function () {
+      _cached = null;
+      _cachedAt = 0;
+      _inflight = null;
+    }
+  };
+})();

--- a/js/plan-cache.js
+++ b/js/plan-cache.js
@@ -85,7 +85,19 @@
     invalidate: function () {
       _cached = null;
       _cachedAt = 0;
+      
+      // Store the current in-flight promise to prevent race conditions
+      var oldInflight = _inflight;
       _inflight = null;
+      
+      // If there was an in-flight request, chain a handler to prevent it from
+      // updating the cache when it completes
+      if (oldInflight) {
+        oldInflight.then(function() {
+          // Do nothing with the result - prevent the old promise's result
+          // from overwriting our freshly invalidated cache
+        });
+      }
     }
   };
 })();

--- a/linkedin-optimizer.html
+++ b/linkedin-optimizer.html
@@ -333,6 +333,7 @@
   <script src="js/main.js" type="module"></script>
   <script src="js/analytics.js" type="module"></script>
   <!-- Load Firebase auth for token retrieval -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/marketing/blog.html
+++ b/marketing/blog.html
@@ -229,6 +229,7 @@
   </footer>
 
   <script src="js/component-loader.js?v=20260206-1"></script>
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <script src="js/navigation.js?v=20260208-1"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/blog/7-day-interview-prep-routine.html
+++ b/marketing/blog/7-day-interview-prep-routine.html
@@ -254,6 +254,7 @@
   </footer>
 
   <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
   <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
   <script src="../js/navigation.js?v=20260208-1"></script>
   <script src="../js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/blog/ats-optimization-playbook.html
+++ b/marketing/blog/ats-optimization-playbook.html
@@ -240,6 +240,7 @@
   </footer>
 
   <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
   <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
   <script src="../js/navigation.js?v=20260208-1"></script>
   <script src="../js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/blog/linkedin-profile-optimization.html
+++ b/marketing/blog/linkedin-profile-optimization.html
@@ -229,6 +229,7 @@
   </footer>
 
   <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
   <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
   <script src="../js/navigation.js?v=20260208-1"></script>
   <script src="../js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/blog/mock-interview-online.html
+++ b/marketing/blog/mock-interview-online.html
@@ -283,6 +283,7 @@
   </footer>
 
   <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
   <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
   <script src="../js/navigation.js?v=20260208-1"></script>
   <script src="../js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/blog/post-template.html
+++ b/marketing/blog/post-template.html
@@ -258,6 +258,7 @@
   </footer>
 
   <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
   <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
   <script src="../js/navigation.js?v=20260208-1"></script>
   <script src="../js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/features.html
+++ b/marketing/features.html
@@ -180,6 +180,7 @@
   </footer>
 
   <script src="js/component-loader.js?v=20260206-1"></script>
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <script src="js/navigation.js?v=20260208-1"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/index.html
+++ b/marketing/index.html
@@ -209,6 +209,7 @@
   </footer>
 
   <script src="js/component-loader.js?v=20260206-1"></script>
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <script src="js/navigation.js?v=20260208-1"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/js/firebase-auth.js
+++ b/marketing/js/firebase-auth.js
@@ -85,6 +85,7 @@ function clearAuthCookies() {
 }
 
 // --- DIRECT PLAN FETCH FROM D1 VIA API (navigation-independent) ---
+// Routes through PlanCache when available to deduplicate concurrent requests.
 async function fetchPlanFromAPI() {
   try {
     const user = auth.currentUser;
@@ -97,6 +98,12 @@ async function fetchPlanFromAPI() {
       console.log('🔍 fetchPlanFromAPI: no idToken');
       return null;
     }
+    if (window.PlanCache) {
+      const result = await window.PlanCache.getPlan(idToken);
+      const plan = result && result.plan;
+      console.log(`📊 fetchPlanFromAPI (via PlanCache): plan="${plan}"`);
+      return plan || null;
+    }
     console.log(`🔍 fetchPlanFromAPI: calling /api/plan/me for uid=${user.uid}`);
     const res = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
     if (!res.ok) {
@@ -107,7 +114,6 @@ async function fetchPlanFromAPI() {
     console.log(`📊 fetchPlanFromAPI: API returned plan="${data?.plan}"`);
     return data?.plan || null;
   } catch (e) {
-    // API fetch failed - this is non-critical, will fallback to 'free'
     console.log('ℹ️ Direct plan API fetch unavailable, will use fallback:', e.message || 'network error');
     return null;
   }

--- a/marketing/js/firebase-auth.js
+++ b/marketing/js/firebase-auth.js
@@ -747,8 +747,16 @@ class AuthManager {
               actualPlan = selectedPlan === 'trial' ? 'pending' : selectedPlan;
               console.log('✅ Using newly selected plan for LinkedIn sign-in (same-window):', actualPlan);
             } else {
-              // Fetch plan from API using token
-              const kvPlan = await apiFetchJSON('/api/plan/me');
+              // Fetch plan from API using PlanCache (deduplicated)
+              const idToken = getIdTokenSync();
+              let kvPlan = null;
+              if (window.PlanCache && idToken) {
+                window.PlanCache.invalidate();
+                const result = await window.PlanCache.getPlan(idToken);
+                kvPlan = result && result.plan ? result : null;
+              } else {
+                kvPlan = await apiFetchJSON('/api/plan/me');
+              }
               if (kvPlan?.plan) {
                 actualPlan = kvPlan.plan;
                 console.log('✅ Fetched plan from API during LinkedIn sign-in (same-window):', actualPlan);

--- a/marketing/js/navigation.js
+++ b/marketing/js/navigation.js
@@ -2560,88 +2560,22 @@ async function initializeNavigation() {
 //   document.body.appendChild(switcher);
 //   navLog('debug', 'Quick plan switcher appended to body');
 
-  // CRITICAL FIX: For authenticated users, fetch plan before rendering navigation
-  // This prevents race condition where navigation shows wrong plan initially
+  // For authenticated users, read plan from PlanCache or localStorage.
+  // The authoritative /api/plan/me fetch is handled by firebase-auth.js via PlanCache.
   if (authState.isAuthenticated && window.FirebaseAuthManager?.getCurrentUser) {
-    navLog('info', 'Authenticated user detected, fetching plan before navigation render');
+    navLog('info', 'Authenticated user detected, reading plan for navigation render');
     try {
-      const user = window.FirebaseAuthManager.getCurrentUser();
-      if (user) {
-        const token = await user.getIdToken();
-        // Fetch plan from API first
-        const planRes = await fetch('/api/plan/me', {
-          headers: { Authorization: `Bearer ${token}` }
-        });
-        if (planRes.ok) {
-          const planData = await planRes.json();
-          if (planData.plan) {
-            navLog('info', 'Fetched plan from API, updating localStorage', planData.plan);
-            localStorage.setItem('user-plan', planData.plan);
-            localStorage.setItem('dev-plan', planData.plan);
-            
-            // If plan is free, double-check with billing-status as fallback
-            if (planData.plan === 'free') {
-              navLog('info', 'Plan is free, checking billing-status as fallback');
-              const billingRes = await fetch('/api/billing-status?force=1', {
-                headers: { Authorization: `Bearer ${token}` }
-              });
-              if (billingRes.ok) {
-                const billingData = await billingRes.json();
-                if (billingData.ok && billingData.plan && billingData.plan !== 'free') {
-                  navLog('info', 'Found plan from billing-status fallback, updating', billingData.plan);
-                  localStorage.setItem('user-plan', billingData.plan);
-                  localStorage.setItem('dev-plan', billingData.plan);
-                  // Sync to D1 asynchronously (via sync-stripe-plan which writes to D1)
-                  fetch('/api/sync-stripe-plan', {
-                    method: 'POST',
-                    headers: { Authorization: `Bearer ${token}` }
-                  }).catch(err => navLog('warn', 'Failed to sync plan to D1 (non-critical):', err));
-                }
-              }
-            }
-          } else {
-            // plan/me returned successfully but without plan field - use billing-status as fallback
-            navLog('info', 'plan/me response missing plan field, checking billing-status as fallback');
-            const billingRes = await fetch('/api/billing-status?force=1', {
-              headers: { Authorization: `Bearer ${token}` }
-            });
-            if (billingRes.ok) {
-              const billingData = await billingRes.json();
-              if (billingData.ok && billingData.plan) {
-                navLog('info', 'Found plan from billing-status fallback (plan/me missing plan)', billingData.plan);
-                localStorage.setItem('user-plan', billingData.plan);
-                localStorage.setItem('dev-plan', billingData.plan);
-                // Sync to KV asynchronously
-                fetch('/api/sync-stripe-plan', {
-                  method: 'POST',
-                  headers: { Authorization: `Bearer ${token}` }
-                }).catch(err => navLog('warn', 'Failed to sync plan to KV (non-critical):', err));
-              }
-            }
-          }
-        } else {
-          // plan/me failed - use billing-status as fallback
-          navLog('info', 'plan/me request failed, checking billing-status as fallback');
-          const billingRes = await fetch('/api/billing-status?force=1', {
-            headers: { Authorization: `Bearer ${token}` }
-          });
-          if (billingRes.ok) {
-            const billingData = await billingRes.json();
-            if (billingData.ok && billingData.plan) {
-              navLog('info', 'Found plan from billing-status fallback (plan/me failed)', billingData.plan);
-              localStorage.setItem('user-plan', billingData.plan);
-              localStorage.setItem('dev-plan', billingData.plan);
-              // Sync to KV asynchronously
-              fetch('/api/sync-stripe-plan', {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${token}` }
-              }).catch(err => navLog('warn', 'Failed to sync plan to KV (non-critical):', err));
-            }
-          }
-        }
+      const cached = window.PlanCache && window.PlanCache.getCachedPlan();
+      if (cached && cached.plan) {
+        navLog('info', 'Using plan from PlanCache:', cached.plan);
+        localStorage.setItem('user-plan', cached.plan);
+        localStorage.setItem('dev-plan', cached.plan);
+      } else {
+        const lsPlan = localStorage.getItem('user-plan');
+        navLog('info', 'PlanCache not yet populated, using localStorage plan:', lsPlan || 'free');
       }
     } catch (planError) {
-      navLog('warn', 'Plan fetch failed (non-critical), continuing with navigation render:', planError);
+      navLog('warn', 'Plan read failed (non-critical), continuing with navigation render:', planError);
     }
   }
   
@@ -2819,21 +2753,12 @@ async function initializeNavigation() {
 }
 
 // --- Plan Reconciliation from D1 via API ---
+// Routes through PlanCache to deduplicate concurrent /api/plan/me requests.
 async function fetchPlanFromAPI() {
   try {
-    // DEFENSIVE GUARD: Ensure FirebaseAuthManager is loaded
     if (!window.FirebaseAuthManager) {
       console.log('🔍 fetchPlanFromAPI: FirebaseAuthManager not loaded yet, skipping');
       return null;
-    }
-
-    // DEFENSIVE GUARD: Wait for auth to be ready if it's still initializing
-    if (window.FirebaseAuthManager.waitForAuthReady) {
-      try {
-        await window.FirebaseAuthManager.waitForAuthReady(1000); // Short timeout
-      } catch (e) {
-        console.log('🔍 fetchPlanFromAPI: Auth ready timeout, continuing anyway');
-      }
     }
 
     const currentUser = window.FirebaseAuthManager?.getCurrentUser?.();
@@ -2841,67 +2766,62 @@ async function fetchPlanFromAPI() {
       console.log('🔍 fetchPlanFromAPI: No current user available');
       return null;
     }
-    
+
     const idToken = await currentUser.getIdToken?.();
     if (!idToken) {
       console.log('🔍 fetchPlanFromAPI: No ID token available');
       return null;
     }
-    
-    console.log('🔍 fetchPlanFromAPI: Fetching plan from D1 via API...');
-    const r = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
-    if (!r.ok) {
-      console.warn(`🔍 fetchPlanFromAPI: API returned ${r.status} ${r.statusText}`);
-      return null;
+
+    let plan = null;
+    if (window.PlanCache) {
+      const result = await window.PlanCache.getPlan(idToken);
+      plan = result && result.plan ? result.plan : null;
+      console.log('🔍 fetchPlanFromAPI (via PlanCache):', plan);
+    } else {
+      console.log('🔍 fetchPlanFromAPI: Fetching plan from D1 via API...');
+      const r = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
+      if (!r.ok) {
+        console.warn(`🔍 fetchPlanFromAPI: API returned ${r.status} ${r.statusText}`);
+        return null;
+      }
+      const data = await r.json();
+      plan = data.plan || 'free';
+      if (data.trialEndsAt) {
+        localStorage.setItem('trial-ends-at', data.trialEndsAt);
+      } else {
+        localStorage.removeItem('trial-ends-at');
+      }
     }
-    
-    const data = await r.json();
-    console.log('🔍 fetchPlanFromAPI: API response:', data);
-    
-    let plan = data.plan || 'free';
-    
-    // CRITICAL FIX: If plan is 'free' but user is authenticated, check billing-status as fallback
-    // This handles cases where D1 is out of sync with Stripe (shouldn't happen, but safety net)
+
+    if (!plan) return null;
+
+    // Billing-status fallback: if D1 says 'free' but Stripe may disagree
     if (plan === 'free' && currentUser) {
       console.log('🔍 fetchPlanFromAPI: Plan is free, checking billing-status as fallback...');
       try {
-        const billingRes = await fetch('/api/billing-status?force=1', { 
-          headers: { Authorization: `Bearer ${idToken}` } 
+        const billingRes = await fetch('/api/billing-status?force=1', {
+          headers: { Authorization: `Bearer ${idToken}` }
         });
         if (billingRes.ok) {
           const billingData = await billingRes.json();
           if (billingData.ok && billingData.plan && billingData.plan !== 'free') {
             console.log(`🔄 fetchPlanFromAPI: Found plan ${billingData.plan} from billing-status, syncing to D1...`);
             plan = billingData.plan;
-            // Sync to D1 (via sync-stripe-plan which writes to D1)
-            try {
-              const syncRes = await fetch('/api/sync-stripe-plan', {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${idToken}` }
-              });
-              if (syncRes.ok) {
-                console.log('✅ fetchPlanFromAPI: Plan synced to D1');
-              }
-            } catch (syncError) {
-              console.warn('⚠️ fetchPlanFromAPI: Failed to sync plan to D1:', syncError);
-            }
+            if (window.PlanCache) window.PlanCache.setCachedPlan(plan);
+            fetch('/api/sync-stripe-plan', {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${idToken}` }
+            }).catch(err => console.warn('⚠️ fetchPlanFromAPI: Failed to sync plan to D1:', err));
           }
         }
       } catch (billingError) {
         console.warn('⚠️ fetchPlanFromAPI: Failed to check billing-status:', billingError);
       }
     }
-    
-    // Store trial end date if available
-    if (data.trialEndsAt) {
-      localStorage.setItem('trial-ends-at', data.trialEndsAt);
-    } else {
-      localStorage.removeItem('trial-ends-at');
-    }
-    
-    // Update localStorage with correct plan
+
     localStorage.setItem('user-plan', plan);
-    console.log(`✅ fetchPlanFromAPI: Successfully fetched plan from D1: ${plan}`);
+    console.log(`✅ fetchPlanFromAPI: Successfully fetched plan: ${plan}`);
     return plan;
   } catch (error) {
     console.warn('❌ fetchPlanFromAPI: Error fetching plan:', error);
@@ -2922,31 +2842,15 @@ async function reconcilePlanFromAPI() {
     return;
   }
   
-  // FIX: Add retry mechanism for plan reconciliation
-  let plan = null;
-  let retryCount = 0;
-  const maxRetries = 3;
-  
   console.log('🔍 reconcilePlanFromAPI: Starting plan reconciliation from D1...');
-  
-  while (!plan && retryCount < maxRetries) {
-    try {
-      plan = await fetchPlanFromAPI();
-      if (plan) {
-        console.log(`✅ Plan reconciliation successful on attempt ${retryCount + 1}:`, plan);
-        break;
-      }
-    } catch (error) {
-      console.warn(`⚠️ Plan reconciliation attempt ${retryCount + 1} failed:`, error);
-    }
-    
-    retryCount++;
-    if (retryCount < maxRetries) {
-      console.log(`🔄 Retrying plan reconciliation in ${retryCount * 1000}ms...`);
-      await new Promise(resolve => setTimeout(resolve, retryCount * 1000));
-    }
+
+  let plan = null;
+  try {
+    plan = await fetchPlanFromAPI();
+  } catch (error) {
+    console.warn('⚠️ Plan reconciliation failed:', error);
   }
-  
+
   const current = localStorage.getItem('user-plan');
   if (plan && plan !== current) {
     console.log(`🔄 Updating plan from ${current} to ${plan}`);
@@ -2955,7 +2859,7 @@ async function reconcilePlanFromAPI() {
     scheduleUpdateNavigation(true);
     try { new BroadcastChannel('auth').postMessage({ type: 'plan-update', plan: plan }); } catch (_) {}
   } else if (!plan) {
-    console.warn('⚠️ Plan reconciliation failed after all retries, keeping current plan:', current);
+    console.warn('⚠️ Plan reconciliation failed, keeping current plan:', current);
   }
 }
 

--- a/marketing/js/navigation.js
+++ b/marketing/js/navigation.js
@@ -2808,7 +2808,11 @@ async function fetchPlanFromAPI() {
           if (billingData.ok && billingData.plan && billingData.plan !== 'free') {
             console.log(`🔄 fetchPlanFromAPI: Found plan ${billingData.plan} from billing-status, syncing to D1...`);
             plan = billingData.plan;
-            if (window.PlanCache) window.PlanCache.setCachedPlan(plan);
+            if (window.PlanCache) {
+              const cachedPlan = window.PlanCache.getCachedPlan();
+              const trialEndsAt = cachedPlan ? cachedPlan.trialEndsAt : localStorage.getItem('trial-ends-at');
+              window.PlanCache.setCachedPlan(plan, trialEndsAt);
+            }
             fetch('/api/sync-stripe-plan', {
               method: 'POST',
               headers: { Authorization: `Bearer ${idToken}` }

--- a/marketing/js/plan-cache.js
+++ b/marketing/js/plan-cache.js
@@ -9,6 +9,7 @@
   var _cached = null;   // { plan, trialEndsAt }
   var _cachedAt = 0;
   var _inflight = null; // Promise | null
+  var _generation = 0;  // Incremented on invalidate to discard stale in-flight results
   var CACHE_TTL = 30000; // 30 seconds
 
   function doFetch(token) {
@@ -28,9 +29,10 @@
       localStorage.setItem('user-plan', result.plan || 'free');
       if (result.trialEndsAt) {
         localStorage.setItem('trial-ends-at', result.trialEndsAt);
-      } else {
-        localStorage.removeItem('trial-ends-at');
       }
+      // Do NOT remove trial-ends-at when absent — a previous API call
+      // may have set it correctly and callers like billing-status fallback
+      // may not have trialEndsAt available.
     } catch (_) { /* localStorage may be unavailable */ }
   }
 
@@ -48,18 +50,19 @@
       // Deduplicate in-flight requests — all callers share the same promise
       if (_inflight) return _inflight;
 
+      var gen = ++_generation;
       _inflight = doFetch(token)
         .then(function (result) {
-          if (result) {
+          if (gen === _generation && result) {
             _cached = result;
             _cachedAt = Date.now();
             persistToLocalStorage(result);
           }
-          _inflight = null;
+          if (gen === _generation) _inflight = null;
           return result;
         })
         .catch(function (err) {
-          _inflight = null;
+          if (gen === _generation) _inflight = null;
           console.warn('[PlanCache] fetch failed:', err);
           return null;
         });
@@ -86,6 +89,7 @@
       _cached = null;
       _cachedAt = 0;
       _inflight = null;
+      ++_generation; // Ensures any in-flight fetch won't overwrite cache when it resolves
     }
   };
 })();

--- a/marketing/js/plan-cache.js
+++ b/marketing/js/plan-cache.js
@@ -1,0 +1,91 @@
+// Centralized plan cache with request deduplication.
+// Every subsystem (firebase-auth.js, navigation.js, page-access-control.js,
+// dashboard.tsx) MUST fetch the user plan through window.PlanCache to avoid
+// redundant /api/plan/me calls. The cache deduplicates in-flight requests
+// and keeps results fresh for CACHE_TTL milliseconds.
+(function () {
+  'use strict';
+
+  var _cached = null;   // { plan, trialEndsAt }
+  var _cachedAt = 0;
+  var _inflight = null; // Promise | null
+  var CACHE_TTL = 30000; // 30 seconds
+
+  function doFetch(token) {
+    return fetch('/api/plan/me', {
+      headers: { Authorization: 'Bearer ' + token }
+    }).then(function (res) {
+      if (!res.ok) return null;
+      return res.json().then(function (data) {
+        return { plan: (data && data.plan) || null, trialEndsAt: (data && data.trialEndsAt) || null };
+      });
+    });
+  }
+
+  function persistToLocalStorage(result) {
+    if (!result) return;
+    try {
+      localStorage.setItem('user-plan', result.plan || 'free');
+      if (result.trialEndsAt) {
+        localStorage.setItem('trial-ends-at', result.trialEndsAt);
+      } else {
+        localStorage.removeItem('trial-ends-at');
+      }
+    } catch (_) { /* localStorage may be unavailable */ }
+  }
+
+  window.PlanCache = {
+    // Main entry point. Returns { plan, trialEndsAt } or null.
+    // Deduplicates concurrent calls automatically.
+    getPlan: function (token, forceRefresh) {
+      if (!token) return Promise.resolve(null);
+
+      // Return cached result if still fresh
+      if (!forceRefresh && _cached && (Date.now() - _cachedAt) < CACHE_TTL) {
+        return Promise.resolve(_cached);
+      }
+
+      // Deduplicate in-flight requests — all callers share the same promise
+      if (_inflight) return _inflight;
+
+      _inflight = doFetch(token)
+        .then(function (result) {
+          if (result) {
+            _cached = result;
+            _cachedAt = Date.now();
+            persistToLocalStorage(result);
+          }
+          _inflight = null;
+          return result;
+        })
+        .catch(function (err) {
+          _inflight = null;
+          console.warn('[PlanCache] fetch failed:', err);
+          return null;
+        });
+
+      return _inflight;
+    },
+
+    // Read-only access to the last fetched value (no network call).
+    getCachedPlan: function () {
+      return _cached;
+    },
+
+    // Manually seed the cache (e.g. after checkout redirect sets plan via
+    // billing-status). Prevents a redundant /api/plan/me round-trip.
+    setCachedPlan: function (plan, trialEndsAt) {
+      _cached = { plan: plan, trialEndsAt: trialEndsAt || null };
+      _cachedAt = Date.now();
+      persistToLocalStorage(_cached);
+    },
+
+    // Clear cache so the next getPlan() will hit the network.
+    // Call after checkout, plan upgrade/downgrade, or manual sync.
+    invalidate: function () {
+      _cached = null;
+      _cachedAt = 0;
+      _inflight = null;
+    }
+  };
+})();

--- a/mock-interview.html
+++ b/mock-interview.html
@@ -1623,6 +1623,7 @@
   <!-- Scripts -->
   <script src="js/navigation.js?v=20260208-1"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <script src="js/role-selector.js?v=20250115-1" type="module"></script>
   <script src="js/main.js" type="module"></script>

--- a/mock-interview.html
+++ b/mock-interview.html
@@ -4,27 +4,145 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <style>html.auth-pending{visibility:hidden}</style>
+  <style>html.auth-pending,html.plan-pending{visibility:hidden}</style>
   <script src="js/static-auth-guard.js?v=20260125-1"></script>
+  <script src="js/page-access-control.js?v=20260331-1"></script>
   <script>
-    // Canonical plan/auth check using JobHackAINavigation
-    function ensureMockInterviewAccess() {
-      const nav = window.JobHackAINavigation;
-      if (!nav || !nav.getEffectivePlan || !nav.getAuthState) {
-        return false; // wait until navigation is ready
+    // --- IMMEDIATE PAGE ACCESS CONTROL ---
+    // Wait for Firebase auth AND plan fetch before checking (prevents false redirects)
+    (async function enforceAccessImmediate() {
+      // If access was already pre-verified (e.g. by test harness), skip all auth logic
+      if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
+        document.documentElement.classList.remove('auth-pending');
+        document.documentElement.classList.remove('plan-pending');
+        return;
       }
-      const plan = nav.getEffectivePlan();
-      const auth = nav.getAuthState();
-      const allowed = ['pro', 'premium'];
-      if (!auth.isAuthenticated || !allowed.includes(plan)) {
-        window.location.href = 'interview-questions.html?upgrade=mock-interview';
-        return false;
-      }
-      return true;
-    }
 
-    document.addEventListener('navigationReady', ensureMockInterviewAccess);
-    document.addEventListener('DOMContentLoaded', ensureMockInterviewAccess);
+      var allowedPlans = ['pro', 'premium'];
+
+      // Synchronous fast path: check localStorage auth + cached plan BEFORE any async work.
+      // This sets __JOBHACKAI_ACCESS_VERIFIED__ immediately so the body guard never races.
+      // SECURITY: Require BOTH user-authenticated AND firebase:authUser: keys
+      // (matches static-auth-guard.js AND logic to prevent XSS single-key bypass)
+      var cachedPlan = localStorage.getItem('user-plan') || 'free';
+      var hasLocalAuth = localStorage.getItem('user-authenticated') === 'true';
+      var hasFBKeys = false;
+      for (var i = 0; i < localStorage.length; i++) {
+        var fk = localStorage.key(i);
+        if (fk && fk.indexOf('firebase:authUser:') === 0) {
+          var fd = localStorage.getItem(fk);
+          if (fd && fd !== 'null' && fd.length > 10) { hasFBKeys = true; break; }
+        }
+      }
+      if (hasLocalAuth && hasFBKeys && allowedPlans.includes(cachedPlan)) {
+        console.log('✅ [MOCK-INTERVIEW] Sync fast path: access granted for cached plan:', cachedPlan);
+        window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+        window.__JOBHACKAI_VERIFIED_PLAN__ = cachedPlan;
+        document.documentElement.classList.remove('auth-pending');
+        document.documentElement.classList.remove('plan-pending');
+        return;
+      }
+
+      // Helper: delegate to shared module
+      var waitForGlobal = window.PageAccessControl
+        ? window.PageAccessControl.waitForGlobal
+        : function(name, timeout) {
+            if (window[name]) return Promise.resolve(true);
+            var deadline = Date.now() + timeout;
+            return new Promise(function (resolve) {
+              var interval = setInterval(function () {
+                if (window[name] || Date.now() >= deadline) {
+                  clearInterval(interval);
+                  resolve(!!window[name]);
+                }
+              }, 50);
+            });
+          };
+
+      // Step 1: Wait for FirebaseAuthManager to load (max 3s)
+      await waitForGlobal('FirebaseAuthManager', 3000);
+
+      // Step 2: Wait for Firebase auth to be ready
+      var user = null;
+      if (window.FirebaseAuthManager && window.FirebaseAuthManager.waitForAuthReady) {
+        try {
+          user = await window.FirebaseAuthManager.waitForAuthReady(5000);
+        } catch (e) {
+          console.warn('[MOCK-INTERVIEW] Auth ready timeout:', e);
+        }
+      }
+
+      // Step 3: Determine authentication
+      // Note: waitForAuthReady can return AUTH_PENDING sentinel ({_authPending:true})
+      // on timeout — a truthy non-user object. Exclude it.
+      var isAuthenticated = !!user && !user._authPending;
+      if (!isAuthenticated) {
+        // Fallback: check localStorage + Firebase SDK keys
+        var hasLocalStorageAuth = localStorage.getItem('user-authenticated') === 'true';
+        var hasFirebaseKeys = Object.keys(localStorage).some(function (k) {
+          return k.startsWith('firebase:authUser:') &&
+            localStorage.getItem(k) &&
+            localStorage.getItem(k) !== 'null' &&
+            localStorage.getItem(k).length > 10;
+        });
+        // SECURITY: Require BOTH signals (matches sync fast path + static-auth-guard.js)
+        isAuthenticated = hasLocalStorageAuth && hasFirebaseKeys;
+      }
+
+      if (!isAuthenticated) {
+        console.log('🚫 [MOCK-INTERVIEW] Not authenticated, redirecting to login');
+        window.location.href = 'login.html';
+        return;
+      }
+
+      // Step 4: Check cached plan first (fast path)
+      var plan = localStorage.getItem('user-plan') || 'free';
+      if (allowedPlans.includes(plan)) {
+        console.log('✅ [MOCK-INTERVIEW] Access granted for cached plan:', plan);
+        document.documentElement.classList.remove('auth-pending');
+        document.documentElement.classList.remove('plan-pending');
+        window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+        window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
+        return;
+      }
+
+      // Step 5: Cached plan would deny access — add plan-pending to hide content
+      // while we fetch the authoritative plan from the API
+      document.documentElement.classList.add('plan-pending');
+
+      // Wait for navigation module to load so we can use fetchPlanFromAPI
+      await waitForGlobal('JobHackAINavigation', 2000);
+
+      if (window.JobHackAINavigation && window.JobHackAINavigation.fetchPlanFromAPI) {
+        try {
+          var apiPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
+          if (apiPlan) plan = apiPlan;
+        } catch (e) {
+          console.warn('[MOCK-INTERVIEW] API plan fetch error:', e);
+        }
+      }
+
+      // Also check getEffectivePlan (handles dev-plan overrides on non-prod)
+      if (!allowedPlans.includes(plan) && window.JobHackAINavigation && window.JobHackAINavigation.getEffectivePlan) {
+        var effectivePlan = window.JobHackAINavigation.getEffectivePlan();
+        if (effectivePlan && allowedPlans.includes(effectivePlan)) {
+          plan = effectivePlan;
+        }
+      }
+
+      // Step 6: Final decision
+      if (!allowedPlans.includes(plan)) {
+        console.log('🚫 [MOCK-INTERVIEW] Access denied for plan:', plan, '— redirecting to interview-questions');
+        window.location.href = 'interview-questions.html?upgrade=mock-interview';
+        return;
+      }
+
+      document.documentElement.classList.remove('auth-pending');
+      document.documentElement.classList.remove('plan-pending');
+      window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+      window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
+      console.log('✅ [MOCK-INTERVIEW] Access granted for plan:', plan);
+    })();
   </script>
   <title>Mock Interviews with AI - JobHackAI</title>
   <link rel="icon" type="image/png" href="assets/jobhackai_icon_only_128.png">
@@ -3059,6 +3177,31 @@
       document.addEventListener('DOMContentLoaded', init);
     } else {
       init();
+    }
+
+    // --- DEFERRED RE-VERIFICATION & PAGE ACCESS CONTROL ---
+    // Delegated to shared page-access-control.js
+    var _miAccessOpts = {
+      allowedPlans: ['pro', 'premium'],
+      logPrefix: '[MOCK-INTERVIEW]'
+    };
+
+    function deferredPlanReVerify() {
+      if (window.PageAccessControl) window.PageAccessControl.deferredPlanReVerify(_miAccessOpts);
+    }
+
+    async function miEnforceAccess() {
+      if (window.PageAccessControl) await window.PageAccessControl.enforceAccess(_miAccessOpts);
+    }
+
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', async function () {
+        await miEnforceAccess();
+      });
+    } else {
+      setTimeout(async function () {
+        await miEnforceAccess();
+      }, 100);
     }
   </script>
   <script src="js/feedback-widget.js?v=20260303-1" defer></script>

--- a/mock-interview.html
+++ b/mock-interview.html
@@ -3183,7 +3183,8 @@
     // Delegated to shared page-access-control.js
     var _miAccessOpts = {
       allowedPlans: ['pro', 'premium'],
-      logPrefix: '[MOCK-INTERVIEW]'
+      logPrefix: '[MOCK-INTERVIEW]',
+      deniedRedirect: 'interview-questions.html?upgrade=mock-interview'
     };
 
     function deferredPlanReVerify() {

--- a/pricing-a.html
+++ b/pricing-a.html
@@ -395,6 +395,7 @@
     </div>
   </footer>
   <!-- Load Firebase auth modules -->
+  <script src="js/plan-cache.js"></script>
   <script src="js/firebase-config.js" type="module"></script>
   <script src="js/firebase-auth.js?v=20260207-2" type="module"></script>
   <!-- Load navigation system -->

--- a/privacy.html
+++ b/privacy.html
@@ -281,6 +281,7 @@
   </footer>
 
   <!-- Load Firebase auth (ensures logged-in nav renders) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1297,6 +1297,7 @@
         window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
         window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
         console.log('[RESUME-FEEDBACK] enforceAccess: fallback granted access, flag set');
+        deferredPlanReVerify();
       }
     }
 

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1413,7 +1413,7 @@
 
     // --- PLAN-BASED ACCESS CONTROL ---
     function checkPlanAccess() {
-      const currentPlan = window.JobHackAINavigation ? window.JobHackAINavigation.getEffectivePlan() : 'free';
+      const currentPlan = getCurrentUserPlan();
       const lockedDiv = document.getElementById('rfp-locked');
       const formDiv = document.getElementById('rfp-form');
       const resultsDiv = document.getElementById('rfp-results');
@@ -1648,17 +1648,31 @@
     }
 
     // --- UPDATED USER PLAN LOGIC ---
+    const RF_ALLOWED_PLANS = ['trial', 'essential', 'pro', 'premium'];
+
+    function getVerifiedCachedPlan() {
+      const cachedPlan = localStorage.getItem('user-plan');
+      return window.__JOBHACKAI_ACCESS_VERIFIED__ && RF_ALLOWED_PLANS.includes(cachedPlan)
+        ? cachedPlan
+        : null;
+    }
+
     function getCurrentUserPlan() {
-      // Use navigation system's plan detection for consistency
+      const verifiedCachedPlan = getVerifiedCachedPlan();
+
+      // During early hydration on dev, navigation can briefly report visitor/free
+      // before auth/plan reconciliation finishes even though the head guard already
+      // verified a paid plan from cache. Prefer the verified cached plan in that window.
       let plan = 'free';
       if (window.JobHackAINavigation && typeof window.JobHackAINavigation.getEffectivePlan === 'function') {
         plan = window.JobHackAINavigation.getEffectivePlan();
-        // If navigation returns undefined or invalid, fall back to localStorage
-        if (!plan || plan === 'undefined') {
-          plan = localStorage.getItem('user-plan') || 'free';
+        if (verifiedCachedPlan && (!plan || plan === 'undefined' || plan === 'visitor' || plan === 'free')) {
+          plan = verifiedCachedPlan;
+        } else if (!plan || plan === 'undefined') {
+          plan = localStorage.getItem('user-plan') || verifiedCachedPlan || 'free';
         }
       } else {
-        plan = localStorage.getItem('user-plan') || 'free';
+        plan = verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';
       }
       
       // FIX: Validate plan value to prevent corrupted data (e.g., "central")
@@ -2815,8 +2829,8 @@
       const allowedPlans = ['pro', 'premium'];
       let currentPlan = null;
       try {
-        if (window.JobHackAINavigation && typeof window.JobHackAINavigation.getEffectivePlan === 'function') {
-          currentPlan = window.JobHackAINavigation.getEffectivePlan();
+        if (typeof getCurrentUserPlan === 'function') {
+          currentPlan = getCurrentUserPlan();
         } else if (typeof getCurrentPlanStandalone === 'function') {
           currentPlan = getCurrentPlanStandalone();
         }

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1236,7 +1236,7 @@
             console.log('[RESUME-FEEDBACK] Deferred re-verify: updating verified plan to', apiPlan);
             window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
             updateRfTileForPlan();
-            document.dispatchEvent(new CustomEvent('planChanged', { detail: { plan: apiPlan } }));
+            window.dispatchEvent(new CustomEvent('planChanged', { detail: { plan: apiPlan } }));
           }
         } catch (e) {
           console.warn('[RESUME-FEEDBACK] Deferred re-verify error:', e);

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1296,6 +1296,8 @@
       } else {
         window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
         window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
+        document.documentElement.classList.remove('auth-pending');
+        document.documentElement.classList.remove('plan-pending');
         console.log('[RESUME-FEEDBACK] enforceAccess: fallback granted access, flag set');
         deferredPlanReVerify();
       }

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -87,6 +87,7 @@
             document.documentElement.classList.remove('auth-pending');
             document.documentElement.classList.remove('plan-pending');
             window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+            window.__JOBHACKAI_VERIFIED_PLAN__ = cachedPlan;
             done = true;
             return;
           }
@@ -125,6 +126,7 @@
           document.documentElement.classList.remove('auth-pending');
           document.documentElement.classList.remove('plan-pending');
           window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+          window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
           done = true;
         } finally {
           inFlight = false;
@@ -142,6 +144,7 @@
           document.documentElement.classList.remove('auth-pending');
           document.documentElement.classList.remove('plan-pending');
           window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+          window.__JOBHACKAI_VERIFIED_PLAN__ = cachedPlan;
           done = true;
           try { clearTimeout(timeoutHandle); } catch (_) {}
         } else {
@@ -1261,6 +1264,7 @@
         }
       } else {
         window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+        window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
         console.log('[RESUME-FEEDBACK] enforceAccess: fallback granted access, flag set');
       }
     }
@@ -1640,6 +1644,7 @@
         // Access granted - clear plan pending flag and class
         // This allows tests to detect when plan hydration is complete
         window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+        window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
         window.__JOBHACKAI_PLAN_PENDING__ = false;
         document.documentElement.classList.remove('plan-pending');
         // Ensure UI is updated
@@ -1651,6 +1656,10 @@
     const RF_ALLOWED_PLANS = ['trial', 'essential', 'pro', 'premium'];
 
     function getVerifiedCachedPlan() {
+      const verifiedPlan = window.__JOBHACKAI_VERIFIED_PLAN__;
+      if (window.__JOBHACKAI_ACCESS_VERIFIED__ && RF_ALLOWED_PLANS.includes(verifiedPlan)) {
+        return verifiedPlan;
+      }
       const cachedPlan = localStorage.getItem('user-plan');
       return window.__JOBHACKAI_ACCESS_VERIFIED__ && RF_ALLOWED_PLANS.includes(cachedPlan)
         ? cachedPlan

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1681,6 +1681,7 @@
         document.documentElement.classList.remove('plan-pending');
         // Ensure UI is updated
         updateRfTileForPlan();
+        deferredPlanReVerify();
       }
     }
 

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -137,7 +137,7 @@
       } else {
         // Fast path: if BOTH auth signals present and cached plan is allowed, show immediately
         // SECURITY: Require BOTH signals (matches static-auth-guard.js AND logic)
-        if (isAuthenticated && cachedPlan && allowedPlans.includes(cachedPlan)) {
+        if (cachedPlan && allowedPlans.includes(cachedPlan)) {
           window.__JOBHACKAI_PLAN_PENDING__ = false;
           document.documentElement.classList.remove('auth-pending');
           document.documentElement.classList.remove('plan-pending');

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -9216,31 +9216,27 @@
      * Initialize history on page load
      */
     function initializeHistory() {
+      // Determine authentication: trust the access-verified flag, else check localStorage
+      var isAuthenticated = false;
       if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
-        loadHistoryList();
-        return;
+        isAuthenticated = true;
+      } else {
+        // SECURITY: Check Firebase SDK keys synchronously (works before FirebaseAuthManager is ready)
+        // Use same pattern as checkAuthentication() for consistency
+        var hasLocalStorageAuth = localStorage.getItem('user-authenticated') === 'true';
+        var hasFirebaseKeys = false;
+        try {
+          hasFirebaseKeys = Object.keys(localStorage).some(function(k) {
+            return k.startsWith('firebase:authUser:') &&
+              localStorage.getItem(k) &&
+              localStorage.getItem(k) !== 'null' &&
+              localStorage.getItem(k).length > 10;
+          });
+        } catch (e) { /* ignore */ }
+        // SECURITY: Require BOTH signals (same as checkAuthentication localStorage path)
+        isAuthenticated = hasLocalStorageAuth && hasFirebaseKeys;
       }
 
-      // Only load history if user is authenticated
-      // SECURITY: Check Firebase SDK keys synchronously (works before FirebaseAuthManager is ready)
-      // FirebaseAuthManager.getCurrentUser() returns null until onAuthStateChanged fires
-      // Use same pattern as checkAuthentication() for consistency
-      function hasFirebaseAuthKeys() {
-        try {
-          return Object.keys(localStorage).some(k => 
-            k.startsWith('firebase:authUser:') && 
-            localStorage.getItem(k) && 
-            localStorage.getItem(k) !== 'null' &&
-            localStorage.getItem(k).length > 10
-          );
-        } catch (e) {
-          return false;
-        }
-      }
-      const hasLocalStorageAuth = localStorage.getItem('user-authenticated') === 'true';
-      const hasFirebaseKeys = hasFirebaseAuthKeys();
-      // SECURITY: Require BOTH signals (same as checkAuthentication localStorage path)
-      const isAuthenticated = hasLocalStorageAuth && hasFirebaseKeys;
       if (!isAuthenticated) {
         console.log('[RESUME-FEEDBACK-HISTORY] Skipping history load - not authenticated');
         const emptyEl = document.getElementById('rf-history-empty');
@@ -9249,7 +9245,7 @@
         if (emptyEl) emptyEl.hidden = false;
         return;
       }
-      
+
       // Load history from server
       fetchResumeFeedbackHistory();
       

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1186,6 +1186,7 @@
   <script src="js/mobile-menu.js?v=20250115-1"></script>
   
   <!-- Load Firebase auth as ES module (same pattern as dashboard.html) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   
   <!-- DEV-ONLY PLAN TOGGLE will be added by navigation.js -->

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1226,11 +1226,11 @@
     };
 
     function deferredPlanReVerify() {
-      window.PageAccessControl.deferredPlanReVerify(_rfAccessOpts);
+      if (window.PageAccessControl) window.PageAccessControl.deferredPlanReVerify(_rfAccessOpts);
     }
 
     async function enforceAccess() {
-      await window.PageAccessControl.enforceAccess(_rfAccessOpts);
+      if (window.PageAccessControl) await window.PageAccessControl.enforceAccess(_rfAccessOpts);
     }
 
     // Wait for DOM to be ready before enforcing access again
@@ -1623,7 +1623,8 @@
     const RF_ALLOWED_PLANS = window.PageAccessControl ? window.PageAccessControl.PAID_PLANS : ['trial', 'essential', 'pro', 'premium'];
 
     function getCurrentUserPlan() {
-      return window.PageAccessControl.getCurrentUserPlan(RF_ALLOWED_PLANS, '[RESUME-FEEDBACK]');
+      if (window.PageAccessControl) return window.PageAccessControl.getCurrentUserPlan(RF_ALLOWED_PLANS, '[RESUME-FEEDBACK]');
+      return localStorage.getItem('user-plan') || 'free';
     }
 
     // --- UPDATED USER OBJECT ---

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1639,6 +1639,7 @@
       } else {
         // Access granted - clear plan pending flag and class
         // This allows tests to detect when plan hydration is complete
+        window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
         window.__JOBHACKAI_PLAN_PENDING__ = false;
         document.documentElement.classList.remove('plan-pending');
         // Ensure UI is updated

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1213,11 +1213,38 @@
     }
   </script>
   <script>
+    // --- DEFERRED RE-VERIFICATION ---
+    // When the head guard granted access via the sync fast path (localStorage only),
+    // schedule an async API check to catch stale/expired plans.
+    function deferredPlanReVerify() {
+      setTimeout(async function() {
+        try {
+          if (!window.JobHackAINavigation) return;
+          if (typeof window.JobHackAINavigation.fetchPlanFromAPI !== 'function') return;
+          var apiPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
+          if (!apiPlan) return;
+          var allowedPlans = ['trial', 'essential', 'pro', 'premium'];
+          if (!allowedPlans.includes(apiPlan)) {
+            console.warn('[RESUME-FEEDBACK] Deferred re-verify: plan is now', apiPlan, '— revoking access');
+            window.__JOBHACKAI_ACCESS_VERIFIED__ = false;
+            window.__JOBHACKAI_VERIFIED_PLAN__ = null;
+            window.location.href = 'pricing-a.html?plan=essential';
+          } else if (apiPlan !== window.__JOBHACKAI_VERIFIED_PLAN__) {
+            console.log('[RESUME-FEEDBACK] Deferred re-verify: updating verified plan to', apiPlan);
+            window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
+          }
+        } catch (e) {
+          console.warn('[RESUME-FEEDBACK] Deferred re-verify error:', e);
+        }
+      }, 2000);
+    }
+
     // --- PAGE ACCESS CONTROL (Second check after navigation system) ---
     // Skip if the head guard already verified access (prevents race condition redirects)
     async function enforceAccess() {
       if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
-        console.log('[RESUME-FEEDBACK] enforceAccess: skipping, head guard already verified access');
+        console.log('[RESUME-FEEDBACK] enforceAccess: head guard set flag, scheduling deferred re-verification');
+        deferredPlanReVerify();
         return;
       }
 
@@ -1675,10 +1702,11 @@
       let plan = 'free';
       if (window.JobHackAINavigation && typeof window.JobHackAINavigation.getEffectivePlan === 'function') {
         plan = window.JobHackAINavigation.getEffectivePlan();
-        if (verifiedCachedPlan && (!plan || plan === 'undefined' || plan === 'visitor' || plan === 'free')) {
-          plan = verifiedCachedPlan;
-        } else if (!plan || plan === 'undefined') {
-          plan = localStorage.getItem('user-plan') || verifiedCachedPlan || 'free';
+        // Only use verifiedCachedPlan when navigation hasn't hydrated yet
+        // (undefined/visitor). Once navigation reports a real plan (including 'free'),
+        // trust it — it reflects the authoritative state (e.g. expired trial).
+        if (!plan || plan === 'undefined' || plan === 'visitor') {
+          plan = verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';
         }
       } else {
         plan = verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1621,10 +1621,6 @@
     // --- USER PLAN LOGIC (delegated to shared page-access-control.js) ---
     const RF_ALLOWED_PLANS = window.PageAccessControl.PAID_PLANS;
 
-    function getVerifiedCachedPlan() {
-      return window.PageAccessControl.getVerifiedCachedPlan(RF_ALLOWED_PLANS);
-    }
-
     function getCurrentUserPlan() {
       return window.PageAccessControl.getCurrentUserPlan(RF_ALLOWED_PLANS, '[RESUME-FEEDBACK]');
     }

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1235,6 +1235,8 @@
           } else if (apiPlan !== window.__JOBHACKAI_VERIFIED_PLAN__) {
             console.log('[RESUME-FEEDBACK] Deferred re-verify: updating verified plan to', apiPlan);
             window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
+            updateRfTileForPlan();
+            document.dispatchEvent(new CustomEvent('planChanged', { detail: { plan: apiPlan } }));
           }
         } catch (e) {
           console.warn('[RESUME-FEEDBACK] Deferred re-verify error:', e);

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1220,7 +1220,7 @@
     // --- DEFERRED RE-VERIFICATION & PAGE ACCESS CONTROL ---
     // Delegated to shared page-access-control.js
     var _rfAccessOpts = {
-      allowedPlans: window.PageAccessControl.PAID_PLANS,
+      allowedPlans: window.PageAccessControl ? window.PageAccessControl.PAID_PLANS : ['trial', 'essential', 'pro', 'premium'],
       logPrefix: '[RESUME-FEEDBACK]',
       onPlanChanged: function () { updateRfTileForPlan(); }
     };
@@ -1620,7 +1620,7 @@
     }
 
     // --- USER PLAN LOGIC (delegated to shared page-access-control.js) ---
-    const RF_ALLOWED_PLANS = window.PageAccessControl.PAID_PLANS;
+    const RF_ALLOWED_PLANS = window.PageAccessControl ? window.PageAccessControl.PAID_PLANS : ['trial', 'essential', 'pro', 'premium'];
 
     function getCurrentUserPlan() {
       return window.PageAccessControl.getCurrentUserPlan(RF_ALLOWED_PLANS, '[RESUME-FEEDBACK]');

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1259,6 +1259,9 @@
         } else {
           window.location.href = 'pricing-a.html?plan=essential';
         }
+      } else {
+        window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
+        console.log('[RESUME-FEEDBACK] enforceAccess: fallback granted access, flag set');
       }
     }
 

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1577,6 +1577,7 @@
       // Skip if head guard already verified access (prevents race-condition redirects)
       if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
         console.log('[RESUME-FEEDBACK] enforceAccessControl: skipping, head guard already verified access');
+        deferredPlanReVerify();
         return;
       }
 
@@ -1593,6 +1594,7 @@
           // Re-check after async wait — head guard may have verified during the wait
           if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
             console.log('[RESUME-FEEDBACK] enforceAccessControl: head guard verified during auth wait');
+            deferredPlanReVerify();
             return;
           }
 

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1219,7 +1219,7 @@
     // --- DEFERRED RE-VERIFICATION & PAGE ACCESS CONTROL ---
     // Delegated to shared page-access-control.js
     var _rfAccessOpts = {
-      allowedPlans: ['trial', 'essential', 'pro', 'premium'],
+      allowedPlans: window.PageAccessControl.PAID_PLANS,
       logPrefix: '[RESUME-FEEDBACK]',
       onPlanChanged: function () { updateRfTileForPlan(); }
     };

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -6,6 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <style>html.auth-pending,html.plan-pending{visibility:hidden}</style>
   <script src="js/static-auth-guard.js?v=20260125-1"></script>
+  <script src="js/page-access-control.js?v=20260331-1"></script>
   <script>
     // --- IMMEDIATE PAGE ACCESS CONTROL ---
     // Run immediately to prevent content flash for unauthorized users
@@ -38,19 +39,21 @@
         if (!done) handleAuthReadyOrTimeout();
       }, 5000);
 
-      // Helper: wait for an object to appear on window
-      function waitForGlobal(name, timeout) {
-        if (window[name]) return Promise.resolve(true);
-        var deadline = Date.now() + timeout;
-        return new Promise(function (resolve) {
-          var interval = setInterval(function () {
-            if (window[name] || Date.now() >= deadline) {
-              clearInterval(interval);
-              resolve(!!window[name]);
-            }
-          }, 50);
-        });
-      }
+      // Helper: delegate to shared module
+      var waitForGlobal = window.PageAccessControl
+        ? window.PageAccessControl.waitForGlobal
+        : function(name, timeout) {
+            if (window[name]) return Promise.resolve(true);
+            var deadline = Date.now() + timeout;
+            return new Promise(function (resolve) {
+              var interval = setInterval(function () {
+                if (window[name] || Date.now() >= deadline) {
+                  clearInterval(interval);
+                  resolve(!!window[name]);
+                }
+              }, 50);
+            });
+          };
 
       async function handleAuthReadyOrTimeout() {
         if (done || inFlight) return;
@@ -1213,96 +1216,20 @@
     }
   </script>
   <script>
-    // --- DEFERRED RE-VERIFICATION ---
-    // When the head guard granted access via the sync fast path (localStorage only),
-    // schedule an async API check to catch stale/expired plans.
-    var _deferredReVerifyScheduled = false;
+    // --- DEFERRED RE-VERIFICATION & PAGE ACCESS CONTROL ---
+    // Delegated to shared page-access-control.js
+    var _rfAccessOpts = {
+      allowedPlans: ['trial', 'essential', 'pro', 'premium'],
+      logPrefix: '[RESUME-FEEDBACK]',
+      onPlanChanged: function () { updateRfTileForPlan(); }
+    };
+
     function deferredPlanReVerify() {
-      if (_deferredReVerifyScheduled) return;
-      _deferredReVerifyScheduled = true;
-      setTimeout(async function() {
-        try {
-          if (!window.JobHackAINavigation) return;
-          if (typeof window.JobHackAINavigation.fetchPlanFromAPI !== 'function') return;
-          var apiPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-          if (!apiPlan) return;
-          var allowedPlans = ['trial', 'essential', 'pro', 'premium'];
-          if (!allowedPlans.includes(apiPlan)) {
-            console.warn('[RESUME-FEEDBACK] Deferred re-verify: plan is now', apiPlan, '— revoking access');
-            window.__JOBHACKAI_ACCESS_VERIFIED__ = false;
-            window.__JOBHACKAI_VERIFIED_PLAN__ = null;
-            window.location.href = 'pricing-a.html?plan=essential';
-          } else if (apiPlan !== window.__JOBHACKAI_VERIFIED_PLAN__) {
-            console.log('[RESUME-FEEDBACK] Deferred re-verify: updating verified plan to', apiPlan);
-            window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
-            updateRfTileForPlan();
-            window.dispatchEvent(new CustomEvent('planChanged', { detail: { plan: apiPlan } }));
-          }
-        } catch (e) {
-          console.warn('[RESUME-FEEDBACK] Deferred re-verify error:', e);
-        }
-      }, 2000);
+      window.PageAccessControl.deferredPlanReVerify(_rfAccessOpts);
     }
 
-    // --- PAGE ACCESS CONTROL (Second check after navigation system) ---
-    // Skip if the head guard already verified access (prevents race condition redirects)
     async function enforceAccess() {
-      if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
-        console.log('[RESUME-FEEDBACK] enforceAccess: head guard set flag, scheduling deferred re-verification');
-        deferredPlanReVerify();
-        return;
-      }
-
-      // Wait for head guard async path to complete before checking independently.
-      // Head guard awaits FirebaseAuthManager (3s) + waitForAuthReady (5s) + API fetch,
-      // so allow up to 10s for it to set __JOBHACKAI_ACCESS_VERIFIED__.
-      var waited = 0;
-      while (!window.__JOBHACKAI_ACCESS_VERIFIED__ && waited < 10000) {
-        await new Promise(function(r) { setTimeout(r, 200); });
-        waited += 200;
-      }
-      if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
-        console.log('[RESUME-FEEDBACK] enforceAccess: head guard verified after', waited, 'ms');
-        deferredPlanReVerify();
-        return;
-      }
-
-      // Head guard timed out or denied — do independent fallback check
-      var isAuthenticated, plan;
-
-      if (window.JobHackAINavigation) {
-        var authState = window.JobHackAINavigation.getAuthState();
-        isAuthenticated = authState && authState.isAuthenticated;
-        plan = window.JobHackAINavigation.getEffectivePlan();
-      } else {
-        var hasLocalStorageAuth = localStorage.getItem('user-authenticated') === 'true';
-        var hasFirebaseKeys = Object.keys(localStorage).some(function (k) {
-          return k.startsWith('firebase:authUser:') &&
-            localStorage.getItem(k) &&
-            localStorage.getItem(k) !== 'null' &&
-            localStorage.getItem(k).length > 10;
-        });
-        // SECURITY: Require BOTH signals (matches head fast path + static-auth-guard.js)
-        isAuthenticated = hasLocalStorageAuth && hasFirebaseKeys;
-        plan = localStorage.getItem('user-plan') || 'free';
-      }
-
-      var allowedPlans = ['trial', 'essential', 'pro', 'premium'];
-
-      if (!isAuthenticated || !allowedPlans.includes(plan)) {
-        if (!isAuthenticated) {
-          window.location.href = 'login.html';
-        } else {
-          window.location.href = 'pricing-a.html?plan=essential';
-        }
-      } else {
-        window.__JOBHACKAI_ACCESS_VERIFIED__ = true;
-        window.__JOBHACKAI_VERIFIED_PLAN__ = plan;
-        document.documentElement.classList.remove('auth-pending');
-        document.documentElement.classList.remove('plan-pending');
-        console.log('[RESUME-FEEDBACK] enforceAccess: fallback granted access, flag set');
-        deferredPlanReVerify();
-      }
+      await window.PageAccessControl.enforceAccess(_rfAccessOpts);
     }
 
     // Wait for DOM to be ready before enforcing access again
@@ -1691,61 +1618,15 @@
       }
     }
 
-    // --- UPDATED USER PLAN LOGIC ---
-    const RF_ALLOWED_PLANS = ['trial', 'essential', 'pro', 'premium'];
+    // --- USER PLAN LOGIC (delegated to shared page-access-control.js) ---
+    const RF_ALLOWED_PLANS = window.PageAccessControl.PAID_PLANS;
 
     function getVerifiedCachedPlan() {
-      const verifiedPlan = window.__JOBHACKAI_VERIFIED_PLAN__;
-      if (window.__JOBHACKAI_ACCESS_VERIFIED__ && RF_ALLOWED_PLANS.includes(verifiedPlan)) {
-        return verifiedPlan;
-      }
-      const cachedPlan = localStorage.getItem('user-plan');
-      return window.__JOBHACKAI_ACCESS_VERIFIED__ && RF_ALLOWED_PLANS.includes(cachedPlan)
-        ? cachedPlan
-        : null;
+      return window.PageAccessControl.getVerifiedCachedPlan(RF_ALLOWED_PLANS);
     }
 
     function getCurrentUserPlan() {
-      const verifiedCachedPlan = getVerifiedCachedPlan();
-
-      // During early hydration on dev, navigation can briefly report visitor/free
-      // before auth/plan reconciliation finishes even though the head guard already
-      // verified a paid plan from cache. Prefer the verified cached plan in that window.
-      let plan = 'free';
-      if (window.JobHackAINavigation && typeof window.JobHackAINavigation.getEffectivePlan === 'function') {
-        plan = window.JobHackAINavigation.getEffectivePlan();
-        // Only use verifiedCachedPlan when navigation hasn't hydrated yet
-        // (undefined/visitor). Once navigation reports a real plan (including 'free'),
-        // trust it — it reflects the authoritative state (e.g. expired trial).
-        if (!plan || plan === 'undefined' || plan === 'visitor') {
-          plan = verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';
-        }
-      } else {
-        plan = verifiedCachedPlan || localStorage.getItem('user-plan') || 'free';
-      }
-      
-      // FIX: Validate plan value to prevent corrupted data (e.g., "central")
-      const validPlans = ['visitor', 'free', 'trial', 'essential', 'pro', 'premium'];
-      if (!validPlans.includes(plan)) {
-        const oldPlan = plan; // Capture original invalid plan before reassignment
-        console.warn('[RESUME-FEEDBACK] Invalid plan detected:', plan, '- resetting to free');
-        plan = 'free';
-        // Clean up corrupted plan values
-        localStorage.setItem('user-plan', 'free');
-        const devPlan = localStorage.getItem('dev-plan');
-        if (devPlan && !validPlans.includes(devPlan)) {
-          localStorage.setItem('dev-plan', 'free');
-        }
-        // Log for debugging
-        console.log('[RESUME-FEEDBACK] Plan cleanup completed:', {
-          oldPlan: oldPlan,
-          newPlan: 'free',
-          localStoragePlan: localStorage.getItem('user-plan'),
-          devPlan: localStorage.getItem('dev-plan')
-        });
-      }
-      
-      return plan;
+      return window.PageAccessControl.getCurrentUserPlan(RF_ALLOWED_PLANS, '[RESUME-FEEDBACK]');
     }
 
     // --- UPDATED USER OBJECT ---

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1536,6 +1536,12 @@
     }
     
     async function enforceAccessControl(allowedPlans) {
+      // Skip if head guard already verified access (prevents race-condition redirects)
+      if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
+        console.log('[RESUME-FEEDBACK] enforceAccessControl: skipping, head guard already verified access');
+        return;
+      }
+
       // TRI-STATE FIX: Wait for Firebase auth to be ready before redirecting
       // This prevents race conditions where Firebase is still initializing
       let isAuthenticated, plan;
@@ -1545,7 +1551,13 @@
         try {
           console.log('[RESUME-FEEDBACK] Waiting for Firebase auth to be ready before access control check...');
           const user = await window.FirebaseAuthManager.waitForAuthReady(8000);
-          
+
+          // Re-check after async wait — head guard may have verified during the wait
+          if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
+            console.log('[RESUME-FEEDBACK] enforceAccessControl: head guard verified during auth wait');
+            return;
+          }
+
           // Prefer Firebase user result over navigation state (navigation may not have synced yet)
           if (window.JobHackAINavigation) {
             const authState = window.JobHackAINavigation.getAuthState();

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -9188,6 +9188,11 @@
      * Initialize history on page load
      */
     function initializeHistory() {
+      if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
+        loadHistoryList();
+        return;
+      }
+
       // Only load history if user is authenticated
       // SECURITY: Check Firebase SDK keys synchronously (works before FirebaseAuthManager is ready)
       // FirebaseAuthManager.getCurrentUser() returns null until onAuthStateChanged fires

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1216,7 +1216,10 @@
     // --- DEFERRED RE-VERIFICATION ---
     // When the head guard granted access via the sync fast path (localStorage only),
     // schedule an async API check to catch stale/expired plans.
+    var _deferredReVerifyScheduled = false;
     function deferredPlanReVerify() {
+      if (_deferredReVerifyScheduled) return;
+      _deferredReVerifyScheduled = true;
       setTimeout(async function() {
         try {
           if (!window.JobHackAINavigation) return;
@@ -1258,6 +1261,7 @@
       }
       if (window.__JOBHACKAI_ACCESS_VERIFIED__) {
         console.log('[RESUME-FEEDBACK] enforceAccess: head guard verified after', waited, 'ms');
+        deferredPlanReVerify();
         return;
       }
 

--- a/terms.html
+++ b/terms.html
@@ -610,6 +610,7 @@
   </footer>
 
   <!-- Load Firebase auth (ensures logged-in nav renders) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>


### PR DESCRIPTION
## Release: develop → main

This PR promotes `develop` into `main` for the next production release. It bundles compliance, auth/plan gating hardening, feedback reliability/security fixes, and lifecycle/account flows that were validated on `develop`.

## What this release solves

- **Auth/plan race conditions on protected pages** (`interview-questions`, `resume-feedback-pro`):
  - Adds durable access verification via `__JOBHACKAI_ACCESS_VERIFIED__` + `__JOBHACKAI_VERIFIED_PLAN__`.
  - Prevents stale local cache from overriding authoritative nav/API plan state.
  - Adds deferred API re-verification to catch stale/expired plans after initial fast-path access.
- **UI consistency during plan hydration**:
  - Clears pending classes on successful fallback access paths.
  - Refreshes plan-dependent UI when deferred re-verification returns a newer plan.
- **Security hardening**:
  - Removes unauthenticated feedback diagnostics exposure.
  - Avoids leaking internal error details in API responses.
  - Maintains strict auth signal checks in localStorage fallback paths.
- **Feedback and reliability**:
  - Stabilizes feedback behavior in Cloudflare/Workers error paths.
  - Keeps status handling predictable for clients.
- **Testability and regression prevention**:
  - E2E helpers now set verified-plan state consistently.
  - Coverage tracks auth/plan hydration and protected-page behavior more accurately.

## Key files/areas

- `interview-questions.html`
- `resume-feedback-pro.html`
- `app/tests/e2e/full-app-check.spec.js`
- feedback/api/auth supporting paths merged into `develop`

## Risk / impact

- **Medium**: touches access control, plan gating, and redirect behavior on paid pages.
- Main mitigation: guard deduping, deferred re-verify, and develop-branch validation before release.

## Post-merge verification checklist

- [ ] Protected pages load correctly for paid users without false redirects.
- [ ] Downgraded/expired plan users are redirected correctly after deferred verification.
- [ ] Resume feedback and interview question UI state matches resolved plan.
- [ ] Feedback submission works and returns expected API error shape on failures.
- [ ] E2E suite for auth/plan-gated flows passes in target environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth/plan gating and redirect behavior on paid pages, so regressions could lock out valid subscribers or leak gated content if the new fast-path/deferred verification logic misbehaves. Scope is broad across many pages and both app/marketing bundles, but changes are mostly refactors toward shared, deduplicated plan retrieval.
> 
> **Overview**
> **Centralizes subscription plan retrieval** by introducing `js/plan-cache.js` (and marketing equivalent) to deduplicate `/api/plan/me` requests, persist `user-plan`/`trial-ends-at`, and provide invalidation/seed APIs.
> 
> **Refactors auth + plan consumers** (`firebase-auth.js`, `navigation.js`, `dashboard.tsx`, and several dashboard.html call sites) to read plan/trial data from `PlanCache` (with localStorage fallback) instead of issuing direct `/api/plan/me` fetches, and simplifies plan reconciliation retry loops.
> 
> **Hardens paid-page access control** by adding shared `js/page-access-control.js` and updating `interview-questions.html`, `mock-interview.html`, and `resume-feedback-pro.html` to use a consistent head guard with `auth-pending`/`plan-pending` gating, stricter localStorage auth checks (requires both auth flag + Firebase SDK keys), an `__JOBHACKAI_ACCESS_VERIFIED__` short-circuit to avoid DOM/redirect races, and deferred API re-verification to revoke/refresh access after initial fast-path.
> 
> **Updates test harness** to set the new verified-access globals and wait for pending classes to clear, reducing E2E flakiness around auth/plan hydration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6fbd82e83ceffb384e45d26cd36c402b51ff0d4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->