### PR TITLE
Merge pull request #760 from dlarosa92/claude/fix-access-verification-SBZVu

### DIFF
--- a/js/page-access-control.js
+++ b/js/page-access-control.js
@@ -115,11 +115,6 @@ window.PageAccessControl = (function () {
     }, 2000);
   }
 
-  // Allow re-scheduling after a page-level plan change (e.g. upgrade)
-  function resetDeferredReVerify() {
-    _deferredReVerifyScheduled = false;
-  }
-
   // ---- page access enforcement ----
 
   // opts.allowedPlans  – array of plan slugs that grant access (default PAID_PLANS)
@@ -194,7 +189,6 @@ window.PageAccessControl = (function () {
     getVerifiedCachedPlan: getVerifiedCachedPlan,
     getCurrentUserPlan: getCurrentUserPlan,
     deferredPlanReVerify: deferredPlanReVerify,
-    resetDeferredReVerify: resetDeferredReVerify,
     enforceAccess: enforceAccess
   };
 })();


### PR DESCRIPTION
Fix missing access-verified recheck after Firebase auth wait in inter…

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication/entitlement gating and redirect behavior on paid pages; mistakes could incorrectly grant/deny access or cause redirect loops, though the change is mostly a consolidation of existing logic.
> 
> **Overview**
> Adds a shared `js/page-access-control.js` module to centralize page-level auth + plan gating, including a *deferred plan re-verification* that rechecks the authoritative plan via API after a localStorage fast-path grant.
> 
> Updates `interview-questions.html` and `resume-feedback-pro.html` to load the new module, set `window.__JOBHACKAI_VERIFIED_PLAN__` whenever access is granted, and replace duplicated `waitForGlobal`, plan resolution, and secondary `enforceAccess` logic with `PageAccessControl` helpers (also removing the upgrade banner on `interview-questions.html` because the guard redirects instead).
> 
> Adjusts Resume Feedback’s access control flow to re-check `__JOBHACKAI_ACCESS_VERIFIED__` after awaiting Firebase auth readiness, and updates E2E setup (`full-app-check.spec.js`) to seed `__JOBHACKAI_VERIFIED_PLAN__` for deterministic tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e55db3a1461502398dd7fe2c9f535e6b0b4356f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->