### PR TITLE
Merge pull request #760 from dlarosa92/claude/fix-access-verification-SBZVu

### DIFF
--- a/interview-questions.html
+++ b/interview-questions.html
@@ -1935,10 +1935,6 @@
     // --- USER PLAN LOGIC (delegated to shared page-access-control.js) ---
     const IQ_ALLOWED_PLANS = window.PageAccessControl.PAID_PLANS;
 
-    function getVerifiedCachedPlan() {
-      return window.PageAccessControl.getVerifiedCachedPlan(IQ_ALLOWED_PLANS);
-    }
-
     function getUserPlan() {
       return window.PageAccessControl.getCurrentUserPlan(IQ_ALLOWED_PLANS, '[INTERVIEW-Q]');
     }

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1621,10 +1621,6 @@
     // --- USER PLAN LOGIC (delegated to shared page-access-control.js) ---
     const RF_ALLOWED_PLANS = window.PageAccessControl.PAID_PLANS;
 
-    function getVerifiedCachedPlan() {
-      return window.PageAccessControl.getVerifiedCachedPlan(RF_ALLOWED_PLANS);
-    }
-
     function getCurrentUserPlan() {
       return window.PageAccessControl.getCurrentUserPlan(RF_ALLOWED_PLANS, '[RESUME-FEEDBACK]');
     }


### PR DESCRIPTION
Fix missing access-verified recheck after Firebase auth wait in inter…

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches page-level auth/plan gating and redirect behavior on paid features, so regressions could lock users out or expose content briefly if the new shared guard misbehaves. Scope is limited to a couple of protected pages plus test harness updates.
> 
> **Overview**
> Adds `js/page-access-control.js` to centralize page-level auth/plan enforcement, current-plan resolution (with plan-value validation), and a **deferred API re-verification** step to catch stale localStorage fast-path grants.
> 
> Updates `interview-questions.html` and `resume-feedback-pro.html` to use the shared module (including shared `waitForGlobal`), set `window.__JOBHACKAI_VERIFIED_PLAN__` whenever access is granted, and replace duplicated second-pass guard logic with `PageAccessControl.enforceAccess()` + re-verify hooks to refresh UI or revoke access.
> 
> Adjusts a few page behaviors around the new guard: removes an upgrade banner path that should never render post-redirect, uses the shared plan getter for entitlements (e.g., mock interview/PDF download), and makes resume-history loading trust the access-verified flag before falling back to localStorage auth signals. E2E harness now sets `__JOBHACKAI_VERIFIED_PLAN__` when forcing authenticated plans.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56927c4895c035406ae39dcf6d42496248dbbc56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->