### PR TITLE
Merge pull request #760 from dlarosa92/claude/fix-access-verification-SBZVu

### DIFF
--- a/404.html
+++ b/404.html
@@ -164,6 +164,7 @@
     })();
   </script>
   <!-- Load Firebase auth (required for navigation auth state detection) -->
+  <script src="/js/plan-cache.js"></script>
   <script type="module" src="/js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="/js/navigation.js?v=20260208-1"></script>

--- a/account-setting.html
+++ b/account-setting.html
@@ -654,6 +654,7 @@
   </script>
   
   <!-- Account Settings Functionality -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <script type="module" src="js/firestore-profiles.js"></script>
   <script>

--- a/app/src/pages/dashboard.tsx
+++ b/app/src/pages/dashboard.tsx
@@ -284,21 +284,32 @@ export default function Dashboard() {
         // SECURITY: Do NOT store user-email in localStorage - email available via Firebase auth
         try { localStorage.setItem('user-authenticated', 'true'); } catch (_) {}
 
-        // Default plan
+        // Read plan from PlanCache (populated by firebase-auth.js) or localStorage.
+        // Do NOT call /api/plan/me here — firebase-auth.js already fetched it via PlanCache.
         let plan = 'free';
         let trialEndsAt = '';
         let token = '';
         try {
           token = await u.getIdToken();
-          const r = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${token}` } });
-          if (r.ok) {
-            const data = await r.json();
-            plan = data?.plan || 'free';
-            trialEndsAt = data?.trialEndsAt || '';
-            try {
-              localStorage.setItem('user-plan', plan);
-              if (trialEndsAt) localStorage.setItem('trial-ends-at', trialEndsAt);
-            } catch (_) {}
+          // Try PlanCache first (deduplicated, already fetched by firebase-auth.js)
+          const w = window as any;
+          if (w.PlanCache) {
+            const cached = w.PlanCache.getCachedPlan();
+            if (cached && cached.plan) {
+              plan = cached.plan;
+              trialEndsAt = cached.trialEndsAt || '';
+            } else {
+              // PlanCache exists but hasn't been populated yet — fetch through it
+              const result = await w.PlanCache.getPlan(token);
+              if (result) {
+                plan = result.plan || 'free';
+                trialEndsAt = result.trialEndsAt || '';
+              }
+            }
+          } else {
+            // PlanCache not loaded (unlikely in HTML dashboard) — read localStorage
+            plan = localStorage.getItem('user-plan') || 'free';
+            trialEndsAt = localStorage.getItem('trial-ends-at') || '';
           }
         } catch (_) {}
 

--- a/cookies.html
+++ b/cookies.html
@@ -290,6 +290,7 @@
   </footer>
 
   <!-- Load Firebase auth (ensures logged-in nav renders) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/cover-letter-generator.html
+++ b/cover-letter-generator.html
@@ -285,6 +285,7 @@
   <script src="js/main.js" type="module"></script>
   <script src="js/analytics.js" type="module"></script>
   <!-- Load Firebase auth for token retrieval -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/dashboard.html
+++ b/dashboard.html
@@ -19,6 +19,7 @@
   <link rel="stylesheet" href="css/header.css">
   <link rel="stylesheet" href="css/footer.css">
   <script src="js/components/usage-indicator.js"></script>
+  <script src="js/plan-cache.js"></script>
   <script type="module">
     import authManager, { AUTH_PENDING } from './js/firebase-auth.js?v=20260207-2';
     document.documentElement.classList.add('auth-pending');

--- a/help.html
+++ b/help.html
@@ -619,6 +619,7 @@
   </footer>
 
   <!-- Load Firebase auth (ensures logged-in nav renders) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/index.html
+++ b/index.html
@@ -259,6 +259,7 @@
   </script>
 
   <!-- Load Firebase auth (required for navigation auth state detection) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/interview-questions.html
+++ b/interview-questions.html
@@ -4644,6 +4644,7 @@ function initIQPage(){
   <script src="js/stripe-integration.js"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>
   <!-- Load Firebase auth as ES module (required for API authentication) - MUST load before inactivity-tracker -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Inactivity tracker - auto-logout after 30 minutes of inactivity -->
   <script src="js/inactivity-tracker.js?v=20250115-1"></script>

--- a/js/firebase-auth.js
+++ b/js/firebase-auth.js
@@ -93,6 +93,7 @@ function clearAuthCookies() {
 }
 
 // --- DIRECT PLAN FETCH FROM D1 VIA API (navigation-independent) ---
+// Routes through PlanCache when available to deduplicate concurrent requests.
 async function fetchPlanFromAPI() {
   try {
     const user = auth.currentUser;
@@ -105,6 +106,14 @@ async function fetchPlanFromAPI() {
       console.log('🔍 fetchPlanFromAPI: no idToken');
       return null;
     }
+    // Use PlanCache to deduplicate concurrent /api/plan/me calls
+    if (window.PlanCache) {
+      const result = await window.PlanCache.getPlan(idToken);
+      const plan = result && result.plan;
+      console.log(`📊 fetchPlanFromAPI (via PlanCache): plan="${plan}"`);
+      return plan || null;
+    }
+    // Fallback: direct fetch if PlanCache not loaded yet
     console.log(`🔍 fetchPlanFromAPI: calling /api/plan/me for uid=${user.uid}`);
     const res = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
     if (!res.ok) {
@@ -115,7 +124,6 @@ async function fetchPlanFromAPI() {
     console.log(`📊 fetchPlanFromAPI: API returned plan="${data?.plan}"`);
     return data?.plan || null;
   } catch (e) {
-    // API fetch failed - this is non-critical, will fallback to 'free'
     console.log('ℹ️ Direct plan API fetch unavailable, will use fallback:', e.message || 'network error');
     return null;
   }
@@ -701,74 +709,34 @@ class AuthManager {
           actualPlan = pendingSelection === 'trial' ? 'pending' : pendingSelection;
           console.log('✅ Using fresh plan selection in auth listener:', actualPlan);
         } else {
-          // FIX: Wait for auth to be ready before fetching plan to prevent race condition
+          // Fetch plan via centralized PlanCache (deduplicates concurrent requests)
           let kvPlan = null;
           try {
-            // Wait for Firebase auth to be fully ready (max 3 seconds)
-            console.log('🔄 Waiting for Firebase auth to be ready before plan fetching...');
-            await this.waitForAuthReady(3000);
-            
-            if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-              kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-              if (kvPlan) console.log('✅ Fetched plan via navigation system:', kvPlan);
-            }
-            // Fallback: fetch directly from API if navigation not ready
-            if (!kvPlan) {
+            const idToken = await user.getIdToken();
+            if (window.PlanCache) {
+              const result = await window.PlanCache.getPlan(idToken);
+              kvPlan = result && result.plan;
+              if (kvPlan) console.log('✅ Fetched plan via PlanCache:', kvPlan);
+            } else {
               kvPlan = await fetchPlanFromAPI();
-              if (kvPlan) console.log('✅ Fetched plan directly from API (navigation not ready):', kvPlan);
+              if (kvPlan) console.log('✅ Fetched plan directly from API (PlanCache not loaded):', kvPlan);
             }
           } catch (e) {
             console.warn('Could not fetch plan from API:', e);
-            // Add retry mechanism for failed API fetches
-            try {
-              console.log('🔄 Retrying plan fetch after 1 second...');
-              await new Promise(resolve => setTimeout(resolve, 1000));
-              if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-                kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-              }
-              if (!kvPlan) {
-                kvPlan = await fetchPlanFromAPI();
-              }
-              if (kvPlan) console.log('✅ Retry successful, fetched plan:', kvPlan);
-            } catch (retryError) {
-              console.warn('Retry also failed:', retryError);
-            }
           }
-          
+
           if (kvPlan && kvPlan !== 'free') {
             actualPlan = kvPlan;
             console.log('✅ Retrieved user plan from D1 (via API):', actualPlan);
-          } else {
-            // API fetch returned null or 'free' - try Firestore as fallback (but NOT email-based lookup)
+          } else if (!kvPlan) {
+            // API fetch returned null - try Firestore as fallback (but NOT email-based lookup)
             const profileResult = await UserProfileManager.getProfile(user.uid);
             if (profileResult.success && profileResult.profile) {
               actualPlan = profileResult.profile.plan || 'free';
               console.log('✅ Retrieved user plan from Firestore (API fallback):', actualPlan);
             } else {
-              // All sources unavailable - default to 'free' (D1 is source of truth, no email-based fallback)
               actualPlan = 'free';
-              console.log('ℹ️ Using default plan (API/Firestore unavailable). D1 is source of truth - no email-based fallback.');
-              // FIX: Add delayed retry for plan reconciliation
-              console.log('🔄 Scheduling delayed plan reconciliation in 5 seconds...');
-              setTimeout(async () => {
-                try {
-                  console.log('🔄 Attempting delayed plan reconciliation...');
-                  const delayedPlan = await window.JobHackAINavigation?.fetchPlanFromAPI?.();
-                    if (delayedPlan && delayedPlan !== 'free') {
-                    console.log('✅ Delayed reconciliation successful:', delayedPlan);
-                    localStorage.setItem('user-plan', delayedPlan);
-                    localStorage.setItem('dev-plan', delayedPlan);
-                    if (window.JobHackAINavigation && typeof window.JobHackAINavigation.scheduleUpdateNavigation === 'function') {
-                      window.JobHackAINavigation.scheduleUpdateNavigation(true);
-                    } else if (window.JobHackAINavigation && typeof window.JobHackAINavigation.updateNavigation === 'function') {
-                      // fallback
-                      window.JobHackAINavigation.updateNavigation();
-                    }
-                  }
-                } catch (e) {
-                  console.warn('Delayed reconciliation failed:', e);
-                }
-              }, 5000);
+              console.log('ℹ️ Using default plan (API/Firestore unavailable). D1 is source of truth.');
             }
           }
         }
@@ -811,8 +779,15 @@ class AuthManager {
               actualPlan = selectedPlan === 'trial' ? 'pending' : selectedPlan;
               console.log('✅ Using newly selected plan for LinkedIn sign-in (same-window):', actualPlan);
             } else {
-              // Fetch plan from API using token
-              const kvPlan = await apiFetchJSON('/api/plan/me');
+              // Fetch plan from API using PlanCache (deduplicated)
+              const idToken = getIdTokenSync();
+              let kvPlan = null;
+              if (window.PlanCache && idToken) {
+                const result = await window.PlanCache.getPlan(idToken);
+                kvPlan = result && result.plan ? result : null;
+              } else {
+                kvPlan = await apiFetchJSON('/api/plan/me');
+              }
               if (kvPlan?.plan) {
                 actualPlan = kvPlan.plan;
                 console.log('✅ Fetched plan from API during LinkedIn sign-in (same-window):', actualPlan);
@@ -875,7 +850,14 @@ class AuthManager {
         } else {
           // Normal token restoration (page refresh) - just fetch plan and set state
           try {
-            const kvPlan = await apiFetchJSON('/api/plan/me');
+            const idToken = getIdTokenSync();
+            let kvPlan = null;
+            if (window.PlanCache && idToken) {
+              const result = await window.PlanCache.getPlan(idToken);
+              kvPlan = result && result.plan ? result : null;
+            } else {
+              kvPlan = await apiFetchJSON('/api/plan/me');
+            }
             const actualPlan = kvPlan?.plan || 'free';
             if (window.JobHackAINavigation) {
               window.JobHackAINavigation.setAuthState(true, actualPlan);
@@ -1018,50 +1000,33 @@ class AuthManager {
       // FIX: Wait for auth to be ready before fetching plan to prevent race condition
       let kvPlan = null;
       try {
-        // Wait for Firebase auth to be fully ready (max 3 seconds)
-        console.log('🔄 Waiting for Firebase auth to be ready during sign-in...');
-        await this.waitForAuthReady(3000);
-        
-        if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-          kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-          if (kvPlan) console.log('✅ Fetched plan via navigation system during sign-in:', kvPlan);
-        }
-        // Fallback: fetch directly from API if navigation not ready
-        if (!kvPlan) {
+        const idToken = await user.getIdToken();
+        if (window.PlanCache) {
+          // Invalidate cache on fresh sign-in so we get the latest plan
+          window.PlanCache.invalidate();
+          const result = await window.PlanCache.getPlan(idToken);
+          kvPlan = result && result.plan;
+          if (kvPlan) console.log('✅ Fetched plan via PlanCache during sign-in:', kvPlan);
+        } else {
           kvPlan = await fetchPlanFromAPI();
           if (kvPlan) console.log('✅ Fetched plan directly from API during sign-in:', kvPlan);
         }
       } catch (e) {
         console.warn('Could not fetch plan from API during sign-in:', e);
-        // Add retry mechanism for failed API fetches
-        try {
-          console.log('🔄 Retrying plan fetch during sign-in after 1 second...');
-          await new Promise(resolve => setTimeout(resolve, 1000));
-          if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-            kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-          }
-          if (!kvPlan) {
-            kvPlan = await fetchPlanFromAPI();
-          }
-          if (kvPlan) console.log('✅ Retry successful during sign-in, fetched plan:', kvPlan);
-        } catch (retryError) {
-          console.warn('Retry also failed during sign-in:', retryError);
-        }
       }
-      
+
       if (kvPlan && kvPlan !== 'free') {
         actualPlan = kvPlan;
         console.log('✅ Retrieved user plan from D1 (via API) during sign-in:', actualPlan);
-      } else {
-        // API fetch returned null or 'free' - try Firestore as fallback (but NOT email-based lookup)
+      } else if (!kvPlan) {
+        // API fetch returned null - try Firestore as fallback (but NOT email-based lookup)
         const profileResult = await UserProfileManager.getProfile(user.uid);
         if (profileResult.success && profileResult.profile) {
           actualPlan = profileResult.profile.plan || 'free';
           console.log('✅ Retrieved user plan from Firestore during sign-in (API fallback):', actualPlan);
         } else {
-          // All sources unavailable - default to 'free' (D1 is source of truth, no email-based fallback)
           actualPlan = 'free';
-          console.log('ℹ️ All plan sources failed during sign-in, defaulting to free. D1 is source of truth - no email-based fallback.');
+          console.log('ℹ️ All plan sources failed during sign-in, defaulting to free.');
         }
       }
 
@@ -1105,57 +1070,34 @@ class AuthManager {
       actualPlan = selectedPlan === 'trial' ? 'pending' : selectedPlan;
       console.log('✅ Using newly selected plan for Google sign-in:', actualPlan);
     } else {
-      // FIX: Wait for auth to be ready before fetching plan to prevent race condition
+      // Fetch plan via PlanCache (deduplicated)
       let kvPlan = null;
       try {
-        if (this._redirectProcessing) {
-          console.log('🔄 Redirect sign-in detected; skipping waitForAuthReady to avoid delay');
+        const idToken = await user.getIdToken();
+        if (window.PlanCache) {
+          window.PlanCache.invalidate(); // Fresh sign-in, get latest
+          const result = await window.PlanCache.getPlan(idToken);
+          kvPlan = result && result.plan;
+          if (kvPlan) console.log('✅ Fetched plan via PlanCache during Google sign-in:', kvPlan);
         } else {
-          // Wait for Firebase auth to be fully ready (max 3 seconds)
-          console.log('🔄 Waiting for Firebase auth to be ready during Google sign-in...');
-          await this.waitForAuthReady(3000);
-        }
-        
-        if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-          kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-          if (kvPlan) console.log('✅ Fetched plan via navigation system during Google sign-in:', kvPlan);
-        }
-        // Fallback: fetch directly from API if navigation not ready
-        if (!kvPlan) {
           kvPlan = await fetchPlanFromAPI();
           if (kvPlan) console.log('✅ Fetched plan directly from API during Google sign-in:', kvPlan);
         }
       } catch (e) {
         console.warn('Could not fetch plan from API during Google sign-in:', e);
-        // Add retry mechanism for failed API fetches
-        try {
-          console.log('🔄 Retrying plan fetch during Google sign-in after 1 second...');
-          await new Promise(resolve => setTimeout(resolve, 1000));
-          if (window.JobHackAINavigation && typeof window.JobHackAINavigation.fetchPlanFromAPI === 'function') {
-            kvPlan = await window.JobHackAINavigation.fetchPlanFromAPI();
-          }
-          if (!kvPlan) {
-            kvPlan = await fetchPlanFromAPI();
-          }
-          if (kvPlan) console.log('✅ Retry successful during Google sign-in, fetched plan:', kvPlan);
-        } catch (retryError) {
-          console.warn('Retry also failed during Google sign-in:', retryError);
-        }
       }
-      
+
       if (kvPlan && kvPlan !== 'free') {
         actualPlan = kvPlan;
         console.log('✅ Retrieved user plan from D1 (via API) during Google sign-in:', actualPlan);
-      } else {
-        // API fetch returned null or 'free' - try Firestore as fallback (but NOT email-based lookup)
+      } else if (!kvPlan) {
         const profileResult = await UserProfileManager.getProfile(user.uid);
         if (profileResult.success && profileResult.profile) {
           actualPlan = profileResult.profile.plan || 'free';
           console.log('✅ Retrieved user plan from Firestore during Google sign-in (API fallback):', actualPlan);
         } else {
-          // All sources unavailable - default to 'free' (D1 is source of truth, no email-based fallback)
           actualPlan = 'free';
-          console.log('ℹ️ All plan sources failed during Google sign-in, defaulting to free. D1 is source of truth - no email-based fallback.');
+          console.log('ℹ️ All plan sources failed during Google sign-in, defaulting to free.');
         }
       }
     }
@@ -1333,17 +1275,23 @@ class AuthManager {
               actualPlan = selectedPlan === 'trial' ? 'pending' : selectedPlan;
               console.log('✅ Using newly selected plan for LinkedIn sign-in:', actualPlan);
             } else {
-              // Fetch plan from API using token
+              // Fetch plan from API using PlanCache (deduplicated)
               let kvPlan = null;
               try {
-                kvPlan = await apiFetchJSON('/api/plan/me');
+                const idToken = getIdTokenSync();
+                if (window.PlanCache && idToken) {
+                  window.PlanCache.invalidate(); // Fresh sign-in, get latest
+                  const result = await window.PlanCache.getPlan(idToken);
+                  kvPlan = result && result.plan ? result : null;
+                } else {
+                  kvPlan = await apiFetchJSON('/api/plan/me');
+                }
                 if (kvPlan?.plan) {
                   actualPlan = kvPlan.plan;
                   console.log('✅ Fetched plan from API during LinkedIn sign-in:', actualPlan);
                 }
               } catch (e) {
                 console.warn('Could not fetch plan from API during LinkedIn sign-in:', e);
-                // Try Firestore as fallback
                 try {
                   const profileResult = await UserProfileManager.getProfile(uid);
                   if (profileResult.success && profileResult.profile) {

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -2569,88 +2569,25 @@ async function initializeNavigation() {
 //   document.body.appendChild(switcher);
 //   navLog('debug', 'Quick plan switcher appended to body');
 
-  // CRITICAL FIX: For authenticated users, fetch plan before rendering navigation
-  // This prevents race condition where navigation shows wrong plan initially
+  // For authenticated users, read plan from PlanCache or localStorage.
+  // The authoritative /api/plan/me fetch is handled by firebase-auth.js via PlanCache
+  // (which deduplicates concurrent requests). Navigation just reads the cached result.
   if (authState.isAuthenticated && window.FirebaseAuthManager?.getCurrentUser) {
-    navLog('info', 'Authenticated user detected, fetching plan before navigation render');
+    navLog('info', 'Authenticated user detected, reading plan for navigation render');
     try {
-      const user = window.FirebaseAuthManager.getCurrentUser();
-      if (user) {
-        const token = await user.getIdToken();
-        // Fetch plan from API first
-        const planRes = await fetch('/api/plan/me', {
-          headers: { Authorization: `Bearer ${token}` }
-        });
-        if (planRes.ok) {
-          const planData = await planRes.json();
-          if (planData.plan) {
-            navLog('info', 'Fetched plan from API, updating localStorage', planData.plan);
-            localStorage.setItem('user-plan', planData.plan);
-            localStorage.setItem('dev-plan', planData.plan);
-            
-            // If plan is free, double-check with billing-status as fallback
-            if (planData.plan === 'free') {
-              navLog('info', 'Plan is free, checking billing-status as fallback');
-              const billingRes = await fetch('/api/billing-status?force=1', {
-                headers: { Authorization: `Bearer ${token}` }
-              });
-              if (billingRes.ok) {
-                const billingData = await billingRes.json();
-                if (billingData.ok && billingData.plan && billingData.plan !== 'free') {
-                  navLog('info', 'Found plan from billing-status fallback, updating', billingData.plan);
-                  localStorage.setItem('user-plan', billingData.plan);
-                  localStorage.setItem('dev-plan', billingData.plan);
-                  // Sync to D1 asynchronously (via sync-stripe-plan which writes to D1)
-                  fetch('/api/sync-stripe-plan', {
-                    method: 'POST',
-                    headers: { Authorization: `Bearer ${token}` }
-                  }).catch(err => navLog('warn', 'Failed to sync plan to D1 (non-critical):', err));
-                }
-              }
-            }
-          } else {
-            // plan/me returned successfully but without plan field - use billing-status as fallback
-            navLog('info', 'plan/me response missing plan field, checking billing-status as fallback');
-            const billingRes = await fetch('/api/billing-status?force=1', {
-              headers: { Authorization: `Bearer ${token}` }
-            });
-            if (billingRes.ok) {
-              const billingData = await billingRes.json();
-              if (billingData.ok && billingData.plan) {
-                navLog('info', 'Found plan from billing-status fallback (plan/me missing plan)', billingData.plan);
-                localStorage.setItem('user-plan', billingData.plan);
-                localStorage.setItem('dev-plan', billingData.plan);
-                // Sync to KV asynchronously
-                fetch('/api/sync-stripe-plan', {
-                  method: 'POST',
-                  headers: { Authorization: `Bearer ${token}` }
-                }).catch(err => navLog('warn', 'Failed to sync plan to KV (non-critical):', err));
-              }
-            }
-          }
-        } else {
-          // plan/me failed - use billing-status as fallback
-          navLog('info', 'plan/me request failed, checking billing-status as fallback');
-          const billingRes = await fetch('/api/billing-status?force=1', {
-            headers: { Authorization: `Bearer ${token}` }
-          });
-          if (billingRes.ok) {
-            const billingData = await billingRes.json();
-            if (billingData.ok && billingData.plan) {
-              navLog('info', 'Found plan from billing-status fallback (plan/me failed)', billingData.plan);
-              localStorage.setItem('user-plan', billingData.plan);
-              localStorage.setItem('dev-plan', billingData.plan);
-              // Sync to KV asynchronously
-              fetch('/api/sync-stripe-plan', {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${token}` }
-              }).catch(err => navLog('warn', 'Failed to sync plan to KV (non-critical):', err));
-            }
-          }
-        }
+      // Check PlanCache first (populated by firebase-auth.js during auth init)
+      const cached = window.PlanCache && window.PlanCache.getCachedPlan();
+      if (cached && cached.plan) {
+        navLog('info', 'Using plan from PlanCache:', cached.plan);
+        localStorage.setItem('user-plan', cached.plan);
+        localStorage.setItem('dev-plan', cached.plan);
+      } else {
+        // PlanCache not populated yet — use localStorage (set by firebase-auth.js)
+        const lsPlan = localStorage.getItem('user-plan');
+        navLog('info', 'PlanCache not yet populated, using localStorage plan:', lsPlan || 'free');
       }
     } catch (planError) {
-      navLog('warn', 'Plan fetch failed (non-critical), continuing with navigation render:', planError);
+      navLog('warn', 'Plan read failed (non-critical), continuing with navigation render:', planError);
     }
   }
   
@@ -2828,21 +2765,13 @@ async function initializeNavigation() {
 }
 
 // --- Plan Reconciliation from D1 via API ---
+// Routes through PlanCache to deduplicate concurrent /api/plan/me requests.
+// Retains billing-status fallback for D1/Stripe sync mismatches.
 async function fetchPlanFromAPI() {
   try {
-    // DEFENSIVE GUARD: Ensure FirebaseAuthManager is loaded
     if (!window.FirebaseAuthManager) {
       console.log('🔍 fetchPlanFromAPI: FirebaseAuthManager not loaded yet, skipping');
       return null;
-    }
-
-    // DEFENSIVE GUARD: Wait for auth to be ready if it's still initializing
-    if (window.FirebaseAuthManager.waitForAuthReady) {
-      try {
-        await window.FirebaseAuthManager.waitForAuthReady(1000); // Short timeout
-      } catch (e) {
-        console.log('🔍 fetchPlanFromAPI: Auth ready timeout, continuing anyway');
-      }
     }
 
     const currentUser = window.FirebaseAuthManager?.getCurrentUser?.();
@@ -2850,67 +2779,63 @@ async function fetchPlanFromAPI() {
       console.log('🔍 fetchPlanFromAPI: No current user available');
       return null;
     }
-    
+
     const idToken = await currentUser.getIdToken?.();
     if (!idToken) {
       console.log('🔍 fetchPlanFromAPI: No ID token available');
       return null;
     }
-    
-    console.log('🔍 fetchPlanFromAPI: Fetching plan from D1 via API...');
-    const r = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
-    if (!r.ok) {
-      console.warn(`🔍 fetchPlanFromAPI: API returned ${r.status} ${r.statusText}`);
-      return null;
+
+    // Use PlanCache to deduplicate concurrent /api/plan/me calls
+    let plan = null;
+    if (window.PlanCache) {
+      const result = await window.PlanCache.getPlan(idToken);
+      plan = result && result.plan ? result.plan : null;
+      console.log('🔍 fetchPlanFromAPI (via PlanCache):', plan);
+    } else {
+      console.log('🔍 fetchPlanFromAPI: Fetching plan from D1 via API...');
+      const r = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
+      if (!r.ok) {
+        console.warn(`🔍 fetchPlanFromAPI: API returned ${r.status} ${r.statusText}`);
+        return null;
+      }
+      const data = await r.json();
+      plan = data.plan || 'free';
+      if (data.trialEndsAt) {
+        localStorage.setItem('trial-ends-at', data.trialEndsAt);
+      } else {
+        localStorage.removeItem('trial-ends-at');
+      }
     }
-    
-    const data = await r.json();
-    console.log('🔍 fetchPlanFromAPI: API response:', data);
-    
-    let plan = data.plan || 'free';
-    
-    // CRITICAL FIX: If plan is 'free' but user is authenticated, check billing-status as fallback
-    // This handles cases where D1 is out of sync with Stripe (shouldn't happen, but safety net)
+
+    if (!plan) return null;
+
+    // Billing-status fallback: if D1 says 'free' but Stripe may disagree
     if (plan === 'free' && currentUser) {
       console.log('🔍 fetchPlanFromAPI: Plan is free, checking billing-status as fallback...');
       try {
-        const billingRes = await fetch('/api/billing-status?force=1', { 
-          headers: { Authorization: `Bearer ${idToken}` } 
+        const billingRes = await fetch('/api/billing-status?force=1', {
+          headers: { Authorization: `Bearer ${idToken}` }
         });
         if (billingRes.ok) {
           const billingData = await billingRes.json();
           if (billingData.ok && billingData.plan && billingData.plan !== 'free') {
             console.log(`🔄 fetchPlanFromAPI: Found plan ${billingData.plan} from billing-status, syncing to D1...`);
             plan = billingData.plan;
-            // Sync to D1 (via sync-stripe-plan which writes to D1)
-            try {
-              const syncRes = await fetch('/api/sync-stripe-plan', {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${idToken}` }
-              });
-              if (syncRes.ok) {
-                console.log('✅ fetchPlanFromAPI: Plan synced to D1');
-              }
-            } catch (syncError) {
-              console.warn('⚠️ fetchPlanFromAPI: Failed to sync plan to D1:', syncError);
-            }
+            if (window.PlanCache) window.PlanCache.setCachedPlan(plan);
+            fetch('/api/sync-stripe-plan', {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${idToken}` }
+            }).catch(err => console.warn('⚠️ fetchPlanFromAPI: Failed to sync plan to D1:', err));
           }
         }
       } catch (billingError) {
         console.warn('⚠️ fetchPlanFromAPI: Failed to check billing-status:', billingError);
       }
     }
-    
-    // Store trial end date if available
-    if (data.trialEndsAt) {
-      localStorage.setItem('trial-ends-at', data.trialEndsAt);
-    } else {
-      localStorage.removeItem('trial-ends-at');
-    }
-    
-    // Update localStorage with correct plan
+
     localStorage.setItem('user-plan', plan);
-    console.log(`✅ fetchPlanFromAPI: Successfully fetched plan from D1: ${plan}`);
+    console.log(`✅ fetchPlanFromAPI: Successfully fetched plan: ${plan}`);
     return plan;
   } catch (error) {
     console.warn('❌ fetchPlanFromAPI: Error fetching plan:', error);
@@ -2931,31 +2856,16 @@ async function reconcilePlanFromAPI() {
     return;
   }
   
-  // FIX: Add retry mechanism for plan reconciliation
-  let plan = null;
-  let retryCount = 0;
-  const maxRetries = 3;
-  
   console.log('🔍 reconcilePlanFromAPI: Starting plan reconciliation from D1...');
-  
-  while (!plan && retryCount < maxRetries) {
-    try {
-      plan = await fetchPlanFromAPI();
-      if (plan) {
-        console.log(`✅ Plan reconciliation successful on attempt ${retryCount + 1}:`, plan);
-        break;
-      }
-    } catch (error) {
-      console.warn(`⚠️ Plan reconciliation attempt ${retryCount + 1} failed:`, error);
-    }
-    
-    retryCount++;
-    if (retryCount < maxRetries) {
-      console.log(`🔄 Retrying plan reconciliation in ${retryCount * 1000}ms...`);
-      await new Promise(resolve => setTimeout(resolve, retryCount * 1000));
-    }
+
+  // Single attempt — PlanCache handles deduplication; no retry cascade needed
+  let plan = null;
+  try {
+    plan = await fetchPlanFromAPI();
+  } catch (error) {
+    console.warn('⚠️ Plan reconciliation failed:', error);
   }
-  
+
   const current = localStorage.getItem('user-plan');
   if (plan && plan !== current) {
     console.log(`🔄 Updating plan from ${current} to ${plan}`);
@@ -2964,7 +2874,7 @@ async function reconcilePlanFromAPI() {
     scheduleUpdateNavigation(true);
     try { new BroadcastChannel('auth').postMessage({ type: 'plan-update', plan: plan }); } catch (_) {}
   } else if (!plan) {
-    console.warn('⚠️ Plan reconciliation failed after all retries, keeping current plan:', current);
+    console.warn('⚠️ Plan reconciliation failed, keeping current plan:', current);
   }
 }
 

--- a/js/plan-cache.js
+++ b/js/plan-cache.js
@@ -1,0 +1,91 @@
+// Centralized plan cache with request deduplication.
+// Every subsystem (firebase-auth.js, navigation.js, page-access-control.js,
+// dashboard.tsx) MUST fetch the user plan through window.PlanCache to avoid
+// redundant /api/plan/me calls. The cache deduplicates in-flight requests
+// and keeps results fresh for CACHE_TTL milliseconds.
+(function () {
+  'use strict';
+
+  var _cached = null;   // { plan, trialEndsAt }
+  var _cachedAt = 0;
+  var _inflight = null; // Promise | null
+  var CACHE_TTL = 30000; // 30 seconds
+
+  function doFetch(token) {
+    return fetch('/api/plan/me', {
+      headers: { Authorization: 'Bearer ' + token }
+    }).then(function (res) {
+      if (!res.ok) return null;
+      return res.json().then(function (data) {
+        return { plan: (data && data.plan) || null, trialEndsAt: (data && data.trialEndsAt) || null };
+      });
+    });
+  }
+
+  function persistToLocalStorage(result) {
+    if (!result) return;
+    try {
+      localStorage.setItem('user-plan', result.plan || 'free');
+      if (result.trialEndsAt) {
+        localStorage.setItem('trial-ends-at', result.trialEndsAt);
+      } else {
+        localStorage.removeItem('trial-ends-at');
+      }
+    } catch (_) { /* localStorage may be unavailable */ }
+  }
+
+  window.PlanCache = {
+    // Main entry point. Returns { plan, trialEndsAt } or null.
+    // Deduplicates concurrent calls automatically.
+    getPlan: function (token, forceRefresh) {
+      if (!token) return Promise.resolve(null);
+
+      // Return cached result if still fresh
+      if (!forceRefresh && _cached && (Date.now() - _cachedAt) < CACHE_TTL) {
+        return Promise.resolve(_cached);
+      }
+
+      // Deduplicate in-flight requests — all callers share the same promise
+      if (_inflight) return _inflight;
+
+      _inflight = doFetch(token)
+        .then(function (result) {
+          if (result) {
+            _cached = result;
+            _cachedAt = Date.now();
+            persistToLocalStorage(result);
+          }
+          _inflight = null;
+          return result;
+        })
+        .catch(function (err) {
+          _inflight = null;
+          console.warn('[PlanCache] fetch failed:', err);
+          return null;
+        });
+
+      return _inflight;
+    },
+
+    // Read-only access to the last fetched value (no network call).
+    getCachedPlan: function () {
+      return _cached;
+    },
+
+    // Manually seed the cache (e.g. after checkout redirect sets plan via
+    // billing-status). Prevents a redundant /api/plan/me round-trip.
+    setCachedPlan: function (plan, trialEndsAt) {
+      _cached = { plan: plan, trialEndsAt: trialEndsAt || null };
+      _cachedAt = Date.now();
+      persistToLocalStorage(_cached);
+    },
+
+    // Clear cache so the next getPlan() will hit the network.
+    // Call after checkout, plan upgrade/downgrade, or manual sync.
+    invalidate: function () {
+      _cached = null;
+      _cachedAt = 0;
+      _inflight = null;
+    }
+  };
+})();

--- a/linkedin-optimizer.html
+++ b/linkedin-optimizer.html
@@ -333,6 +333,7 @@
   <script src="js/main.js" type="module"></script>
   <script src="js/analytics.js" type="module"></script>
   <!-- Load Firebase auth for token retrieval -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/marketing/blog.html
+++ b/marketing/blog.html
@@ -229,6 +229,7 @@
   </footer>
 
   <script src="js/component-loader.js?v=20260206-1"></script>
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <script src="js/navigation.js?v=20260208-1"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/blog/7-day-interview-prep-routine.html
+++ b/marketing/blog/7-day-interview-prep-routine.html
@@ -254,6 +254,7 @@
   </footer>
 
   <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
   <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
   <script src="../js/navigation.js?v=20260208-1"></script>
   <script src="../js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/blog/ats-optimization-playbook.html
+++ b/marketing/blog/ats-optimization-playbook.html
@@ -240,6 +240,7 @@
   </footer>
 
   <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
   <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
   <script src="../js/navigation.js?v=20260208-1"></script>
   <script src="../js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/blog/linkedin-profile-optimization.html
+++ b/marketing/blog/linkedin-profile-optimization.html
@@ -229,6 +229,7 @@
   </footer>
 
   <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
   <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
   <script src="../js/navigation.js?v=20260208-1"></script>
   <script src="../js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/blog/mock-interview-online.html
+++ b/marketing/blog/mock-interview-online.html
@@ -283,6 +283,7 @@
   </footer>
 
   <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
   <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
   <script src="../js/navigation.js?v=20260208-1"></script>
   <script src="../js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/blog/post-template.html
+++ b/marketing/blog/post-template.html
@@ -258,6 +258,7 @@
   </footer>
 
   <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
   <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
   <script src="../js/navigation.js?v=20260208-1"></script>
   <script src="../js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/features.html
+++ b/marketing/features.html
@@ -180,6 +180,7 @@
   </footer>
 
   <script src="js/component-loader.js?v=20260206-1"></script>
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <script src="js/navigation.js?v=20260208-1"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/index.html
+++ b/marketing/index.html
@@ -209,6 +209,7 @@
   </footer>
 
   <script src="js/component-loader.js?v=20260206-1"></script>
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <script src="js/navigation.js?v=20260208-1"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>

--- a/marketing/js/firebase-auth.js
+++ b/marketing/js/firebase-auth.js
@@ -85,6 +85,7 @@ function clearAuthCookies() {
 }
 
 // --- DIRECT PLAN FETCH FROM D1 VIA API (navigation-independent) ---
+// Routes through PlanCache when available to deduplicate concurrent requests.
 async function fetchPlanFromAPI() {
   try {
     const user = auth.currentUser;
@@ -97,6 +98,12 @@ async function fetchPlanFromAPI() {
       console.log('🔍 fetchPlanFromAPI: no idToken');
       return null;
     }
+    if (window.PlanCache) {
+      const result = await window.PlanCache.getPlan(idToken);
+      const plan = result && result.plan;
+      console.log(`📊 fetchPlanFromAPI (via PlanCache): plan="${plan}"`);
+      return plan || null;
+    }
     console.log(`🔍 fetchPlanFromAPI: calling /api/plan/me for uid=${user.uid}`);
     const res = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
     if (!res.ok) {
@@ -107,7 +114,6 @@ async function fetchPlanFromAPI() {
     console.log(`📊 fetchPlanFromAPI: API returned plan="${data?.plan}"`);
     return data?.plan || null;
   } catch (e) {
-    // API fetch failed - this is non-critical, will fallback to 'free'
     console.log('ℹ️ Direct plan API fetch unavailable, will use fallback:', e.message || 'network error');
     return null;
   }

--- a/marketing/js/navigation.js
+++ b/marketing/js/navigation.js
@@ -2560,88 +2560,22 @@ async function initializeNavigation() {
 //   document.body.appendChild(switcher);
 //   navLog('debug', 'Quick plan switcher appended to body');
 
-  // CRITICAL FIX: For authenticated users, fetch plan before rendering navigation
-  // This prevents race condition where navigation shows wrong plan initially
+  // For authenticated users, read plan from PlanCache or localStorage.
+  // The authoritative /api/plan/me fetch is handled by firebase-auth.js via PlanCache.
   if (authState.isAuthenticated && window.FirebaseAuthManager?.getCurrentUser) {
-    navLog('info', 'Authenticated user detected, fetching plan before navigation render');
+    navLog('info', 'Authenticated user detected, reading plan for navigation render');
     try {
-      const user = window.FirebaseAuthManager.getCurrentUser();
-      if (user) {
-        const token = await user.getIdToken();
-        // Fetch plan from API first
-        const planRes = await fetch('/api/plan/me', {
-          headers: { Authorization: `Bearer ${token}` }
-        });
-        if (planRes.ok) {
-          const planData = await planRes.json();
-          if (planData.plan) {
-            navLog('info', 'Fetched plan from API, updating localStorage', planData.plan);
-            localStorage.setItem('user-plan', planData.plan);
-            localStorage.setItem('dev-plan', planData.plan);
-            
-            // If plan is free, double-check with billing-status as fallback
-            if (planData.plan === 'free') {
-              navLog('info', 'Plan is free, checking billing-status as fallback');
-              const billingRes = await fetch('/api/billing-status?force=1', {
-                headers: { Authorization: `Bearer ${token}` }
-              });
-              if (billingRes.ok) {
-                const billingData = await billingRes.json();
-                if (billingData.ok && billingData.plan && billingData.plan !== 'free') {
-                  navLog('info', 'Found plan from billing-status fallback, updating', billingData.plan);
-                  localStorage.setItem('user-plan', billingData.plan);
-                  localStorage.setItem('dev-plan', billingData.plan);
-                  // Sync to D1 asynchronously (via sync-stripe-plan which writes to D1)
-                  fetch('/api/sync-stripe-plan', {
-                    method: 'POST',
-                    headers: { Authorization: `Bearer ${token}` }
-                  }).catch(err => navLog('warn', 'Failed to sync plan to D1 (non-critical):', err));
-                }
-              }
-            }
-          } else {
-            // plan/me returned successfully but without plan field - use billing-status as fallback
-            navLog('info', 'plan/me response missing plan field, checking billing-status as fallback');
-            const billingRes = await fetch('/api/billing-status?force=1', {
-              headers: { Authorization: `Bearer ${token}` }
-            });
-            if (billingRes.ok) {
-              const billingData = await billingRes.json();
-              if (billingData.ok && billingData.plan) {
-                navLog('info', 'Found plan from billing-status fallback (plan/me missing plan)', billingData.plan);
-                localStorage.setItem('user-plan', billingData.plan);
-                localStorage.setItem('dev-plan', billingData.plan);
-                // Sync to KV asynchronously
-                fetch('/api/sync-stripe-plan', {
-                  method: 'POST',
-                  headers: { Authorization: `Bearer ${token}` }
-                }).catch(err => navLog('warn', 'Failed to sync plan to KV (non-critical):', err));
-              }
-            }
-          }
-        } else {
-          // plan/me failed - use billing-status as fallback
-          navLog('info', 'plan/me request failed, checking billing-status as fallback');
-          const billingRes = await fetch('/api/billing-status?force=1', {
-            headers: { Authorization: `Bearer ${token}` }
-          });
-          if (billingRes.ok) {
-            const billingData = await billingRes.json();
-            if (billingData.ok && billingData.plan) {
-              navLog('info', 'Found plan from billing-status fallback (plan/me failed)', billingData.plan);
-              localStorage.setItem('user-plan', billingData.plan);
-              localStorage.setItem('dev-plan', billingData.plan);
-              // Sync to KV asynchronously
-              fetch('/api/sync-stripe-plan', {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${token}` }
-              }).catch(err => navLog('warn', 'Failed to sync plan to KV (non-critical):', err));
-            }
-          }
-        }
+      const cached = window.PlanCache && window.PlanCache.getCachedPlan();
+      if (cached && cached.plan) {
+        navLog('info', 'Using plan from PlanCache:', cached.plan);
+        localStorage.setItem('user-plan', cached.plan);
+        localStorage.setItem('dev-plan', cached.plan);
+      } else {
+        const lsPlan = localStorage.getItem('user-plan');
+        navLog('info', 'PlanCache not yet populated, using localStorage plan:', lsPlan || 'free');
       }
     } catch (planError) {
-      navLog('warn', 'Plan fetch failed (non-critical), continuing with navigation render:', planError);
+      navLog('warn', 'Plan read failed (non-critical), continuing with navigation render:', planError);
     }
   }
   
@@ -2819,21 +2753,12 @@ async function initializeNavigation() {
 }
 
 // --- Plan Reconciliation from D1 via API ---
+// Routes through PlanCache to deduplicate concurrent /api/plan/me requests.
 async function fetchPlanFromAPI() {
   try {
-    // DEFENSIVE GUARD: Ensure FirebaseAuthManager is loaded
     if (!window.FirebaseAuthManager) {
       console.log('🔍 fetchPlanFromAPI: FirebaseAuthManager not loaded yet, skipping');
       return null;
-    }
-
-    // DEFENSIVE GUARD: Wait for auth to be ready if it's still initializing
-    if (window.FirebaseAuthManager.waitForAuthReady) {
-      try {
-        await window.FirebaseAuthManager.waitForAuthReady(1000); // Short timeout
-      } catch (e) {
-        console.log('🔍 fetchPlanFromAPI: Auth ready timeout, continuing anyway');
-      }
     }
 
     const currentUser = window.FirebaseAuthManager?.getCurrentUser?.();
@@ -2841,67 +2766,62 @@ async function fetchPlanFromAPI() {
       console.log('🔍 fetchPlanFromAPI: No current user available');
       return null;
     }
-    
+
     const idToken = await currentUser.getIdToken?.();
     if (!idToken) {
       console.log('🔍 fetchPlanFromAPI: No ID token available');
       return null;
     }
-    
-    console.log('🔍 fetchPlanFromAPI: Fetching plan from D1 via API...');
-    const r = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
-    if (!r.ok) {
-      console.warn(`🔍 fetchPlanFromAPI: API returned ${r.status} ${r.statusText}`);
-      return null;
+
+    let plan = null;
+    if (window.PlanCache) {
+      const result = await window.PlanCache.getPlan(idToken);
+      plan = result && result.plan ? result.plan : null;
+      console.log('🔍 fetchPlanFromAPI (via PlanCache):', plan);
+    } else {
+      console.log('🔍 fetchPlanFromAPI: Fetching plan from D1 via API...');
+      const r = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
+      if (!r.ok) {
+        console.warn(`🔍 fetchPlanFromAPI: API returned ${r.status} ${r.statusText}`);
+        return null;
+      }
+      const data = await r.json();
+      plan = data.plan || 'free';
+      if (data.trialEndsAt) {
+        localStorage.setItem('trial-ends-at', data.trialEndsAt);
+      } else {
+        localStorage.removeItem('trial-ends-at');
+      }
     }
-    
-    const data = await r.json();
-    console.log('🔍 fetchPlanFromAPI: API response:', data);
-    
-    let plan = data.plan || 'free';
-    
-    // CRITICAL FIX: If plan is 'free' but user is authenticated, check billing-status as fallback
-    // This handles cases where D1 is out of sync with Stripe (shouldn't happen, but safety net)
+
+    if (!plan) return null;
+
+    // Billing-status fallback: if D1 says 'free' but Stripe may disagree
     if (plan === 'free' && currentUser) {
       console.log('🔍 fetchPlanFromAPI: Plan is free, checking billing-status as fallback...');
       try {
-        const billingRes = await fetch('/api/billing-status?force=1', { 
-          headers: { Authorization: `Bearer ${idToken}` } 
+        const billingRes = await fetch('/api/billing-status?force=1', {
+          headers: { Authorization: `Bearer ${idToken}` }
         });
         if (billingRes.ok) {
           const billingData = await billingRes.json();
           if (billingData.ok && billingData.plan && billingData.plan !== 'free') {
             console.log(`🔄 fetchPlanFromAPI: Found plan ${billingData.plan} from billing-status, syncing to D1...`);
             plan = billingData.plan;
-            // Sync to D1 (via sync-stripe-plan which writes to D1)
-            try {
-              const syncRes = await fetch('/api/sync-stripe-plan', {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${idToken}` }
-              });
-              if (syncRes.ok) {
-                console.log('✅ fetchPlanFromAPI: Plan synced to D1');
-              }
-            } catch (syncError) {
-              console.warn('⚠️ fetchPlanFromAPI: Failed to sync plan to D1:', syncError);
-            }
+            if (window.PlanCache) window.PlanCache.setCachedPlan(plan);
+            fetch('/api/sync-stripe-plan', {
+              method: 'POST',
+              headers: { Authorization: `Bearer ${idToken}` }
+            }).catch(err => console.warn('⚠️ fetchPlanFromAPI: Failed to sync plan to D1:', err));
           }
         }
       } catch (billingError) {
         console.warn('⚠️ fetchPlanFromAPI: Failed to check billing-status:', billingError);
       }
     }
-    
-    // Store trial end date if available
-    if (data.trialEndsAt) {
-      localStorage.setItem('trial-ends-at', data.trialEndsAt);
-    } else {
-      localStorage.removeItem('trial-ends-at');
-    }
-    
-    // Update localStorage with correct plan
+
     localStorage.setItem('user-plan', plan);
-    console.log(`✅ fetchPlanFromAPI: Successfully fetched plan from D1: ${plan}`);
+    console.log(`✅ fetchPlanFromAPI: Successfully fetched plan: ${plan}`);
     return plan;
   } catch (error) {
     console.warn('❌ fetchPlanFromAPI: Error fetching plan:', error);
@@ -2922,31 +2842,15 @@ async function reconcilePlanFromAPI() {
     return;
   }
   
-  // FIX: Add retry mechanism for plan reconciliation
-  let plan = null;
-  let retryCount = 0;
-  const maxRetries = 3;
-  
   console.log('🔍 reconcilePlanFromAPI: Starting plan reconciliation from D1...');
-  
-  while (!plan && retryCount < maxRetries) {
-    try {
-      plan = await fetchPlanFromAPI();
-      if (plan) {
-        console.log(`✅ Plan reconciliation successful on attempt ${retryCount + 1}:`, plan);
-        break;
-      }
-    } catch (error) {
-      console.warn(`⚠️ Plan reconciliation attempt ${retryCount + 1} failed:`, error);
-    }
-    
-    retryCount++;
-    if (retryCount < maxRetries) {
-      console.log(`🔄 Retrying plan reconciliation in ${retryCount * 1000}ms...`);
-      await new Promise(resolve => setTimeout(resolve, retryCount * 1000));
-    }
+
+  let plan = null;
+  try {
+    plan = await fetchPlanFromAPI();
+  } catch (error) {
+    console.warn('⚠️ Plan reconciliation failed:', error);
   }
-  
+
   const current = localStorage.getItem('user-plan');
   if (plan && plan !== current) {
     console.log(`🔄 Updating plan from ${current} to ${plan}`);
@@ -2955,7 +2859,7 @@ async function reconcilePlanFromAPI() {
     scheduleUpdateNavigation(true);
     try { new BroadcastChannel('auth').postMessage({ type: 'plan-update', plan: plan }); } catch (_) {}
   } else if (!plan) {
-    console.warn('⚠️ Plan reconciliation failed after all retries, keeping current plan:', current);
+    console.warn('⚠️ Plan reconciliation failed, keeping current plan:', current);
   }
 }
 

--- a/marketing/js/plan-cache.js
+++ b/marketing/js/plan-cache.js
@@ -1,0 +1,91 @@
+// Centralized plan cache with request deduplication.
+// Every subsystem (firebase-auth.js, navigation.js, page-access-control.js,
+// dashboard.tsx) MUST fetch the user plan through window.PlanCache to avoid
+// redundant /api/plan/me calls. The cache deduplicates in-flight requests
+// and keeps results fresh for CACHE_TTL milliseconds.
+(function () {
+  'use strict';
+
+  var _cached = null;   // { plan, trialEndsAt }
+  var _cachedAt = 0;
+  var _inflight = null; // Promise | null
+  var CACHE_TTL = 30000; // 30 seconds
+
+  function doFetch(token) {
+    return fetch('/api/plan/me', {
+      headers: { Authorization: 'Bearer ' + token }
+    }).then(function (res) {
+      if (!res.ok) return null;
+      return res.json().then(function (data) {
+        return { plan: (data && data.plan) || null, trialEndsAt: (data && data.trialEndsAt) || null };
+      });
+    });
+  }
+
+  function persistToLocalStorage(result) {
+    if (!result) return;
+    try {
+      localStorage.setItem('user-plan', result.plan || 'free');
+      if (result.trialEndsAt) {
+        localStorage.setItem('trial-ends-at', result.trialEndsAt);
+      } else {
+        localStorage.removeItem('trial-ends-at');
+      }
+    } catch (_) { /* localStorage may be unavailable */ }
+  }
+
+  window.PlanCache = {
+    // Main entry point. Returns { plan, trialEndsAt } or null.
+    // Deduplicates concurrent calls automatically.
+    getPlan: function (token, forceRefresh) {
+      if (!token) return Promise.resolve(null);
+
+      // Return cached result if still fresh
+      if (!forceRefresh && _cached && (Date.now() - _cachedAt) < CACHE_TTL) {
+        return Promise.resolve(_cached);
+      }
+
+      // Deduplicate in-flight requests — all callers share the same promise
+      if (_inflight) return _inflight;
+
+      _inflight = doFetch(token)
+        .then(function (result) {
+          if (result) {
+            _cached = result;
+            _cachedAt = Date.now();
+            persistToLocalStorage(result);
+          }
+          _inflight = null;
+          return result;
+        })
+        .catch(function (err) {
+          _inflight = null;
+          console.warn('[PlanCache] fetch failed:', err);
+          return null;
+        });
+
+      return _inflight;
+    },
+
+    // Read-only access to the last fetched value (no network call).
+    getCachedPlan: function () {
+      return _cached;
+    },
+
+    // Manually seed the cache (e.g. after checkout redirect sets plan via
+    // billing-status). Prevents a redundant /api/plan/me round-trip.
+    setCachedPlan: function (plan, trialEndsAt) {
+      _cached = { plan: plan, trialEndsAt: trialEndsAt || null };
+      _cachedAt = Date.now();
+      persistToLocalStorage(_cached);
+    },
+
+    // Clear cache so the next getPlan() will hit the network.
+    // Call after checkout, plan upgrade/downgrade, or manual sync.
+    invalidate: function () {
+      _cached = null;
+      _cachedAt = 0;
+      _inflight = null;
+    }
+  };
+})();

--- a/mock-interview.html
+++ b/mock-interview.html
@@ -1623,6 +1623,7 @@
   <!-- Scripts -->
   <script src="js/navigation.js?v=20260208-1"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <script src="js/role-selector.js?v=20250115-1" type="module"></script>
   <script src="js/main.js" type="module"></script>

--- a/pricing-a.html
+++ b/pricing-a.html
@@ -395,6 +395,7 @@
     </div>
   </footer>
   <!-- Load Firebase auth modules -->
+  <script src="js/plan-cache.js"></script>
   <script src="js/firebase-config.js" type="module"></script>
   <script src="js/firebase-auth.js?v=20260207-2" type="module"></script>
   <!-- Load navigation system -->

--- a/privacy.html
+++ b/privacy.html
@@ -281,6 +281,7 @@
   </footer>
 
   <!-- Load Firebase auth (ensures logged-in nav renders) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1186,6 +1186,7 @@
   <script src="js/mobile-menu.js?v=20250115-1"></script>
   
   <!-- Load Firebase auth as ES module (same pattern as dashboard.html) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   
   <!-- DEV-ONLY PLAN TOGGLE will be added by navigation.js -->

--- a/terms.html
+++ b/terms.html
@@ -610,6 +610,7 @@
   </footer>
 
   <!-- Load Firebase auth (ensures logged-in nav renders) -->
+  <script src="js/plan-cache.js"></script>
   <script type="module" src="js/firebase-auth.js?v=20260207-2"></script>
   <!-- Load navigation system -->
   <script src="js/navigation.js?v=20260208-1"></script>


### PR DESCRIPTION
Fix missing access-verified recheck after Firebase auth wait in inter…

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth/entitlement gating and plan hydration across both app and marketing surfaces; regressions could cause incorrect redirects or wrong plan-based UI until cache/guard timing settles.
> 
> **Overview**
> Introduces a shared `window.PlanCache` to **deduplicate and cache** `/api/plan/me` lookups (with localStorage persistence), and wires it into `firebase-auth.js`, `navigation.js`, and the React dashboard to stop each surface from independently fetching the plan.
> 
> Adds `js/page-access-control.js` to **centralize protected-page plan/auth gating** with a deferred re-verification step, then refactors `interview-questions.html` and `resume-feedback-pro.html` to delegate their duplicated access checks and plan reads to this module (including tracking `window.__JOBHACKAI_VERIFIED_PLAN__`).
> 
> Updates many HTML pages to load `plan-cache.js`, and adjusts e2e setup to set `__JOBHACKAI_VERIFIED_PLAN__` for the new guard flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 55cd8798623a79805332b8953c56cf14aabb9141. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->