### PR TITLE
Fix incomplete Bugbot patches: complete PageAccessControl null guards…

### DIFF
--- a/interview-questions.html
+++ b/interview-questions.html
@@ -1936,7 +1936,8 @@
     const IQ_ALLOWED_PLANS = window.PageAccessControl ? window.PageAccessControl.PAID_PLANS : ['trial', 'essential', 'pro', 'premium'];
 
     function getUserPlan() {
-      return window.PageAccessControl.getCurrentUserPlan(IQ_ALLOWED_PLANS, '[INTERVIEW-Q]');
+      if (window.PageAccessControl) return window.PageAccessControl.getCurrentUserPlan(IQ_ALLOWED_PLANS, '[INTERVIEW-Q]');
+      return localStorage.getItem('user-plan') || 'free';
     }
 
     const user = {
@@ -4602,11 +4603,11 @@ function initIQPage(){
     };
 
     function deferredPlanReVerify() {
-      window.PageAccessControl.deferredPlanReVerify(_iqAccessOpts);
+      if (window.PageAccessControl) window.PageAccessControl.deferredPlanReVerify(_iqAccessOpts);
     }
 
     async function enforceAccess() {
-      await window.PageAccessControl.enforceAccess(_iqAccessOpts);
+      if (window.PageAccessControl) await window.PageAccessControl.enforceAccess(_iqAccessOpts);
     }
     
     // Initialize page when DOM is ready

--- a/js/plan-cache.js
+++ b/js/plan-cache.js
@@ -9,6 +9,7 @@
   var _cached = null;   // { plan, trialEndsAt }
   var _cachedAt = 0;
   var _inflight = null; // Promise | null
+  var _generation = 0;  // Incremented on invalidate to discard stale in-flight results
   var CACHE_TTL = 30000; // 30 seconds
 
   function doFetch(token) {
@@ -28,9 +29,10 @@
       localStorage.setItem('user-plan', result.plan || 'free');
       if (result.trialEndsAt) {
         localStorage.setItem('trial-ends-at', result.trialEndsAt);
-      } else {
-        localStorage.removeItem('trial-ends-at');
       }
+      // Do NOT remove trial-ends-at when absent — a previous API call
+      // may have set it correctly and callers like billing-status fallback
+      // may not have trialEndsAt available.
     } catch (_) { /* localStorage may be unavailable */ }
   }
 
@@ -48,18 +50,19 @@
       // Deduplicate in-flight requests — all callers share the same promise
       if (_inflight) return _inflight;
 
+      var gen = ++_generation;
       _inflight = doFetch(token)
         .then(function (result) {
-          if (result) {
+          if (gen === _generation && result) {
             _cached = result;
             _cachedAt = Date.now();
             persistToLocalStorage(result);
           }
-          _inflight = null;
+          if (gen === _generation) _inflight = null;
           return result;
         })
         .catch(function (err) {
-          _inflight = null;
+          if (gen === _generation) _inflight = null;
           console.warn('[PlanCache] fetch failed:', err);
           return null;
         });
@@ -85,19 +88,8 @@
     invalidate: function () {
       _cached = null;
       _cachedAt = 0;
-      
-      // Store the current in-flight promise to prevent race conditions
-      var oldInflight = _inflight;
       _inflight = null;
-      
-      // If there was an in-flight request, chain a handler to prevent it from
-      // updating the cache when it completes
-      if (oldInflight) {
-        oldInflight.then(function() {
-          // Do nothing with the result - prevent the old promise's result
-          // from overwriting our freshly invalidated cache
-        });
-      }
+      ++_generation; // Ensures any in-flight fetch won't overwrite cache when it resolves
     }
   };
 })();

--- a/marketing/js/plan-cache.js
+++ b/marketing/js/plan-cache.js
@@ -9,6 +9,7 @@
   var _cached = null;   // { plan, trialEndsAt }
   var _cachedAt = 0;
   var _inflight = null; // Promise | null
+  var _generation = 0;  // Incremented on invalidate to discard stale in-flight results
   var CACHE_TTL = 30000; // 30 seconds
 
   function doFetch(token) {
@@ -28,9 +29,10 @@
       localStorage.setItem('user-plan', result.plan || 'free');
       if (result.trialEndsAt) {
         localStorage.setItem('trial-ends-at', result.trialEndsAt);
-      } else {
-        localStorage.removeItem('trial-ends-at');
       }
+      // Do NOT remove trial-ends-at when absent — a previous API call
+      // may have set it correctly and callers like billing-status fallback
+      // may not have trialEndsAt available.
     } catch (_) { /* localStorage may be unavailable */ }
   }
 
@@ -48,18 +50,19 @@
       // Deduplicate in-flight requests — all callers share the same promise
       if (_inflight) return _inflight;
 
+      var gen = ++_generation;
       _inflight = doFetch(token)
         .then(function (result) {
-          if (result) {
+          if (gen === _generation && result) {
             _cached = result;
             _cachedAt = Date.now();
             persistToLocalStorage(result);
           }
-          _inflight = null;
+          if (gen === _generation) _inflight = null;
           return result;
         })
         .catch(function (err) {
-          _inflight = null;
+          if (gen === _generation) _inflight = null;
           console.warn('[PlanCache] fetch failed:', err);
           return null;
         });
@@ -86,6 +89,7 @@
       _cached = null;
       _cachedAt = 0;
       _inflight = null;
+      ++_generation; // Ensures any in-flight fetch won't overwrite cache when it resolves
     }
   };
 })();

--- a/resume-feedback-pro.html
+++ b/resume-feedback-pro.html
@@ -1226,11 +1226,11 @@
     };
 
     function deferredPlanReVerify() {
-      window.PageAccessControl.deferredPlanReVerify(_rfAccessOpts);
+      if (window.PageAccessControl) window.PageAccessControl.deferredPlanReVerify(_rfAccessOpts);
     }
 
     async function enforceAccess() {
-      await window.PageAccessControl.enforceAccess(_rfAccessOpts);
+      if (window.PageAccessControl) await window.PageAccessControl.enforceAccess(_rfAccessOpts);
     }
 
     // Wait for DOM to be ready before enforcing access again
@@ -1623,7 +1623,8 @@
     const RF_ALLOWED_PLANS = window.PageAccessControl ? window.PageAccessControl.PAID_PLANS : ['trial', 'essential', 'pro', 'premium'];
 
     function getCurrentUserPlan() {
-      return window.PageAccessControl.getCurrentUserPlan(RF_ALLOWED_PLANS, '[RESUME-FEEDBACK]');
+      if (window.PageAccessControl) return window.PageAccessControl.getCurrentUserPlan(RF_ALLOWED_PLANS, '[RESUME-FEEDBACK]');
+      return localStorage.getItem('user-plan') || 'free';
     }
 
     // --- UPDATED USER OBJECT ---


### PR DESCRIPTION
…, prevent trial-ends-at wipe, correct race condition fix

- Bug 1: Add null guards on deferredPlanReVerify(), enforceAccess(), getCurrentUserPlan() method calls in resume-feedback-pro.html and interview-questions.html (Bugbot only guarded PAID_PLANS property reads, not method calls)
- Bug 3: Stop persistToLocalStorage from removing trial-ends-at when trialEndsAt is absent — callers like billing-status fallback may not have it available
- Bug 4: Replace incorrect no-op .then() race condition fix with generation counter pattern — the old fix didn't prevent the original .then() handler from overwriting _cached with stale data. Also apply race condition fix to marketing/js/plan-cache.js which was missing it entirely.

https://claude.ai/code/session_01Fuz8udXPug5CkpbAWJJCt2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches plan/access enforcement and shared plan caching; mistakes could cause incorrect gating/redirects or stale plan state, though changes are small and defensive.
> 
> **Overview**
> Fixes missing `PageAccessControl` null-guards in `interview-questions.html` and `resume-feedback-pro.html` by conditionally calling `getCurrentUserPlan`, `deferredPlanReVerify`, and `enforceAccess`, with a `localStorage` plan fallback when the shared module isn’t present.
> 
> Hardens `PlanCache` (both `js/plan-cache.js` and `marketing/js/plan-cache.js`) by **preserving** `trial-ends-at` when the API response omits it and by replacing the prior invalidate race workaround with a **generation counter** so stale in-flight `/api/plan/me` results can’t overwrite refreshed cache state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d81eeb89d52f9edc0b1418931f744fc98dceff72. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->