### PR TITLE
Add opts.deniedRedirect to PageAccessControl to fix body-guard redire…

### DIFF
--- a/js/page-access-control.js
+++ b/js/page-access-control.js
@@ -102,7 +102,7 @@ window.PageAccessControl = (function () {
           console.warn(logPrefix, 'Deferred re-verify: plan is now', apiPlan, '— revoking access');
           window.__JOBHACKAI_ACCESS_VERIFIED__ = false;
           window.__JOBHACKAI_VERIFIED_PLAN__ = null;
-          window.location.href = 'pricing-a.html?plan=essential';
+          window.location.href = opts.deniedRedirect || 'pricing-a.html?plan=essential';
         } else if (apiPlan !== window.__JOBHACKAI_VERIFIED_PLAN__) {
           console.log(logPrefix, 'Deferred re-verify: updating verified plan to', apiPlan);
           window.__JOBHACKAI_VERIFIED_PLAN__ = apiPlan;
@@ -170,7 +170,7 @@ window.PageAccessControl = (function () {
       if (!isAuthenticated) {
         window.location.href = 'login.html';
       } else {
-        window.location.href = 'pricing-a.html?plan=essential';
+        window.location.href = opts.deniedRedirect || 'pricing-a.html?plan=essential';
       }
     } else {
       window.__JOBHACKAI_ACCESS_VERIFIED__ = true;

--- a/mock-interview.html
+++ b/mock-interview.html
@@ -3183,7 +3183,8 @@
     // Delegated to shared page-access-control.js
     var _miAccessOpts = {
       allowedPlans: ['pro', 'premium'],
-      logPrefix: '[MOCK-INTERVIEW]'
+      logPrefix: '[MOCK-INTERVIEW]',
+      deniedRedirect: 'interview-questions.html?upgrade=mock-interview'
     };
 
     function deferredPlanReVerify() {


### PR DESCRIPTION
…ct mismatch

PageAccessControl.enforceAccess and deferredPlanReVerify hardcoded the plan-denied redirect to pricing-a.html?plan=essential. Mock-interview needs to redirect to interview-questions.html?upgrade=mock-interview when access is denied. Add opts.deniedRedirect support with the existing URL as the default, so existing callers are unaffected.

https://claude.ai/code/session_01Fuz8udXPug5CkpbAWJJCt2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, backward-compatible change to client-side redirect URLs; main impact is users may be sent to a different upgrade page if misconfigured.
> 
> **Overview**
> Adds `opts.deniedRedirect` to `PageAccessControl` so both `enforceAccess` and `deferredPlanReVerify` can redirect plan-denied users to a caller-specified URL instead of always sending them to `pricing-a.html?plan=essential` (default preserved).
> 
> Updates `mock-interview.html` to pass a mock-interview-specific denied redirect (`interview-questions.html?upgrade=mock-interview`) to keep the body-guard and deferred re-verification flows consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52c6653a6ea94ccf35b52e74b41bf0c3a69e56c3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->