### PR TITLE
Upgrade OpenAI models from gpt-4o to gpt-4.1 series

### DIFF
--- a/app/functions/_lib/grammar-ai-check.js
+++ b/app/functions/_lib/grammar-ai-check.js
@@ -53,7 +53,7 @@ export async function verifyGrammarWithAI(resumeText, env) {
     }
   }
 
-  const model = env.OPENAI_MODEL_GRAMMAR || 'gpt-4o-mini';
+  const model = env.OPENAI_MODEL_GRAMMAR || 'gpt-4.1-mini';
   const apiUrl = 'https://api.openai.com/v1/chat/completions';
 
   const systemPrompt = 'You are a grammar evaluator. Answer with JSON only.';

--- a/app/functions/_lib/openai-client.js
+++ b/app/functions/_lib/openai-client.js
@@ -52,7 +52,7 @@ function detectTruncation(result, feature) {
 /**
  * Call OpenAI API with structured outputs and optional fallback model.
  * @param {Object} options - API options
- * @param {string} options.model - Primary model (gpt-4o-mini, gpt-4o, etc.)
+ * @param {string} options.model - Primary model (gpt-4.1-mini, gpt-4.1, etc.)
  * @param {string} [options.fallbackModel] - Optional fallback model on non-rate-limit failures
  * @param {Array} options.messages - Chat messages
  * @param {Object} options.responseFormat - Structured output schema (optional)
@@ -67,7 +67,7 @@ function detectTruncation(result, feature) {
  * @returns {Promise<Object>} API response
  */
 export async function callOpenAI({
-  model = 'gpt-4o-mini',
+  model = 'gpt-4.1-mini',
   fallbackModel = null,
   messages = [],
   responseFormat = null,
@@ -342,7 +342,7 @@ export async function callOpenAI({
  * @returns {Promise<Object>} OpenAI response with atsRubric and atsIssues only
  */
 export async function generateATSFeedback(resumeText, ruleBasedScores, jobTitle, env, options = {}) {
-  const baseModel = env.OPENAI_MODEL_FEEDBACK || 'gpt-4o-mini';
+  const baseModel = env.OPENAI_MODEL_FEEDBACK || 'gpt-4.1-mini';
   const skipRoleTips = options.skipRoleTips === true;
   const shortMode = options.shortMode === true;
 
@@ -626,7 +626,7 @@ ${roleContext}
  * @returns {Promise<Object>} OpenAI response with roleSpecificFeedback only
  */
 export async function generateRoleTips(resumeText, ruleBasedScores, jobTitle, env, options = {}) {
-  const baseModel = env.OPENAI_MODEL_FEEDBACK || 'gpt-4o-mini';
+  const baseModel = env.OPENAI_MODEL_FEEDBACK || 'gpt-4.1-mini';
   const timeoutMs = options.timeoutMs || 20000; // PHASE 2: 20-25s timeout for Tier 2
 
   if (!jobTitle || jobTitle.trim().length === 0) {
@@ -785,7 +785,7 @@ RESUME-AWARE CONSTRAINT (CRITICAL):
 
 /**
  * Generate resume rewrite using AI.
- * Uses gpt-4o for higher quality and structured output so UI can rely on shape.
+ * Uses gpt-4.1 for higher quality and structured output so UI can rely on shape.
  * This is a premium feature, so we accept a higher per-call cost but still cap it.
  * 
  * @param {string} resumeText - Original resume text
@@ -796,8 +796,8 @@ RESUME-AWARE CONSTRAINT (CRITICAL):
  * @param {Object} env - Environment variables
  */
 export async function generateResumeRewrite(resumeText, section, jobTitle, atsIssues, roleSpecificFeedback, env) {
-  const baseModel = env.OPENAI_MODEL_REWRITE || 'gpt-4o';
-  const fallbackModel = 'gpt-4o-mini'; // cheaper fallback if 4o has issues
+  const baseModel = env.OPENAI_MODEL_REWRITE || 'gpt-4.1';
+  const fallbackModel = 'gpt-4.1-mini'; // cheaper fallback if primary has issues
 
   const maxOutputTokens = Number(env.OPENAI_MAX_TOKENS_REWRITE) > 0
     ? Number(env.OPENAI_MAX_TOKENS_REWRITE)
@@ -954,14 +954,16 @@ async function hashString(str) {
  * Estimate cost in USD for OpenAI API call
  */
 function estimateCost(model, promptTokens, completionTokens, cachedTokens = 0) {
-  // Pricing as of 2024 (approximate, may vary)
+  // Pricing (approximate, may vary)
   const pricing = {
+    'gpt-4.1-mini': { input: 0.4 / 1_000_000, output: 1.6 / 1_000_000 },
+    'gpt-4.1': { input: 2.0 / 1_000_000, output: 8.0 / 1_000_000 },
     'gpt-4o-mini': { input: 0.15 / 1_000_000, output: 0.6 / 1_000_000 },
     'gpt-4o': { input: 2.5 / 1_000_000, output: 10 / 1_000_000 },
     'gpt-4': { input: 30 / 1_000_000, output: 60 / 1_000_000 }
   };
 
-  const modelPricing = pricing[model] || pricing['gpt-4o-mini'];
+  const modelPricing = pricing[model] || pricing['gpt-4.1-mini'];
   const inputCost = Math.max(0, promptTokens - cachedTokens) * modelPricing.input;
   const outputCost = completionTokens * modelPricing.output;
   const cost = inputCost + outputCost;

--- a/app/functions/_lib/openai-template-generator.js
+++ b/app/functions/_lib/openai-template-generator.js
@@ -45,7 +45,7 @@ Guidelines:
         'Content-Type': 'application/json'
       },
       body: JSON.stringify({
-        model: 'gpt-4o-mini', // Cost-effective model
+        model: 'gpt-4.1-mini', // Cost-effective model
         messages: [
           { role: 'system', content: 'You are an expert in job role requirements and skill templates. Return only valid JSON.' },
           { role: 'user', content: prompt }

--- a/app/functions/api/cover-letter/generate.js
+++ b/app/functions/api/cover-letter/generate.js
@@ -269,8 +269,8 @@ export async function onRequest(context) {
 
     const result = await callOpenAI(
       {
-        model: 'gpt-4o-mini',
-        fallbackModel: 'gpt-4o-mini',
+        model: 'gpt-4.1-mini',
+        fallbackModel: 'gpt-4.1-mini',
         messages: [
           {
             role: 'system',

--- a/app/functions/api/interview-questions/generate.js
+++ b/app/functions/api/interview-questions/generate.js
@@ -119,7 +119,7 @@ CRITICAL:
   };
 
   const aiResponse = await callOpenAI({
-    model: env.OPENAI_MODEL_IQ || 'gpt-4o-mini',
+    model: env.OPENAI_MODEL_IQ || 'gpt-4.1-mini',
     messages: [
       { role: 'system', content: systemPrompt },
       { role: 'user', content: userPrompt }

--- a/app/functions/api/linkedin/analyze.js
+++ b/app/functions/api/linkedin/analyze.js
@@ -402,8 +402,8 @@ export async function onRequest(context) {
       // AI call (single call for all sections)
       aiResult = await callOpenAI(
         {
-          model: env.OPENAI_MODEL_LINKEDIN_ANALYZE || 'gpt-4o-mini',
-          fallbackModel: 'gpt-4o-mini',
+          model: env.OPENAI_MODEL_LINKEDIN_ANALYZE || 'gpt-4.1-mini',
+          fallbackModel: 'gpt-4.1-mini',
           messages: buildAnalyzeMessages(inputJsonObj),
           responseFormat: analyzeResponseSchema(includeRecommendations),
           maxTokens: Number(env.OPENAI_MAX_TOKENS_LINKEDIN_ANALYZE) > 0 ? Number(env.OPENAI_MAX_TOKENS_LINKEDIN_ANALYZE) : 1300,

--- a/app/functions/api/linkedin/regenerate.js
+++ b/app/functions/api/linkedin/regenerate.js
@@ -346,8 +346,8 @@ export async function onRequest(context) {
     try {
       aiResult = await callOpenAI(
         {
-          model: env.OPENAI_MODEL_LINKEDIN_REGENERATE || 'gpt-4o-mini',
-          fallbackModel: 'gpt-4o-mini',
+          model: env.OPENAI_MODEL_LINKEDIN_REGENERATE || 'gpt-4.1-mini',
+          fallbackModel: 'gpt-4.1-mini',
           messages: buildRegenerateMessages(input, currentOutput, section),
           responseFormat: regenerateResponseSchema(),
           maxTokens: Number(env.OPENAI_MAX_TOKENS_LINKEDIN_REGENERATE) > 0 ? Number(env.OPENAI_MAX_TOKENS_LINKEDIN_REGENERATE) : 900,

--- a/app/functions/api/mock-interview/generate-questions.js
+++ b/app/functions/api/mock-interview/generate-questions.js
@@ -101,7 +101,7 @@ Output JSON:
   };
 
   const aiResponse = await callOpenAI({
-    model: env.OPENAI_MODEL_MI || 'gpt-4o-mini',
+    model: env.OPENAI_MODEL_MI || 'gpt-4.1-mini',
     messages: [
       { role: 'system', content: systemPrompt },
       { role: 'user', content: userPrompt }

--- a/app/functions/api/mock-interview/score.js
+++ b/app/functions/api/mock-interview/score.js
@@ -206,7 +206,7 @@ Output JSON exactly in this structure:
   };
 
   const aiResponse = await callOpenAI({
-    model: env.OPENAI_MODEL_MI || 'gpt-4o',
+    model: env.OPENAI_MODEL_MI || 'gpt-4.1',
     messages: [
       { role: 'system', content: systemPrompt },
       { role: 'user', content: userPrompt }

--- a/app/functions/api/role-tips.js
+++ b/app/functions/api/role-tips.js
@@ -205,7 +205,7 @@ export async function onRequest(context) {
     if (env.JOBHACKAI_KV) {
       try {
         // Cache key: uid + resumeId + normalizedRole + model + schema version
-        const modelVersion = env.OPENAI_MODEL_FEEDBACK || 'gpt-4o-mini';
+        const modelVersion = env.OPENAI_MODEL_FEEDBACK || 'gpt-4.1-mini';
         const schemaVersion = 'v1';
         const cacheKey = `roleTips:${uid}:${sanitizedResumeId}:${normalizedRole}:${modelVersion}:${schemaVersion}`;
         const cached = await env.JOBHACKAI_KV.get(cacheKey);
@@ -396,7 +396,7 @@ export async function onRequest(context) {
     // C5: Cache result in KV (optional, non-blocking)
     if (roleSpecificFeedback && env.JOBHACKAI_KV) {
       try {
-        const modelVersion = env.OPENAI_MODEL_FEEDBACK || 'gpt-4o-mini';
+        const modelVersion = env.OPENAI_MODEL_FEEDBACK || 'gpt-4.1-mini';
         const schemaVersion = 'v1';
         const cacheKey = `roleTips:${uid}:${sanitizedResumeId}:${normalizedRole}:${modelVersion}:${schemaVersion}`;
         await env.JOBHACKAI_KV.put(cacheKey, JSON.stringify({

--- a/app/functions/api/test-openai.js
+++ b/app/functions/api/test-openai.js
@@ -55,7 +55,7 @@ export async function onRequest(context) {
     }
 
     // Get model configuration from env vars
-    const model = env.OPENAI_MODEL_ATS || 'gpt-4o-mini';
+    const model = env.OPENAI_MODEL_ATS || 'gpt-4.1-mini';
     const temperature = parseFloat(env.OPENAI_TEMPERATURE_SCORING || '0.2');
     const maxTokens = parseInt(env.OPENAI_MAX_TOKENS_ATS || '800', 10);
 

--- a/test-openai-direct.js
+++ b/test-openai-direct.js
@@ -9,8 +9,8 @@
 // Mock environment for testing
 const mockEnv = {
   OPENAI_API_KEY: process.env.OPENAI_API_KEY || 'test-key',
-  OPENAI_MODEL_FEEDBACK: process.env.OPENAI_MODEL_FEEDBACK || 'gpt-4o-mini',
-  OPENAI_MODEL_REWRITE: process.env.OPENAI_MODEL_REWRITE || 'gpt-4o',
+  OPENAI_MODEL_FEEDBACK: process.env.OPENAI_MODEL_FEEDBACK || 'gpt-4.1-mini',
+  OPENAI_MODEL_REWRITE: process.env.OPENAI_MODEL_REWRITE || 'gpt-4.1',
   OPENAI_MAX_TOKENS_ATS: process.env.OPENAI_MAX_TOKENS_ATS || '800',
   OPENAI_MAX_TOKENS_REWRITE: process.env.OPENAI_MAX_TOKENS_REWRITE || '2000',
   OPENAI_TEMPERATURE_SCORING: process.env.OPENAI_TEMPERATURE_SCORING || '0.2',
@@ -82,7 +82,7 @@ async function testATSFeedback() {
         totalTokens: 'number',
         cachedTokens: 'number'
       },
-      model: 'gpt-4o-mini',
+      model: 'gpt-4.1-mini',
       finishReason: 'stop'
     });
     
@@ -117,7 +117,7 @@ async function testResumeRewrite() {
         totalTokens: 'number',
         cachedTokens: 'number'
       },
-      model: 'gpt-4o',
+      model: 'gpt-4.1',
       finishReason: 'stop'
     });
     


### PR DESCRIPTION
## Summary
This PR updates all OpenAI model references throughout the codebase from the gpt-4o series to the newer gpt-4.1 series, including updated pricing information for cost estimation.

## Key Changes
- **Default model updates**: Changed default models from `gpt-4o-mini` to `gpt-4.1-mini` and `gpt-4o` to `gpt-4.1` across all API endpoints and utility functions
- **Affected features**:
  - ATS feedback generation
  - Role-specific tips generation
  - Resume rewrite generation
  - Cover letter generation
  - LinkedIn profile analysis and regeneration
  - Interview question generation
  - Mock interview question generation and scoring
  - Grammar checking
  - Template generation
- **Pricing updates**: Added pricing data for gpt-4.1 and gpt-4.1-mini models in the cost estimation function, with fallback to gpt-4.1-mini for unknown models
- **Fallback model updates**: Updated fallback model references to use gpt-4.1-mini instead of gpt-4o-mini for consistency
- **Documentation**: Updated JSDoc comments and inline comments to reflect the new model names
- **Test updates**: Updated test expectations to validate the new default models

## Implementation Details
- All environment variable defaults that previously used gpt-4o models now use gpt-4.1 equivalents
- The cost estimation function now includes pricing for both gpt-4.1 and gpt-4.1-mini models
- Fallback model for resume rewrite changed from gpt-4o-mini to gpt-4.1-mini with updated comment clarifying it's the "cheaper fallback"
- Changes are backward compatible - environment variables can still override defaults with any supported model

https://claude.ai/code/session_011iZjVbc8NsDgacLGh8i3YX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swaps the default OpenAI models across many user-facing generation flows, which can change output quality/format and affect latency/cost; also updates cost-estimation pricing and fallback behavior.
> 
> **Overview**
> Updates OpenAI model defaults across the app from the `gpt-4o*` series to the `gpt-4.1*` series (including `callOpenAI` defaults and feature-specific callers like cover letters, interview questions, LinkedIn optimize/analyze/regenerate, mock interview Q&A generation/scoring, role tips, grammar check, and template generation).
> 
> Resume rewrites move to `gpt-4.1` with `gpt-4.1-mini` as the cheaper fallback, and the OpenAI cost estimator is updated with `gpt-4.1`/`gpt-4.1-mini` pricing and a new unknown-model fallback default. Test fixtures/docs are adjusted to match the new model names.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e7ece9a25f9cc3e91972d2aebe8f04a237c3688. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->