### PR TITLE
Fix app root routing and remove production debug surfaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,10 @@ wrangler.local.toml
 *.swo
 *.iml
 
+# Local agent/worktree state
+.claude/settings.local.json
+.claude/worktrees/
+
 # OS/system files
 Thumbs.db
 Desktop.ini

--- a/app/functions/_lib/debug-access.js
+++ b/app/functions/_lib/debug-access.js
@@ -1,0 +1,19 @@
+const PRODUCTION_ENVIRONMENTS = new Set(['prod', 'production']);
+
+function normalizeEnvironmentName(environment) {
+  return String(environment || '').trim().toLowerCase();
+}
+
+export function isProductionEnvironment(env) {
+  return PRODUCTION_ENVIRONMENTS.has(normalizeEnvironmentName(env?.ENVIRONMENT));
+}
+
+export function notFoundInProductionResponse(headers = {}) {
+  return new Response('Not Found', {
+    status: 404,
+    headers: {
+      'Cache-Control': 'no-store',
+      ...headers
+    }
+  });
+}

--- a/app/functions/_lib/debug-access.js
+++ b/app/functions/_lib/debug-access.js
@@ -8,10 +8,19 @@ export function isProductionEnvironment(env) {
   return PRODUCTION_ENVIRONMENTS.has(normalizeEnvironmentName(env?.ENVIRONMENT));
 }
 
+/** Same values as middleware — keep in sync so prod 404 early-returns are not weaker. */
+export const STANDARD_SECURITY_HEADERS = Object.freeze({
+  'x-content-type-options': 'nosniff',
+  'x-frame-options': 'DENY',
+  'referrer-policy': 'strict-origin-when-cross-origin',
+  'permissions-policy': 'camera=(), microphone=(), geolocation=()'
+});
+
 export function notFoundInProductionResponse(headers = {}) {
   return new Response('Not Found', {
     status: 404,
     headers: {
+      ...STANDARD_SECURITY_HEADERS,
       'Cache-Control': 'no-store',
       ...headers
     }

--- a/app/functions/_middleware.js
+++ b/app/functions/_middleware.js
@@ -1,4 +1,28 @@
-export async function onRequest({ next, env }) {
+import { isProductionEnvironment, notFoundInProductionResponse } from './_lib/debug-access.js';
+
+const PRODUCTION_ONLY_DEBUG_PATHS = new Set([
+  '/api/ats-health',
+  '/api/test-openai',
+  '/auth-test',
+  '/auth-test.html',
+  '/dashboard-simple',
+  '/dashboard-simple.html',
+  '/debug-stripe',
+  '/env-test',
+  '/simple-test',
+  '/simple-test.html',
+  '/stripe-key-test',
+  '/stripe-test',
+  '/stripe-test.html'
+]);
+
+export async function onRequest({ request, next, env }) {
+  const pathname = request ? new URL(request.url).pathname.replace(/\/+$/, '') || '/' : null;
+
+  if (pathname && isProductionEnvironment(env) && PRODUCTION_ONLY_DEBUG_PATHS.has(pathname)) {
+    return notFoundInProductionResponse();
+  }
+
   const res = await next();
   const h = new Headers(res.headers);
 

--- a/app/functions/_middleware.js
+++ b/app/functions/_middleware.js
@@ -1,4 +1,8 @@
-import { isProductionEnvironment, notFoundInProductionResponse } from './_lib/debug-access.js';
+import {
+  isProductionEnvironment,
+  notFoundInProductionResponse,
+  STANDARD_SECURITY_HEADERS
+} from './_lib/debug-access.js';
 
 const PRODUCTION_ONLY_DEBUG_PATHS = new Set([
   '/api/ats-health',
@@ -26,11 +30,10 @@ export async function onRequest({ request, next, env }) {
   const res = await next();
   const h = new Headers(res.headers);
 
-  // Security headers — applied on ALL environments
-  h.set('x-content-type-options', 'nosniff');
-  h.set('x-frame-options', 'DENY');
-  h.set('referrer-policy', 'strict-origin-when-cross-origin');
-  h.set('permissions-policy', 'camera=(), microphone=(), geolocation=()');
+  // Security headers — applied on ALL environments (shared with notFoundInProductionResponse)
+  for (const [name, value] of Object.entries(STANDARD_SECURITY_HEADERS)) {
+    h.set(name, value);
+  }
 
   // QA-only: prevent indexing and disable caching
   if (env.ENVIRONMENT === 'qa') {

--- a/app/functions/api/ats-health.js
+++ b/app/functions/api/ats-health.js
@@ -1,6 +1,8 @@
 // ATS Health endpoint
 // Returns "ok" and verifies JOBHACKAI_KV is readable
 
+import { isProductionEnvironment, notFoundInProductionResponse } from '../_lib/debug-access.js';
+
 function corsHeaders(origin, env) {
   const allowedOrigins = [
     'https://dev.jobhackai.io',
@@ -35,6 +37,10 @@ function json(data, status = 200, origin, env) {
 export async function onRequest(context) {
   const { request, env } = context;
   const origin = request.headers.get('Origin') || '';
+
+  if (isProductionEnvironment(env)) {
+    return notFoundInProductionResponse();
+  }
 
   if (request.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders(origin, env) });
@@ -108,7 +114,6 @@ export async function onRequest(context) {
     }, 500, origin, env);
   }
 }
-
 
 
 

--- a/app/functions/api/test-openai.js
+++ b/app/functions/api/test-openai.js
@@ -2,6 +2,7 @@
 // Verifies OPENAI_API_KEY and model configurations are working properly
 
 import { callOpenAI } from '../_lib/openai-client.js';
+import { isProductionEnvironment, notFoundInProductionResponse } from '../_lib/debug-access.js';
 
 function corsHeaders(origin, env) {
   const allowedOrigins = [
@@ -35,6 +36,10 @@ function json(data, status = 200, origin, env) {
 export async function onRequest(context) {
   const { request, env } = context;
   const origin = request.headers.get('Origin') || '';
+
+  if (isProductionEnvironment(env)) {
+    return notFoundInProductionResponse();
+  }
 
   if (request.method === 'OPTIONS') {
     return new Response(null, { headers: corsHeaders(origin, env) });
@@ -163,4 +168,3 @@ Return a short JSON object with this structure:
     }, errorCode, origin, env);
   }
 }
-

--- a/app/functions/debug-stripe.js
+++ b/app/functions/debug-stripe.js
@@ -1,4 +1,10 @@
+import { isProductionEnvironment, notFoundInProductionResponse } from './_lib/debug-access.js';
+
 export async function onRequest({ env }) {
+  if (isProductionEnvironment(env)) {
+    return notFoundInProductionResponse();
+  }
+
   const frontendUrl = env.FRONTEND_URL || 'https://qa.jobhackai.io';
   const successUrl = `${frontendUrl}/payment-success?session_id={CHECKOUT_SESSION_ID}`;
   const cancelUrl = `${frontendUrl}/payment-cancelled`;
@@ -14,6 +20,11 @@ export async function onRequest({ env }) {
       returnUrl: returnUrl,
       timestamp: new Date().toISOString(),
     }),
-    { headers: { 'Content-Type': 'application/json' } }
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store'
+      }
+    }
   );
 }

--- a/app/functions/env-test.js
+++ b/app/functions/env-test.js
@@ -1,4 +1,10 @@
+import { isProductionEnvironment, notFoundInProductionResponse } from './_lib/debug-access.js';
+
 export async function onRequest({ env }) {
+  if (isProductionEnvironment(env)) {
+    return notFoundInProductionResponse();
+  }
+
   const hasFirebaseApiKey = !!env.FIREBASE_API_KEY;
   const hasStripePublishableKey = !!env.STRIPE_PUBLISHABLE_KEY;
   const hasStripeSecretKey = !!env.STRIPE_SECRET_KEY;
@@ -15,6 +21,11 @@ export async function onRequest({ env }) {
       frontendUrl: env.FRONTEND_URL || 'NOT_SET',
       timestamp: new Date().toISOString(),
     }),
-    { headers: { 'Content-Type': 'application/json' } }
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store'
+      }
+    }
   );
 }

--- a/app/functions/stripe-key-test.js
+++ b/app/functions/stripe-key-test.js
@@ -1,4 +1,10 @@
+import { isProductionEnvironment, notFoundInProductionResponse } from './_lib/debug-access.js';
+
 export async function onRequest({ env }) {
+  if (isProductionEnvironment(env)) {
+    return notFoundInProductionResponse();
+  }
+
   const stripeSecretKey = env.STRIPE_SECRET_KEY || 'NOT_SET';
   const stripeKeyType = stripeSecretKey.startsWith('sk_test_') ? 'TEST' : (stripeSecretKey.startsWith('sk_live_') ? 'LIVE' : 'UNKNOWN');
 
@@ -9,6 +15,11 @@ export async function onRequest({ env }) {
       stripeKeyType,
       timestamp: new Date().toISOString(),
     }),
-    { headers: { 'Content-Type': 'application/json' } }
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        'Cache-Control': 'no-store'
+      }
+    }
   );
 }

--- a/app/package.json
+++ b/app/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev -p 3003",
     "build": "next build",
-    "postbuild": "cp -f public/_redirects out/_redirects && cp -f public/_headers out/_headers && cp -f ../index.html out/index.html && (cp -f ../*.html out/ 2>/dev/null || true) && cp -r ../css out/ && cp -r ../js out/ && cp -r ../assets out/",
+    "postbuild": "cp -f public/_redirects out/_redirects && cp -f public/_headers out/_headers && find .. -maxdepth 1 -type f -name '*.html' ! -name 'index.html' -exec cp -f {} out/ \\; && cp -r ../css out/ && cp -r ../js out/ && cp -r ../assets out/",
     "start": "next start",
     "export": "next build && next export",
     "deploy": "wrangler pages deploy out",

--- a/app/public/_redirects
+++ b/app/public/_redirects
@@ -10,6 +10,10 @@
 /auth/action   /auth/action/index.html   200
 /auth/action/   /auth/action/index.html   200
 
+# App root should go to the real login flow, not the legacy landing page
+/   /login   302
+/index.html   /login   301
+
 # Redirect deleted pages to account settings
 /add-card   /account-setting.html   301
 /add-card.html   /account-setting.html   301

--- a/app/src/pages/index.tsx
+++ b/app/src/pages/index.tsx
@@ -9,88 +9,34 @@ export default function Home() {
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, (user) => {
-      if (user) {
-        // User is signed in, redirect to dashboard
-        router.push('/dashboard')
-      }
-      // If user is not signed in, stay on landing page
+      router.replace(user ? '/dashboard' : '/login')
     })
 
     return () => unsubscribe()
   }, [router])
 
-  // Use the same favicon for all tabs
-  useEffect(() => {
-    const FAVICON = '/assets/jobhackai_icon_only_128.png'
-
-    const updateFavicon = () => {
-      const existingFavicons = document.querySelectorAll('link[rel="icon"], link[rel="apple-touch-icon"]')
-      existingFavicons.forEach(link => link.remove())
-
-      const faviconLink = document.createElement('link')
-      faviconLink.rel = 'icon'
-      faviconLink.type = 'image/png'
-      faviconLink.href = FAVICON
-      document.head.appendChild(faviconLink)
-
-      const appleTouchLink = document.createElement('link')
-      appleTouchLink.rel = 'apple-touch-icon'
-      appleTouchLink.href = FAVICON
-      document.head.appendChild(appleTouchLink)
-    }
-
-    updateFavicon()
-  }, [])
-
   return (
     <>
       <Head>
-        <title>JobHackAI</title>
-        <meta name="description" content="Optimize your resume for ATS systems and land more interviews" />
+        <title>Redirecting | JobHackAI</title>
+        <meta name="description" content="Redirecting to the JobHackAI app" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="robots" content="noindex, nofollow" />
         <link rel="icon" type="image/png" href="/assets/jobhackai_icon_only_128.png" />
         <link rel="apple-touch-icon" href="/assets/jobhackai_icon_only_128.png" />
       </Head>
-      
-      <main className="container">
-        <div className="hero">
-          <h1>Welcome to JobHackAI</h1>
-          <p>Your ATS-optimized resume starts here</p>
-          
-          <div className="auth-section">
-            <button 
-              className="btn-primary"
-              onClick={() => router.push('/dashboard')}
-            >
-              Get Started
-            </button>
-            <button 
-              className="btn-secondary"
-              onClick={() => router.push('/dashboard')}
-            >
-              Sign In
-            </button>
-          </div>
-
-          <div className="features">
-            <div className="feature-card">
-              <h3>ATS Resume Scoring</h3>
-              <p>Get your resume scored for ATS compatibility and receive detailed feedback on how to improve.</p>
-            </div>
-            <div className="feature-card">
-              <h3>Resume Feedback</h3>
-              <p>AI-powered feedback system that helps you optimize your resume for maximum impact.</p>
-            </div>
-            <div className="feature-card">
-              <h3>Cover Letter Generator</h3>
-              <p>Create personalized cover letters for any job posting with our AI-powered generator.</p>
-            </div>
-            <div className="feature-card">
-              <h3>Interview Questions</h3>
-              <p>Practice with AI-generated interview questions tailored to your target role.</p>
-            </div>
-          </div>
-        </div>
+      <main
+        style={{
+          minHeight: '100vh',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          fontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif',
+          color: '#1f2937',
+          background: '#f8fafc'
+        }}
+      >
+        <p>Redirecting to the app...</p>
       </main>
     </>
   )


### PR DESCRIPTION
## Summary
- Redirect `app.jobhackai.io/` to the real `/login` entry point and replace the stale exported root page with a lightweight redirect shell.
- Stop copying the legacy repo-root `index.html` into the app export so the old landing page cannot come back in production.
- Gate exposed debug/test routes behind a shared production check and return `404` for the live prod endpoints.

## Testing
- `npm --prefix app ci`
- `npm --prefix app run build`
- Node ESM import check for the changed Cloudflare Pages function modules

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes production request routing/redirect behavior and adds middleware-level 404 gating for several paths, which could inadvertently block legitimate traffic if paths/env detection are wrong.
> 
> **Overview**
> **Production now hides debug/test surfaces and fixes root routing.** A shared `debug-access` helper is introduced and used by middleware + several functions to return a `404` (with consistent security headers and `no-store`) for known debug/test routes when `ENVIRONMENT` is `prod`/`production`.
> 
> The app root is redirected to `/login` via `_redirects`, and `pages/index.tsx` is simplified into a lightweight auth-based redirect shell (no landing page content). The export `postbuild` script is adjusted to stop copying the repo-root `index.html` into `out/`, preventing the legacy landing page from reappearing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a651bd857efa31d0f1b692991225795109810a4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->