### PR TITLE
Fix passive auth cleanup

### DIFF
--- a/404.html
+++ b/404.html
@@ -160,9 +160,13 @@
       }
       const localAuthFlag = safeGet(localStorage, 'user-authenticated');
       const sessionAuthFlag = safeGet(sessionStorage, 'user-authenticated');
-      const resolvedStoredAuth = (localAuthFlag === 'false' || sessionAuthFlag === 'false')
-        ? 'false'
-        : ((sessionAuthFlag === 'true' || localAuthFlag === 'true') ? 'true' : null);
+      const resolvedStoredAuth = sessionAuthFlag === 'true'
+        ? 'true'
+        : (sessionAuthFlag === 'false'
+            ? 'false'
+            : (localAuthFlag === 'false'
+                ? 'false'
+                : ((localAuthFlag === 'true') ? 'true' : null)));
       const isAuthenticated = resolvedStoredAuth === 'true' || (resolvedStoredAuth !== 'false' && hasFirebaseAuthKeys());
       if (isAuthenticated) {
         cta.textContent = 'Go to dashboard';

--- a/app/tests/e2e/account-settings.spec.js
+++ b/app/tests/e2e/account-settings.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { waitForAuthReady, getAuthToken } = require('../helpers/auth-helpers');
 
 async function hasReadOnlyAccountSettingsBundle(page) {

--- a/app/tests/e2e/auth.spec.js
+++ b/app/tests/e2e/auth.spec.js
@@ -26,9 +26,9 @@ test.describe('Authentication', () => {
     try {
       const page = await context.newPage();
 
-      // DEBUG: surface any JS errors / console output from the login page so
-      // failures like a silently-caught init error in login-page.js show up in
-      // CI logs instead of only manifesting as a native GET form submission.
+      // Surface browser-side errors in CI logs so a regression in login-page.js
+      // (silently-caught init errors, module fetch failures) is never invisible
+      // again.
       page.on('pageerror', (err) => {
         console.log('[BROWSER pageerror]', err.message, '\n', err.stack);
       });
@@ -55,20 +55,34 @@ test.describe('Authentication', () => {
         throw new Error('TEST_EMAIL and TEST_PASSWORD environment variables must be set');
       }
 
-      // DEBUG: report whether login-page.js actually attached its submit
-      // handler. If `hasSubmitHandler` is false at submit time, the form will
-      // fall back to a native GET and credentials will land in the URL.
-      const preSubmitState = await page.evaluate(() => {
-        const form = document.getElementById('loginForm');
-        return {
-          formExists: !!form,
-          formDisplay: form ? getComputedStyle(form).display : null,
-          hasFirebaseAuthManager: typeof window.FirebaseAuthManager !== 'undefined',
-          hasAuthPersistence: typeof window.JobHackAIAuthPersistence !== 'undefined',
-          readyState: document.readyState,
-        };
-      });
-      console.log('[LOGIN TEST] pre-submit state:', JSON.stringify(preSubmitState));
+      // Ensure login-page.js actually executed. On fresh browser contexts,
+      // Cloudflare Pages' injected Early Hints preload uses credentials:include
+      // while <script type="module"> fetches with credentials:omit; on a cold
+      // CDN connection the mismatch can cause Chromium to abort the module
+      // fetch (net::ERR_ABORTED). The DOM still shows the form, but no submit
+      // handler is attached, so requestSubmit() falls back to a native GET with
+      // credentials in the URL. Reload once if the auth module didn't load --
+      // on the second visit CF has a warm connection and the script loads.
+      const authModuleLoaded = async () => {
+        try {
+          await page.waitForFunction(
+            () => typeof window.FirebaseAuthManager !== 'undefined',
+            null,
+            { timeout: 8000 }
+          );
+          return true;
+        } catch (_) {
+          return false;
+        }
+      };
+      if (!(await authModuleLoaded())) {
+        console.warn('[LOGIN TEST] FirebaseAuthManager missing after first load; reloading to recover from aborted module fetch');
+        await page.reload();
+        await page.waitForSelector('#loginEmail');
+        if (!(await authModuleLoaded())) {
+          throw new Error('login-page.js did not initialize after reload; submit handler not attached');
+        }
+      }
 
       // Fill credentials
       await page.fill('#loginEmail', TEST_EMAIL);

--- a/app/tests/e2e/auth.spec.js
+++ b/app/tests/e2e/auth.spec.js
@@ -26,6 +26,22 @@ test.describe('Authentication', () => {
     try {
       const page = await context.newPage();
 
+      // DEBUG: surface any JS errors / console output from the login page so
+      // failures like a silently-caught init error in login-page.js show up in
+      // CI logs instead of only manifesting as a native GET form submission.
+      page.on('pageerror', (err) => {
+        console.log('[BROWSER pageerror]', err.message, '\n', err.stack);
+      });
+      page.on('console', (msg) => {
+        const type = msg.type();
+        if (type === 'error' || type === 'warning') {
+          console.log(`[BROWSER ${type}]`, msg.text());
+        }
+      });
+      page.on('requestfailed', (req) => {
+        console.log('[BROWSER requestfailed]', req.url(), req.failure()?.errorText);
+      });
+
       await page.goto('/login');
 
       // Wait for login form using actual selector
@@ -38,6 +54,21 @@ test.describe('Authentication', () => {
       if (!TEST_EMAIL || !TEST_PASSWORD) {
         throw new Error('TEST_EMAIL and TEST_PASSWORD environment variables must be set');
       }
+
+      // DEBUG: report whether login-page.js actually attached its submit
+      // handler. If `hasSubmitHandler` is false at submit time, the form will
+      // fall back to a native GET and credentials will land in the URL.
+      const preSubmitState = await page.evaluate(() => {
+        const form = document.getElementById('loginForm');
+        return {
+          formExists: !!form,
+          formDisplay: form ? getComputedStyle(form).display : null,
+          hasFirebaseAuthManager: typeof window.FirebaseAuthManager !== 'undefined',
+          hasAuthPersistence: typeof window.JobHackAIAuthPersistence !== 'undefined',
+          readyState: document.readyState,
+        };
+      });
+      console.log('[LOGIN TEST] pre-submit state:', JSON.stringify(preSubmitState));
 
       // Fill credentials
       await page.fill('#loginEmail', TEST_EMAIL);

--- a/app/tests/e2e/auth.spec.js
+++ b/app/tests/e2e/auth.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { submitForm, waitForAuthReady } = require('../helpers/auth-helpers');
 
 function generateUniqueSignupEmail() {

--- a/app/tests/e2e/billing.spec.js
+++ b/app/tests/e2e/billing.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { getAuthToken, postStripeCheckout } = require('../helpers/auth-helpers');
 
 async function fetchPlanData(page, token) {

--- a/app/tests/e2e/error-handling.spec.js
+++ b/app/tests/e2e/error-handling.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { waitForAuthReady } = require('../helpers/auth-helpers');
 
 test.describe('Error Handling', () => {

--- a/app/tests/e2e/feedback-api.spec.js
+++ b/app/tests/e2e/feedback-api.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { waitForAuthReady } = require('../helpers/auth-helpers');
 
 /**

--- a/app/tests/e2e/full-app-check.spec.js
+++ b/app/tests/e2e/full-app-check.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const path = require('path');
 const { waitForAuthReady, getAuthToken, postStripeCheckout } = require('../helpers/auth-helpers');
 

--- a/app/tests/e2e/marketing-auth.spec.js
+++ b/app/tests/e2e/marketing-auth.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 
 const MARKETING_BASE = process.env.MARKETING_BASE_URL || 'https://jobhackai.io';
 const AUTH_HANDOFF_SESSION_KEY = 'jhai_auth_handoff';

--- a/app/tests/e2e/plan-access.spec.js
+++ b/app/tests/e2e/plan-access.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { getAuthToken } = require('../helpers/auth-helpers');
 
 test.describe('Plan-Based Access Control', () => {

--- a/app/tests/e2e/resume-feedback.spec.js
+++ b/app/tests/e2e/resume-feedback.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const path = require('path');
 const fs = require('fs');
 

--- a/app/tests/e2e/smoke-real-api.spec.js
+++ b/app/tests/e2e/smoke-real-api.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { getAuthToken, waitForAuthReady } = require('../helpers/auth-helpers');
 
 const ALLOWED_PLANS = new Set(['free', 'trial', 'essential', 'pro', 'premium']);

--- a/app/tests/e2e/terms-checkpoints.spec.js
+++ b/app/tests/e2e/terms-checkpoints.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { submitForm } = require('../helpers/auth-helpers');
 
 function generateUniqueSignupEmail() {

--- a/app/tests/fixtures/auth-fixture.js
+++ b/app/tests/fixtures/auth-fixture.js
@@ -1,0 +1,77 @@
+/**
+ * Playwright test fixture that restores sessionStorage on every context.
+ *
+ * Why this exists: Firebase Auth is configured with browserSessionPersistence,
+ * so auth shards + tokens live in sessionStorage. Playwright's storageState()
+ * only persists cookies + localStorage, so a fresh test context starts with an
+ * empty sessionStorage -- Firebase fires onAuthStateChanged(null) and
+ * static-auth-guard.js redirects protected pages to /login before the test can
+ * interact with them.
+ *
+ * global-setup.js captures sessionStorage after login into
+ * .auth/session-storage.json. This fixture reads that file and injects an
+ * addInitScript on each context so sessionStorage is repopulated before page
+ * scripts run. Tests that want an unauthenticated context can still pass
+ * storageState: undefined to browser.newContext() -- the init script is a
+ * no-op when keys are already present and only restores the saved entries,
+ * which is fine because those tests explicitly clear storage themselves.
+ */
+
+const { test: base, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+
+const sessionStoragePath = path.join(__dirname, '..', '.auth', 'session-storage.json');
+
+function loadSessionStorageFile() {
+  try {
+    if (!fs.existsSync(sessionStoragePath)) return null;
+    const raw = fs.readFileSync(sessionStoragePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.origins)) return null;
+    return parsed;
+  } catch (err) {
+    console.warn('[auth-fixture] Failed to load session-storage.json:', err.message);
+    return null;
+  }
+}
+
+const sessionStorageData = loadSessionStorageFile();
+
+const test = base.extend({
+  context: async ({ context }, use) => {
+    if (sessionStorageData && sessionStorageData.origins.length > 0) {
+      await context.addInitScript((data) => {
+        try {
+          if (!data || !Array.isArray(data.origins)) return;
+          const currentOrigin = window.location.origin;
+          // Don't re-hydrate sessionStorage if the user has explicitly logged
+          // out in this context (logout writes localStorage['user-authenticated']
+          // = 'false' and/or sets 'force-logged-out'). Re-populating Firebase
+          // shards here would silently re-authenticate the user in a new tab
+          // and break logout tests.
+          try {
+            if (localStorage.getItem('user-authenticated') === 'false') return;
+            const forcedLogoutTs = parseInt(localStorage.getItem('force-logged-out') || '0', 10);
+            if (forcedLogoutTs && (Date.now() - forcedLogoutTs) < 60000) return;
+          } catch (_) {}
+          for (const origin of data.origins) {
+            if (!origin || origin.origin !== currentOrigin) continue;
+            const entries = Array.isArray(origin.sessionStorage) ? origin.sessionStorage : [];
+            for (const entry of entries) {
+              if (!entry || typeof entry.name !== 'string') continue;
+              try {
+                if (sessionStorage.getItem(entry.name) == null) {
+                  sessionStorage.setItem(entry.name, entry.value || '');
+                }
+              } catch (_) { /* storage unavailable */ }
+            }
+          }
+        } catch (_) { /* no-op */ }
+      }, sessionStorageData);
+    }
+    await use(context);
+  },
+});
+
+module.exports = { test, expect };

--- a/app/tests/fixtures/global-setup.js
+++ b/app/tests/fixtures/global-setup.js
@@ -204,13 +204,35 @@ async function globalSetup() {
     if (!fs.existsSync(authDir)) {
       fs.mkdirSync(authDir, { recursive: true });
     }
-    
-    // Save auth state
-    await context.storageState({ 
-      path: path.join(authDir, 'user.json') 
+
+    // Save auth state (cookies + localStorage)
+    await context.storageState({
+      path: path.join(authDir, 'user.json')
     });
-    
-    console.log('✅ Authentication successful, state saved');
+
+    // Firebase uses browserSessionPersistence, so auth shards + tokens live in
+    // sessionStorage. Playwright's storageState() does not persist sessionStorage,
+    // so we capture it separately and restore it via auth-fixture.js on context
+    // creation. Without this, protected pages redirect to /login in test tabs
+    // because Firebase has no session to restore.
+    const sessionStorageEntries = await page.evaluate(() => {
+      const entries = [];
+      try {
+        for (let i = 0; i < sessionStorage.length; i++) {
+          const name = sessionStorage.key(i);
+          if (name == null) continue;
+          entries.push({ name, value: sessionStorage.getItem(name) || '' });
+        }
+      } catch (_) {}
+      return entries;
+    });
+    const sessionOrigin = new URL(page.url()).origin;
+    const sessionStoragePath = path.join(authDir, 'session-storage.json');
+    fs.writeFileSync(sessionStoragePath, JSON.stringify({
+      origins: [{ origin: sessionOrigin, sessionStorage: sessionStorageEntries }]
+    }, null, 2));
+
+    console.log(`✅ Authentication successful, state saved (${sessionStorageEntries.length} sessionStorage keys)`);
     
   } catch (error) {
     const currentURL = page.url();

--- a/dashboard.html
+++ b/dashboard.html
@@ -866,6 +866,19 @@
       return _dashboardAuthPersistence.hasFirebaseAuthPersistence();
     }
 
+    function hasSessionTokens() {
+      try {
+        return !!(
+          sessionStorage.getItem('firebase_id_token') ||
+          sessionStorage.getItem('firebase_refresh_token') ||
+          sessionStorage.getItem('linkedin_oidc_id_token') ||
+          sessionStorage.getItem('linkedin_pending_init')
+        );
+      } catch (_) {
+        return false;
+      }
+    }
+
     // --- ENHANCED AUTHENTICATION CHECK ---
     async function checkAuthentication() {
       console.log('🔧 dashboard.html VERSION: fix-auth-cache-loop-v1 - ' + new Date().toISOString());
@@ -883,27 +896,14 @@
       }
 
       const authManager = window.FirebaseAuthManager;
-      let isAuthInStorage = false;
-      let hasPersistedFirebaseAuth = false;
-      let hasTokens = false;
-      let currentIsAuthInStorage = false;
-      let currentHasPersistedFirebaseAuth = false;
-      let currentHasTokens = false;
 
-      isAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
-      hasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
+      const isAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
+      const hasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
+      const hasTokens = hasSessionTokens();
 
-      try {
-        hasTokens = !!(
-          sessionStorage.getItem('firebase_id_token') ||
-          sessionStorage.getItem('firebase_refresh_token') ||
-          sessionStorage.getItem('linkedin_oidc_id_token') ||
-          sessionStorage.getItem('linkedin_pending_init')
-        );
-      } catch (_) {}
-      currentIsAuthInStorage = isAuthInStorage;
-      currentHasPersistedFirebaseAuth = hasPersistedFirebaseAuth;
-      currentHasTokens = hasTokens;
+      let currentIsAuthInStorage = isAuthInStorage;
+      let currentHasPersistedFirebaseAuth = hasPersistedFirebaseAuth;
+      let currentHasTokens = hasTokens;
 
       if (isAuthInStorage || hasPersistedFirebaseAuth || hasTokens) {
         await waitForFirebaseAuthReady(30000);
@@ -911,15 +911,7 @@
         // to false while localStorage can remain stale true (browserSessionPersistence / new tab).
         currentIsAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
         currentHasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
-        currentHasTokens = false;
-        try {
-          currentHasTokens = !!(
-            sessionStorage.getItem('firebase_id_token') ||
-            sessionStorage.getItem('firebase_refresh_token') ||
-            sessionStorage.getItem('linkedin_oidc_id_token') ||
-            sessionStorage.getItem('linkedin_pending_init')
-          );
-        } catch (_) {}
+        currentHasTokens = hasSessionTokens();
         if (currentIsAuthInStorage || currentHasPersistedFirebaseAuth || currentHasTokens) {
           await waitForFirebaseUser(authManager, 30000);
         }
@@ -927,15 +919,7 @@
         await waitForFirebaseAuthReady(5000);
         currentIsAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
         currentHasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
-        currentHasTokens = false;
-        try {
-          currentHasTokens = !!(
-            sessionStorage.getItem('firebase_id_token') ||
-            sessionStorage.getItem('firebase_refresh_token') ||
-            sessionStorage.getItem('linkedin_oidc_id_token') ||
-            sessionStorage.getItem('linkedin_pending_init')
-          );
-        } catch (_) {}
+        currentHasTokens = hasSessionTokens();
       }
 
       const user = authManager.getCurrentUser?.();

--- a/dashboard.html
+++ b/dashboard.html
@@ -886,6 +886,9 @@
       let isAuthInStorage = false;
       let hasPersistedFirebaseAuth = false;
       let hasTokens = false;
+      let currentIsAuthInStorage = false;
+      let currentHasPersistedFirebaseAuth = false;
+      let currentHasTokens = false;
 
       isAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
       hasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
@@ -898,33 +901,47 @@
           sessionStorage.getItem('linkedin_pending_init')
         );
       } catch (_) {}
+      currentIsAuthInStorage = isAuthInStorage;
+      currentHasPersistedFirebaseAuth = hasPersistedFirebaseAuth;
+      currentHasTokens = hasTokens;
 
       if (isAuthInStorage || hasPersistedFirebaseAuth || hasTokens) {
         await waitForFirebaseAuthReady(30000);
         // Re-read after auth is ready: passive cleanup sets sessionStorage user-authenticated
         // to false while localStorage can remain stale true (browserSessionPersistence / new tab).
-        const isAuthInStorageAfterReady = getDashboardStoredValue('user-authenticated') === 'true';
-        const hasPersistedFirebaseAuthAfterReady = hasDashboardFirebaseAuthPersistence();
-        let hasTokensAfterReady = false;
+        currentIsAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
+        currentHasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
+        currentHasTokens = false;
         try {
-          hasTokensAfterReady = !!(
+          currentHasTokens = !!(
             sessionStorage.getItem('firebase_id_token') ||
             sessionStorage.getItem('firebase_refresh_token') ||
             sessionStorage.getItem('linkedin_oidc_id_token') ||
             sessionStorage.getItem('linkedin_pending_init')
           );
         } catch (_) {}
-        if (isAuthInStorageAfterReady || hasPersistedFirebaseAuthAfterReady || hasTokensAfterReady) {
+        if (currentIsAuthInStorage || currentHasPersistedFirebaseAuth || currentHasTokens) {
           await waitForFirebaseUser(authManager, 30000);
         }
       } else {
         await waitForFirebaseAuthReady(5000);
+        currentIsAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
+        currentHasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
+        currentHasTokens = false;
+        try {
+          currentHasTokens = !!(
+            sessionStorage.getItem('firebase_id_token') ||
+            sessionStorage.getItem('firebase_refresh_token') ||
+            sessionStorage.getItem('linkedin_oidc_id_token') ||
+            sessionStorage.getItem('linkedin_pending_init')
+          );
+        } catch (_) {}
       }
 
       const user = authManager.getCurrentUser?.();
       if (!user || !user.email) {
         const authReady = authManager.isAuthReady?.() || window.__firebaseAuthReadyFired;
-        if (authReady || (!isAuthInStorage && !hasPersistedFirebaseAuth)) {
+        if (authReady || (!currentIsAuthInStorage && !currentHasPersistedFirebaseAuth && !currentHasTokens)) {
           console.error('❌ No Firebase user available');
           window.location.href = 'login.html';
           return false;

--- a/js/auth-persistence.js
+++ b/js/auth-persistence.js
@@ -16,7 +16,8 @@
 
   /**
    * Resolve the effective stored auth flag for the current tab.
-   * Explicit false in either storage should win over stale shared true values.
+   * Same-tab session truth should win over a shared localStorage false from
+   * passive cleanup in another tab, while explicit false still wins otherwise.
    */
   function getResolvedStoredAuthFlagValue() {
     var sessionValue = null;
@@ -24,8 +25,10 @@
     try { sessionValue = sessionStorage.getItem('user-authenticated'); } catch (_) {}
     try { localValue = localStorage.getItem('user-authenticated'); } catch (_) {}
 
-    if (localValue === 'false' || sessionValue === 'false') return 'false';
-    if (sessionValue === 'true' || localValue === 'true') return 'true';
+    if (sessionValue === 'true') return 'true';
+    if (sessionValue === 'false') return 'false';
+    if (localValue === 'false') return 'false';
+    if (localValue === 'true') return 'true';
     return null;
   }
 

--- a/js/firebase-auth.js
+++ b/js/firebase-auth.js
@@ -464,11 +464,12 @@ class AuthManager {
     try {
       const cleared = [];
       const isExplicitSignOut = reason === 'firebase-auth-signed-out' && this._explicitSignOutInProgress;
-      // Passive onAuthStateChanged(null) clears this tab's sessionStorage; with browserSessionPersistence,
-      // Firebase does not use localStorage for the live session, but legacy local firebase:authUser:* keys
-      // must be removed so static-auth-guard.js does not treat a new tab as authenticated.
+      // Only explicit sign-out should write localStorage 'user-authenticated' = 'false'. Passive
+      // onAuthStateChanged(null) (e.g., a new tab under browserSessionPersistence with no session)
+      // must not mutate the shared key, because static-auth-guard.js redirects every other tab to
+      // /login.html on that storage event, logging authenticated users out of protected pages.
       try {
-        if (reason === 'firebase-auth-signed-out') {
+        if (isExplicitSignOut) {
           localStorage.setItem('user-authenticated', 'false');
         }
       } catch (_) {}

--- a/js/firebase-auth.js
+++ b/js/firebase-auth.js
@@ -468,7 +468,7 @@ class AuthManager {
       // Firebase does not use localStorage for the live session, but legacy local firebase:authUser:* keys
       // must be removed so static-auth-guard.js does not treat a new tab as authenticated.
       try {
-        if (isExplicitSignOut) {
+        if (reason === 'firebase-auth-signed-out') {
           localStorage.setItem('user-authenticated', 'false');
         }
       } catch (_) {}

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -557,8 +557,10 @@ function getResolvedStoredAuthFlagValue() {
   let localValue = null;
   try { sessionValue = sessionStorage.getItem('user-authenticated'); } catch (_) {}
   try { localValue = localStorage.getItem('user-authenticated'); } catch (_) {}
-  if (localValue === 'false' || sessionValue === 'false') return 'false';
-  if (sessionValue === 'true' || localValue === 'true') return 'true';
+  if (sessionValue === 'true') return 'true';
+  if (sessionValue === 'false') return 'false';
+  if (localValue === 'false') return 'false';
+  if (localValue === 'true') return 'true';
   return null;
 }
 

--- a/js/page-access-control.js
+++ b/js/page-access-control.js
@@ -158,8 +158,10 @@ window.PageAccessControl = (function () {
         var sessionValue = null;
         try { localValue = localStorage.getItem('user-authenticated'); } catch (_) {}
         try { sessionValue = sessionStorage.getItem('user-authenticated'); } catch (_) {}
-        if (localValue === 'false' || sessionValue === 'false') return 'false';
-        if (sessionValue === 'true' || localValue === 'true') return 'true';
+        if (sessionValue === 'true') return 'true';
+        if (sessionValue === 'false') return 'false';
+        if (localValue === 'false') return 'false';
+        if (localValue === 'true') return 'true';
         return null;
       }
 

--- a/login.html
+++ b/login.html
@@ -442,7 +442,8 @@
   <script src="js/auth-persistence.js"></script>
   <script src="js/navigation.js?v=20260208-1" defer></script>
   <script src="js/universal-logout.js?v=20260208-1" defer></script>
-  <script src="js/main.js?v=20251006-1" type="module"></script>
+  <!-- crossorigin matches Cloudflare Pages' injected Early Hints preload credentials mode; without it, modules on fresh contexts intermittently fetch as ERR_ABORTED. -->
+  <script src="js/main.js?v=20251006-1" type="module" crossorigin="anonymous"></script>
   <!-- Initialize navigation early to render correct visitor nav with CTA -->
   <script>
     if (window.JobHackAINavigation && typeof window.JobHackAINavigation.initializeNavigation === 'function') {
@@ -456,7 +457,7 @@
     }
   </script>
   <!-- Firebase Authentication -->
-  <script src="js/login-page.js?v=20251011-1" type="module"></script>
+  <script src="js/login-page.js?v=20251011-1" type="module" crossorigin="anonymous"></script>
   
   <!-- Forgot Password Modal -->
   <div id="forgotPasswordOverlay" style="

--- a/verify-email.html
+++ b/verify-email.html
@@ -127,9 +127,10 @@
   <!-- Core scripts only (no navigation.js) -->
   <script src="js/redirect-tracer.js?v=1" defer></script>
   <script src="js/universal-logout.js?v=20260208-1" defer></script>
-  <script src="js/main.js?v=20251006-1" type="module"></script>
+  <!-- crossorigin matches Cloudflare Pages' injected Early Hints preload credentials mode; without it, modules on fresh contexts intermittently fetch as ERR_ABORTED. -->
+  <script src="js/main.js?v=20251006-1" type="module" crossorigin="anonymous"></script>
   <!-- Verification Flow Script -->
-  <script src="js/verify-email.js" type="module"></script>
+  <script src="js/verify-email.js" type="module" crossorigin="anonymous"></script>
   <script src="js/logo-link-env.js" defer></script>
   <script src="js/schedule-feedback-widget.js" defer></script>
 </body>


### PR DESCRIPTION
Brings `dev0` up to date with passive auth cleanup changes.

Includes updates to `js/auth-persistence.js`, `js/firebase-auth.js`, `js/navigation.js`, `js/page-access-control.js`, plus related wiring in `404.html` and `dashboard.html`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication state reconciliation and logout/redirect behavior across tabs; mistakes could lock users out or leave stale auth state, though changes are localized and covered by updated E2E setup.
> 
> **Overview**
> Fixes cross-tab auth false positives/negatives by changing `user-authenticated` resolution to **prefer same-tab `sessionStorage` over shared `localStorage`**, preventing passive cleanup in one tab from forcing other authenticated tabs to redirect.
> 
> Updates Firebase passive cleanup to **avoid writing `localStorage['user-authenticated']='false'` unless it’s an explicit sign-out**, adjusts dashboard/404 access checks accordingly, and adds `crossorigin="anonymous"` to module scripts on `login.html`/`verify-email.html` to reduce intermittent Cloudflare Early Hints module fetch aborts.
> 
> E2E harness is hardened: tests now use a shared `auth-fixture` that restores captured `sessionStorage` (saved in `global-setup.js`) and the login test adds extra browser-side logging + a reload fallback when the auth module fails to initialize.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af0bc6afed5944c60f2c82ceda7e8209de437fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->