### PR TITLE
fix: harden app auth state and post-login surfaces

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -866,6 +866,19 @@
       return _dashboardAuthPersistence.hasFirebaseAuthPersistence();
     }
 
+    function hasSessionTokens() {
+      try {
+        return !!(
+          sessionStorage.getItem('firebase_id_token') ||
+          sessionStorage.getItem('firebase_refresh_token') ||
+          sessionStorage.getItem('linkedin_oidc_id_token') ||
+          sessionStorage.getItem('linkedin_pending_init')
+        );
+      } catch (_) {
+        return false;
+      }
+    }
+
     // --- ENHANCED AUTHENTICATION CHECK ---
     async function checkAuthentication() {
       console.log('🔧 dashboard.html VERSION: fix-auth-cache-loop-v1 - ' + new Date().toISOString());
@@ -883,27 +896,14 @@
       }
 
       const authManager = window.FirebaseAuthManager;
-      let isAuthInStorage = false;
-      let hasPersistedFirebaseAuth = false;
-      let hasTokens = false;
-      let currentIsAuthInStorage = false;
-      let currentHasPersistedFirebaseAuth = false;
-      let currentHasTokens = false;
 
-      isAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
-      hasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
+      const isAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
+      const hasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
+      const hasTokens = hasSessionTokens();
 
-      try {
-        hasTokens = !!(
-          sessionStorage.getItem('firebase_id_token') ||
-          sessionStorage.getItem('firebase_refresh_token') ||
-          sessionStorage.getItem('linkedin_oidc_id_token') ||
-          sessionStorage.getItem('linkedin_pending_init')
-        );
-      } catch (_) {}
-      currentIsAuthInStorage = isAuthInStorage;
-      currentHasPersistedFirebaseAuth = hasPersistedFirebaseAuth;
-      currentHasTokens = hasTokens;
+      let currentIsAuthInStorage = isAuthInStorage;
+      let currentHasPersistedFirebaseAuth = hasPersistedFirebaseAuth;
+      let currentHasTokens = hasTokens;
 
       if (isAuthInStorage || hasPersistedFirebaseAuth || hasTokens) {
         await waitForFirebaseAuthReady(30000);
@@ -911,15 +911,7 @@
         // to false while localStorage can remain stale true (browserSessionPersistence / new tab).
         currentIsAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
         currentHasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
-        currentHasTokens = false;
-        try {
-          currentHasTokens = !!(
-            sessionStorage.getItem('firebase_id_token') ||
-            sessionStorage.getItem('firebase_refresh_token') ||
-            sessionStorage.getItem('linkedin_oidc_id_token') ||
-            sessionStorage.getItem('linkedin_pending_init')
-          );
-        } catch (_) {}
+        currentHasTokens = hasSessionTokens();
         if (currentIsAuthInStorage || currentHasPersistedFirebaseAuth || currentHasTokens) {
           await waitForFirebaseUser(authManager, 30000);
         }
@@ -927,15 +919,7 @@
         await waitForFirebaseAuthReady(5000);
         currentIsAuthInStorage = getDashboardStoredValue('user-authenticated') === 'true';
         currentHasPersistedFirebaseAuth = hasDashboardFirebaseAuthPersistence();
-        currentHasTokens = false;
-        try {
-          currentHasTokens = !!(
-            sessionStorage.getItem('firebase_id_token') ||
-            sessionStorage.getItem('firebase_refresh_token') ||
-            sessionStorage.getItem('linkedin_oidc_id_token') ||
-            sessionStorage.getItem('linkedin_pending_init')
-          );
-        } catch (_) {}
+        currentHasTokens = hasSessionTokens();
       }
 
       const user = authManager.getCurrentUser?.();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication persistence and logout/redirect guards across multiple pages, which can cause accidental logouts or access if edge cases regress. Also introduces a strict site-wide CSP/HSTS that could break third-party scripts or asset loading if misconfigured.
> 
> **Overview**
> Improves auth-state reliability by introducing `js/auth-persistence.js` and updating multiple pages (e.g. `dashboard.html`, `account-setting.html`, `interview-questions.html`, `404.html`, `inactivity-tracker.js`, `login-page.js`) to resolve auth/plan state across `sessionStorage` + `localStorage` and detect Firebase shards safely, reducing cross-tab/session persistence race conditions and auth-cache loops.
> 
> Switches Firebase Auth persistence to `browserSessionPersistence`, adds more defensive cleanup on passive sign-out vs explicit logout, and makes account settings initial load *read-only* (no `sync-stripe-plan` mutation) while still hydrating plan UI from `billing-status` (with an added Playwright test to enforce this).
> 
> Applies stronger platform hardening by adding a shared `CONTENT_SECURITY_POLICY`, enabling HSTS, and configuring Cloudflare Pages `_headers` to send these security headers site-wide. Separately refreshes favicon handling/paths and defers some scripts, and replaces direct analytics/feedback widget loads with scheduled loaders on select pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0267c00d38de73af262110f1a09435ab2693d319. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->