### PR TITLE
fix: harden app auth state and post-login surfaces

### DIFF
--- a/js/firebase-auth.js
+++ b/js/firebase-auth.js
@@ -464,11 +464,12 @@ class AuthManager {
     try {
       const cleared = [];
       const isExplicitSignOut = reason === 'firebase-auth-signed-out' && this._explicitSignOutInProgress;
-      // Passive onAuthStateChanged(null) clears this tab's sessionStorage; with browserSessionPersistence,
-      // Firebase does not use localStorage for the live session, but legacy local firebase:authUser:* keys
-      // must be removed so static-auth-guard.js does not treat a new tab as authenticated.
+      // Only explicit sign-out should write localStorage 'user-authenticated' = 'false'. Passive
+      // onAuthStateChanged(null) (e.g., a new tab under browserSessionPersistence with no session)
+      // must not mutate the shared key, because static-auth-guard.js redirects every other tab to
+      // /login.html on that storage event, logging authenticated users out of protected pages.
       try {
-        if (reason === 'firebase-auth-signed-out') {
+        if (isExplicitSignOut) {
           localStorage.setItem('user-authenticated', 'false');
         }
       } catch (_) {}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches authentication persistence and auth-gating logic across multiple pages, so regressions could incorrectly log users out or grant/deny access. Also introduces a strict CSP/HSTS header set that could break third-party scripts/assets if the allowlist is incomplete.
> 
> **Overview**
> **Hardens auth persistence and gating across the app.** Firebase auth persistence is switched to `browserSessionPersistence`, and a new shared `js/auth-persistence.js` normalizes reads/writes across `sessionStorage` and `localStorage` to avoid cross-tab logout loops and stale auth flags.
> 
> **Makes protected pages more “same-tab” safe and reduces side effects.** `dashboard.html`, `account-setting.html`, `interview-questions.html`, `login-page.js`, and `inactivity-tracker.js` now rely on resolved auth evidence (including Firebase shard detection) and avoid writing shared `localStorage` "logged out" state on passive sign-out; account settings/dashboard also stop calling `/api/sync-stripe-plan` on load and instead hydrate UI from `billing-status` and emit `planChanged` locally (with an added E2E test ensuring the page remains read-only).
> 
> **Strengthens app-wide security and updates client assets.** Adds a unified Content Security Policy + `Strict-Transport-Security` in both functions (`STANDARD_SECURITY_HEADERS`) and Cloudflare Pages `_headers`, removes dashboard’s React-side dynamic favicon switching, updates favicon links/`dynamic-favicon.js` to new icon assets, and replaces direct `analytics.js`/`feedback-widget.js` includes on some pages with scheduled loaders (`schedule-analytics.js`/`schedule-feedback-widget.js`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a839861557885409732e04eba94cd64b3a2e6061. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->