### PR TITLE
fix: harden app auth state and post-login surfaces

### DIFF
--- a/app/tests/e2e/account-settings.spec.js
+++ b/app/tests/e2e/account-settings.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { waitForAuthReady, getAuthToken } = require('../helpers/auth-helpers');
 
 async function hasReadOnlyAccountSettingsBundle(page) {

--- a/app/tests/e2e/auth.spec.js
+++ b/app/tests/e2e/auth.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { submitForm, waitForAuthReady } = require('../helpers/auth-helpers');
 
 function generateUniqueSignupEmail() {

--- a/app/tests/e2e/billing.spec.js
+++ b/app/tests/e2e/billing.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { getAuthToken, postStripeCheckout } = require('../helpers/auth-helpers');
 
 async function fetchPlanData(page, token) {

--- a/app/tests/e2e/error-handling.spec.js
+++ b/app/tests/e2e/error-handling.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { waitForAuthReady } = require('../helpers/auth-helpers');
 
 test.describe('Error Handling', () => {

--- a/app/tests/e2e/feedback-api.spec.js
+++ b/app/tests/e2e/feedback-api.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { waitForAuthReady } = require('../helpers/auth-helpers');
 
 /**

--- a/app/tests/e2e/full-app-check.spec.js
+++ b/app/tests/e2e/full-app-check.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const path = require('path');
 const { waitForAuthReady, getAuthToken, postStripeCheckout } = require('../helpers/auth-helpers');
 

--- a/app/tests/e2e/marketing-auth.spec.js
+++ b/app/tests/e2e/marketing-auth.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 
 const MARKETING_BASE = process.env.MARKETING_BASE_URL || 'https://jobhackai.io';
 const AUTH_HANDOFF_SESSION_KEY = 'jhai_auth_handoff';

--- a/app/tests/e2e/plan-access.spec.js
+++ b/app/tests/e2e/plan-access.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { getAuthToken } = require('../helpers/auth-helpers');
 
 test.describe('Plan-Based Access Control', () => {

--- a/app/tests/e2e/resume-feedback.spec.js
+++ b/app/tests/e2e/resume-feedback.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const path = require('path');
 const fs = require('fs');
 

--- a/app/tests/e2e/smoke-real-api.spec.js
+++ b/app/tests/e2e/smoke-real-api.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { getAuthToken, waitForAuthReady } = require('../helpers/auth-helpers');
 
 const ALLOWED_PLANS = new Set(['free', 'trial', 'essential', 'pro', 'premium']);

--- a/app/tests/e2e/terms-checkpoints.spec.js
+++ b/app/tests/e2e/terms-checkpoints.spec.js
@@ -1,4 +1,4 @@
-const { test, expect } = require('@playwright/test');
+const { test, expect } = require('../fixtures/auth-fixture');
 const { submitForm } = require('../helpers/auth-helpers');
 
 function generateUniqueSignupEmail() {

--- a/app/tests/fixtures/auth-fixture.js
+++ b/app/tests/fixtures/auth-fixture.js
@@ -1,0 +1,77 @@
+/**
+ * Playwright test fixture that restores sessionStorage on every context.
+ *
+ * Why this exists: Firebase Auth is configured with browserSessionPersistence,
+ * so auth shards + tokens live in sessionStorage. Playwright's storageState()
+ * only persists cookies + localStorage, so a fresh test context starts with an
+ * empty sessionStorage -- Firebase fires onAuthStateChanged(null) and
+ * static-auth-guard.js redirects protected pages to /login before the test can
+ * interact with them.
+ *
+ * global-setup.js captures sessionStorage after login into
+ * .auth/session-storage.json. This fixture reads that file and injects an
+ * addInitScript on each context so sessionStorage is repopulated before page
+ * scripts run. Tests that want an unauthenticated context can still pass
+ * storageState: undefined to browser.newContext() -- the init script is a
+ * no-op when keys are already present and only restores the saved entries,
+ * which is fine because those tests explicitly clear storage themselves.
+ */
+
+const { test: base, expect } = require('@playwright/test');
+const path = require('path');
+const fs = require('fs');
+
+const sessionStoragePath = path.join(__dirname, '..', '.auth', 'session-storage.json');
+
+function loadSessionStorageFile() {
+  try {
+    if (!fs.existsSync(sessionStoragePath)) return null;
+    const raw = fs.readFileSync(sessionStoragePath, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (!parsed || !Array.isArray(parsed.origins)) return null;
+    return parsed;
+  } catch (err) {
+    console.warn('[auth-fixture] Failed to load session-storage.json:', err.message);
+    return null;
+  }
+}
+
+const sessionStorageData = loadSessionStorageFile();
+
+const test = base.extend({
+  context: async ({ context }, use) => {
+    if (sessionStorageData && sessionStorageData.origins.length > 0) {
+      await context.addInitScript((data) => {
+        try {
+          if (!data || !Array.isArray(data.origins)) return;
+          const currentOrigin = window.location.origin;
+          // Don't re-hydrate sessionStorage if the user has explicitly logged
+          // out in this context (logout writes localStorage['user-authenticated']
+          // = 'false' and/or sets 'force-logged-out'). Re-populating Firebase
+          // shards here would silently re-authenticate the user in a new tab
+          // and break logout tests.
+          try {
+            if (localStorage.getItem('user-authenticated') === 'false') return;
+            const forcedLogoutTs = parseInt(localStorage.getItem('force-logged-out') || '0', 10);
+            if (forcedLogoutTs && (Date.now() - forcedLogoutTs) < 60000) return;
+          } catch (_) {}
+          for (const origin of data.origins) {
+            if (!origin || origin.origin !== currentOrigin) continue;
+            const entries = Array.isArray(origin.sessionStorage) ? origin.sessionStorage : [];
+            for (const entry of entries) {
+              if (!entry || typeof entry.name !== 'string') continue;
+              try {
+                if (sessionStorage.getItem(entry.name) == null) {
+                  sessionStorage.setItem(entry.name, entry.value || '');
+                }
+              } catch (_) { /* storage unavailable */ }
+            }
+          }
+        } catch (_) { /* no-op */ }
+      }, sessionStorageData);
+    }
+    await use(context);
+  },
+});
+
+module.exports = { test, expect };

--- a/app/tests/fixtures/global-setup.js
+++ b/app/tests/fixtures/global-setup.js
@@ -204,13 +204,35 @@ async function globalSetup() {
     if (!fs.existsSync(authDir)) {
       fs.mkdirSync(authDir, { recursive: true });
     }
-    
-    // Save auth state
-    await context.storageState({ 
-      path: path.join(authDir, 'user.json') 
+
+    // Save auth state (cookies + localStorage)
+    await context.storageState({
+      path: path.join(authDir, 'user.json')
     });
-    
-    console.log('✅ Authentication successful, state saved');
+
+    // Firebase uses browserSessionPersistence, so auth shards + tokens live in
+    // sessionStorage. Playwright's storageState() does not persist sessionStorage,
+    // so we capture it separately and restore it via auth-fixture.js on context
+    // creation. Without this, protected pages redirect to /login in test tabs
+    // because Firebase has no session to restore.
+    const sessionStorageEntries = await page.evaluate(() => {
+      const entries = [];
+      try {
+        for (let i = 0; i < sessionStorage.length; i++) {
+          const name = sessionStorage.key(i);
+          if (name == null) continue;
+          entries.push({ name, value: sessionStorage.getItem(name) || '' });
+        }
+      } catch (_) {}
+      return entries;
+    });
+    const sessionOrigin = new URL(page.url()).origin;
+    const sessionStoragePath = path.join(authDir, 'session-storage.json');
+    fs.writeFileSync(sessionStoragePath, JSON.stringify({
+      origins: [{ origin: sessionOrigin, sessionStorage: sessionStorageEntries }]
+    }, null, 2));
+
+    console.log(`✅ Authentication successful, state saved (${sessionStorageEntries.length} sessionStorage keys)`);
     
   } catch (error) {
     const currentURL = page.url();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **High Risk**
> High risk because it changes authentication persistence/cleanup logic (session vs local storage) and logout behavior across tabs, which can cause unexpected login/logout flows. It also introduces a strict site-wide CSP/HSTS that could break asset loading or third-party integrations if misconfigured.
> 
> **Overview**
> **Auth state hardening:** switches Firebase Auth persistence to `browserSessionPersistence` and introduces `js/auth-persistence.js` to consistently resolve `user-authenticated` + Firebase auth shards across `sessionStorage`/`localStorage`, preventing cross-tab “passive cleanup” from logging users out in other tabs.
> 
> **Page-level updates:** refactors multiple pages (notably `dashboard.html`, `account-setting.html`, `404.html`, and `interview-questions.html`) to use the new persistence logic, prefer same-tab session evidence, and avoid mutating billing state on initial Account Settings load (removes initial `/api/sync-stripe-plan` behavior and updates nav via `planChanged`).
> 
> **Security + infra:** adds a shared `CONTENT_SECURITY_POLICY` + `strict-transport-security` to function responses and applies the same CSP/HSTS globally via `app/public/_headers`.
> 
> **Tooling/UX:** updates favicon handling (new assets + deferred `dynamic-favicon.js`, removes dashboard TS favicon effect), defers some scripts, swaps to scheduled analytics/feedback widgets on some pages, and updates Playwright to restore `sessionStorage` via a new `auth-fixture` + global setup capture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a604b23118afa497a40feacbcaad0dc25389be2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->