### PR TITLE
fix: harden app auth state and post-login surfaces

### DIFF
--- a/app/tests/e2e/auth.spec.js
+++ b/app/tests/e2e/auth.spec.js
@@ -26,6 +26,22 @@ test.describe('Authentication', () => {
     try {
       const page = await context.newPage();
 
+      // DEBUG: surface any JS errors / console output from the login page so
+      // failures like a silently-caught init error in login-page.js show up in
+      // CI logs instead of only manifesting as a native GET form submission.
+      page.on('pageerror', (err) => {
+        console.log('[BROWSER pageerror]', err.message, '\n', err.stack);
+      });
+      page.on('console', (msg) => {
+        const type = msg.type();
+        if (type === 'error' || type === 'warning') {
+          console.log(`[BROWSER ${type}]`, msg.text());
+        }
+      });
+      page.on('requestfailed', (req) => {
+        console.log('[BROWSER requestfailed]', req.url(), req.failure()?.errorText);
+      });
+
       await page.goto('/login');
 
       // Wait for login form using actual selector
@@ -38,6 +54,21 @@ test.describe('Authentication', () => {
       if (!TEST_EMAIL || !TEST_PASSWORD) {
         throw new Error('TEST_EMAIL and TEST_PASSWORD environment variables must be set');
       }
+
+      // DEBUG: report whether login-page.js actually attached its submit
+      // handler. If `hasSubmitHandler` is false at submit time, the form will
+      // fall back to a native GET and credentials will land in the URL.
+      const preSubmitState = await page.evaluate(() => {
+        const form = document.getElementById('loginForm');
+        return {
+          formExists: !!form,
+          formDisplay: form ? getComputedStyle(form).display : null,
+          hasFirebaseAuthManager: typeof window.FirebaseAuthManager !== 'undefined',
+          hasAuthPersistence: typeof window.JobHackAIAuthPersistence !== 'undefined',
+          readyState: document.readyState,
+        };
+      });
+      console.log('[LOGIN TEST] pre-submit state:', JSON.stringify(preSubmitState));
 
       // Fill credentials
       await page.fill('#loginEmail', TEST_EMAIL);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches client-side authentication persistence, logout/redirect behavior, and plan hydration logic across multiple pages, which can impact access control and session handling. Also introduces a stricter site-wide CSP/HSTS that could break scripts/assets if the allowlist is incomplete.
> 
> **Overview**
> **Hardens auth state handling around `browserSessionPersistence`.** Adds shared `js/auth-persistence.js` and updates multiple pages (`dashboard.html`, `account-setting.html`, `404.html`, `interview-questions.html`, `login-page.js`, `inactivity-tracker.js`, etc.) to resolve auth/plan state across `sessionStorage` + `localStorage`, avoiding cross-tab logout loops and relying on same-tab Firebase shards when needed.
> 
> **Reduces unintended backend mutations on page load.** `account-setting.html` now hydrates plan UI from `GET /api/billing-status` and updates navigation via `planChanged` without calling `POST /api/sync-stripe-plan` on initial render (with a new e2e assertion/marker).
> 
> **Improves platform security + assets.** Adds a consolidated CSP + HSTS via `app/public/_headers` and shared headers in `debug-access.js`, and refreshes favicon/feedback/analytics loading patterns (new favicon assets, deferred scripts, scheduled widget loaders, removes dashboard dynamic favicon effect).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a0339bcc4699371c4d54274d9ff6690bf2e4eec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->