### PR TITLE
fix(auth,e2e): add crossorigin to module scripts + harden login test

### DIFF
--- a/app/tests/e2e/auth.spec.js
+++ b/app/tests/e2e/auth.spec.js
@@ -26,9 +26,9 @@ test.describe('Authentication', () => {
     try {
       const page = await context.newPage();
 
-      // DEBUG: surface any JS errors / console output from the login page so
-      // failures like a silently-caught init error in login-page.js show up in
-      // CI logs instead of only manifesting as a native GET form submission.
+      // Surface browser-side errors in CI logs so a regression in login-page.js
+      // (silently-caught init errors, module fetch failures) is never invisible
+      // again.
       page.on('pageerror', (err) => {
         console.log('[BROWSER pageerror]', err.message, '\n', err.stack);
       });
@@ -55,20 +55,34 @@ test.describe('Authentication', () => {
         throw new Error('TEST_EMAIL and TEST_PASSWORD environment variables must be set');
       }
 
-      // DEBUG: report whether login-page.js actually attached its submit
-      // handler. If `hasSubmitHandler` is false at submit time, the form will
-      // fall back to a native GET and credentials will land in the URL.
-      const preSubmitState = await page.evaluate(() => {
-        const form = document.getElementById('loginForm');
-        return {
-          formExists: !!form,
-          formDisplay: form ? getComputedStyle(form).display : null,
-          hasFirebaseAuthManager: typeof window.FirebaseAuthManager !== 'undefined',
-          hasAuthPersistence: typeof window.JobHackAIAuthPersistence !== 'undefined',
-          readyState: document.readyState,
-        };
-      });
-      console.log('[LOGIN TEST] pre-submit state:', JSON.stringify(preSubmitState));
+      // Ensure login-page.js actually executed. On fresh browser contexts,
+      // Cloudflare Pages' injected Early Hints preload uses credentials:include
+      // while <script type="module"> fetches with credentials:omit; on a cold
+      // CDN connection the mismatch can cause Chromium to abort the module
+      // fetch (net::ERR_ABORTED). The DOM still shows the form, but no submit
+      // handler is attached, so requestSubmit() falls back to a native GET with
+      // credentials in the URL. Reload once if the auth module didn't load --
+      // on the second visit CF has a warm connection and the script loads.
+      const authModuleLoaded = async () => {
+        try {
+          await page.waitForFunction(
+            () => typeof window.FirebaseAuthManager !== 'undefined',
+            null,
+            { timeout: 8000 }
+          );
+          return true;
+        } catch (_) {
+          return false;
+        }
+      };
+      if (!(await authModuleLoaded())) {
+        console.warn('[LOGIN TEST] FirebaseAuthManager missing after first load; reloading to recover from aborted module fetch');
+        await page.reload();
+        await page.waitForSelector('#loginEmail');
+        if (!(await authModuleLoaded())) {
+          throw new Error('login-page.js did not initialize after reload; submit handler not attached');
+        }
+      }
 
       // Fill credentials
       await page.fill('#loginEmail', TEST_EMAIL);

--- a/login.html
+++ b/login.html
@@ -442,7 +442,8 @@
   <script src="js/auth-persistence.js"></script>
   <script src="js/navigation.js?v=20260208-1" defer></script>
   <script src="js/universal-logout.js?v=20260208-1" defer></script>
-  <script src="js/main.js?v=20251006-1" type="module"></script>
+  <!-- crossorigin matches Cloudflare Pages' injected Early Hints preload credentials mode; without it, modules on fresh contexts intermittently fetch as ERR_ABORTED. -->
+  <script src="js/main.js?v=20251006-1" type="module" crossorigin="anonymous"></script>
   <!-- Initialize navigation early to render correct visitor nav with CTA -->
   <script>
     if (window.JobHackAINavigation && typeof window.JobHackAINavigation.initializeNavigation === 'function') {
@@ -456,7 +457,7 @@
     }
   </script>
   <!-- Firebase Authentication -->
-  <script src="js/login-page.js?v=20251011-1" type="module"></script>
+  <script src="js/login-page.js?v=20251011-1" type="module" crossorigin="anonymous"></script>
   
   <!-- Forgot Password Modal -->
   <div id="forgotPasswordOverlay" style="

--- a/verify-email.html
+++ b/verify-email.html
@@ -127,9 +127,10 @@
   <!-- Core scripts only (no navigation.js) -->
   <script src="js/redirect-tracer.js?v=1" defer></script>
   <script src="js/universal-logout.js?v=20260208-1" defer></script>
-  <script src="js/main.js?v=20251006-1" type="module"></script>
+  <!-- crossorigin matches Cloudflare Pages' injected Early Hints preload credentials mode; without it, modules on fresh contexts intermittently fetch as ERR_ABORTED. -->
+  <script src="js/main.js?v=20251006-1" type="module" crossorigin="anonymous"></script>
   <!-- Verification Flow Script -->
-  <script src="js/verify-email.js" type="module"></script>
+  <script src="js/verify-email.js" type="module" crossorigin="anonymous"></script>
   <script src="js/logo-link-env.js" defer></script>
   <script src="js/schedule-feedback-widget.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary

- Adds `crossorigin="anonymous"` to `<script type="module">` tags in `login.html` and `verify-email.html` so their credentials mode matches Cloudflare Pages' injected Early Hints preload. Without this, on a cold CDN connection the preload (`credentials:include`) mismatches the module fetch (`credentials:omit`) and Chromium aborts the module fetch with `net::ERR_ABORTED`.
- Hardens the `auth.spec.js` "should login and redirect to dashboard" test to wait for `window.FirebaseAuthManager` to be defined (the observable proof that `login-page.js` actually executed and the submit handler is wired). If it doesn't appear, reloads once to recover from a transient cold-start race; if it still doesn't appear, throws a descriptive error instead of silently submitting credentials in the URL.
- Promotes the `pageerror` / `console` / `requestfailed` listeners from debug-only (added in 6a0339b via #795) to permanent, so future regressions surface in CI logs instead of showing up as cryptic 20s timeouts.

## Context

The test was failing in PR #791's CI with:

```
TimeoutError: page.waitForURL: Timeout 20000ms exceeded.
  navigated to "https://qa.jobhackai.io/login?loginEmail=***&loginPassword=***"
```

The credentials-in-URL signature meant the form submit handler was never attached. The listeners added in #795 revealed the actual cause on the next CI run:

```
[BROWSER requestfailed] https://qa.jobhackai.io/js/login-page.js?v=20251011-1 net::ERR_ABORTED
[BROWSER requestfailed] https://qa.jobhackai.io/js/main.js?v=20251006-1 net::ERR_ABORTED
... every defer/module script aborted ...
[BROWSER warning] A preload for '.../js/main.js...' is found, but is not used because the request credentials mode does not match. Consider taking a look at crossorigin attribute.
[LOGIN TEST] pre-submit state: {"hasFirebaseAuthManager":false,"hasAuthPersistence":true,"readyState":"interactive"}
```

`auth-persistence.js` (synchronous, non-module) loaded fine. Every `defer` / `type="module"` script aborted. This only reproduced on fresh `browser.newContext()` calls because cached/authenticated contexts don't hit the cold-start path.

## Test plan

- [ ] E2E: `should login and redirect to dashboard` passes on the first attempt against QA with a fresh browser context
- [ ] E2E: no `[BROWSER requestfailed] …/js/login-page.js … net::ERR_ABORTED` entries in the log for the login test
- [ ] E2E: all 53 tests pass (44 passed / 8 skipped / 0 failed)
- [ ] Verify the preload-mismatch warning is gone for `login.html` module scripts (`main.js`, `login-page.js`) and `verify-email.html` (`main.js`, `verify-email.js`)
- [ ] If CF still cold-aborts a module fetch, the test reloads once and logs `[LOGIN TEST] FirebaseAuthManager missing after first load; reloading to recover from aborted module fetch` rather than timing out silently

https://claude.ai/code/session_011QRPfuoEDwXbPenLor2pkR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production `login.html`/`verify-email.html` script tags and could impact how critical auth modules load in browsers, though the change is small and targeted. E2E changes are test-only but alter retry behavior and may mask flaky regressions if the underlying load issue persists.
> 
> **Overview**
> Fixes intermittent aborted `type="module"` loads on Cloudflare Pages cold starts by adding `crossorigin="anonymous"` to module script tags on `login.html` and `verify-email.html`.
> 
> Hardens the login E2E by permanently logging browser-side errors/warnings/request failures and by waiting for `window.FirebaseAuthManager` to appear; if it doesn’t, the test reloads once and fails fast with a clear error instead of leaking credentials via native GET form submission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2aef6518dc45a733d00207422cf596c979dd2b8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->