### PR TITLE
fix(auth): clear stale localStorage auth flag on passive sign-out; harden 404 CTA

### DIFF
--- a/404.html
+++ b/404.html
@@ -167,7 +167,10 @@
             : (localAuthFlag === 'false'
                 ? 'false'
                 : ((localAuthFlag === 'true') ? 'true' : null)));
-      const isAuthenticated = resolvedStoredAuth === 'true' || (resolvedStoredAuth !== 'false' && hasFirebaseAuthKeys());
+      // Require Firebase auth evidence in addition to the stored flag so a stale
+      // localStorage 'true' left behind by a passive sign-out in another tab doesn't
+      // falsely promote the CTA to "Go to dashboard" for unauthenticated visitors.
+      const isAuthenticated = resolvedStoredAuth !== 'false' && hasFirebaseAuthKeys();
       if (isAuthenticated) {
         cta.textContent = 'Go to dashboard';
         cta.setAttribute('href', '/dashboard.html');

--- a/404.html
+++ b/404.html
@@ -167,10 +167,12 @@
             : (localAuthFlag === 'false'
                 ? 'false'
                 : ((localAuthFlag === 'true') ? 'true' : null)));
-      // Require Firebase auth evidence in addition to the stored flag so a stale
-      // localStorage 'true' left behind by a passive sign-out in another tab doesn't
-      // falsely promote the CTA to "Go to dashboard" for unauthenticated visitors.
-      const isAuthenticated = resolvedStoredAuth !== 'false' && hasFirebaseAuthKeys();
+      // Require both an explicit stored 'true' flag and Firebase auth evidence so a
+      // stale localStorage 'true' left behind by a passive sign-out in another tab
+      // doesn't falsely promote the CTA, and a lone surviving Firebase shard (after a
+      // partial cleanup that removed the flag) doesn't either. Matches the strict
+      // hasStoredAuth && hasFirebaseKeys pattern used in js/page-access-control.js:187.
+      const isAuthenticated = resolvedStoredAuth === 'true' && hasFirebaseAuthKeys();
       if (isAuthenticated) {
         cta.textContent = 'Go to dashboard';
         cta.setAttribute('href', '/dashboard.html');

--- a/js/firebase-auth.js
+++ b/js/firebase-auth.js
@@ -511,6 +511,17 @@ class AuthManager {
         try {
           cleared.push(...clearFirebaseAuthShards(window.localStorage));
         } catch (_) {}
+        // Remove the stale localStorage 'user-authenticated' flag so new tabs with empty
+        // sessionStorage don't read a permanently stale 'true'. Use removeItem (not
+        // setItem('false')) because static-auth-guard.js and universal-logout.js only
+        // redirect on storage events where newValue === 'false'; a null newValue is a
+        // no-op for those listeners and therefore safe for other authenticated tabs.
+        try {
+          if (localStorage.getItem('user-authenticated') !== null) {
+            localStorage.removeItem('user-authenticated');
+            cleared.push('user-authenticated:local-removed');
+          }
+        } catch (_) {}
       }
       if (isExplicitSignOut) {
         try {

--- a/marketing/js/firebase-auth.js
+++ b/marketing/js/firebase-auth.js
@@ -426,6 +426,17 @@ class AuthManager {
         try {
           cleared.push(...clearFirebaseAuthShards(window.localStorage));
         } catch (_) {}
+        // Remove the stale localStorage 'user-authenticated' flag so new tabs with empty
+        // sessionStorage don't read a permanently stale 'true'. Use removeItem (not
+        // setItem('false')) because static-auth-guard.js and universal-logout.js only
+        // redirect on storage events where newValue === 'false'; a null newValue is a
+        // no-op for those listeners and therefore safe for other authenticated tabs.
+        try {
+          if (localStorage.getItem('user-authenticated') !== null) {
+            localStorage.removeItem('user-authenticated');
+            cleared.push('user-authenticated:local-removed');
+          }
+        } catch (_) {}
       }
       if (isExplicitSignOut) {
         try {


### PR DESCRIPTION
## Summary

Fixes the cursor-bot review finding on PR #790:

> Passive sign-out leaves stale `localStorage['user-authenticated'] = 'true'` indefinitely.
> In new tabs / new browser sessions with empty `sessionStorage`, `getResolvedStoredAuthFlagValue`
> returns `'true'` even though Firebase evidence has already been cleared, and the 404 page's
> CTA then shows "Go to dashboard" for unauthenticated users.

## Bug verification

In `js/firebase-auth.js#_clearStaleAuthStorage`, during a passive sign-out (non-explicit
reason == `'firebase-auth-signed-out'`):

- `localStorage['user-authenticated']` was **not** written (only `sessionStorage` was set to `'false'`).
- But `clearFirebaseAuthShards(window.localStorage)` **was** called — so Firebase evidence was wiped
  from both storages while the stale flag persisted.

In a new tab with empty `sessionStorage`:

- `sessionAuthFlag = null`, `localAuthFlag = 'true'` → resolved = `'true'`.
- `404.html` used `resolvedStoredAuth === 'true' || (…)`, trusting the flag alone → "Go to dashboard".

## Fix

- **`js/firebase-auth.js`** (and `marketing/js/firebase-auth.js` copy): during passive cleanup, also
  `removeItem('user-authenticated')` from `localStorage`. Use `removeItem` (fires storage event with
  `newValue === null`) rather than `setItem('false')` so `static-auth-guard.js` / `universal-logout.js`
  — which only redirect on `newValue === 'false'` — don't force-logout other authenticated tabs.
- **`404.html`**: require Firebase-key corroboration in addition to the stored flag, matching the
  stricter `hasStoredAuth && hasFirebaseKeys` pattern already used in `js/page-access-control.js:187`.

## Test plan

- [ ] Sign in on app.jobhackai.io, then visit a marketing page in the same browser profile; open a new tab to a 404 URL → CTA is "Go to dashboard" (Firebase shards present in either storage).
- [ ] Sign out explicitly → new tab to a 404 URL → CTA is "Go to homepage".
- [ ] Sign in, then in DevTools drop the Firebase `firebase:authUser:*` shards from both storages to simulate a passive cleanup that left a stale `localStorage['user-authenticated']='true'`. Open a new tab to a 404 URL → CTA is now "Go to homepage" (previously "Go to dashboard").
- [ ] Open the app in tab A (authenticated). In tab B, trigger passive sign-out and confirm tab A is not force-redirected to `/login.html` (removeItem does not match the `newValue === 'false'` cross-tab logout trigger).

https://claude.ai/code/session_01X7bDL8ZruCghiuia3Y4i9c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches auth persistence/cleanup behavior across tabs; a mistake could cause incorrect logout propagation or incorrect authenticated/unauthenticated UI, but changes are small and narrowly scoped.
> 
> **Overview**
> Fixes an auth-state edge case where a passive Firebase sign-out could leave `localStorage['user-authenticated']='true'`, causing new tabs (notably `404.html`) to show authenticated CTAs.
> 
> During passive cleanup in `js/firebase-auth.js` and `marketing/js/firebase-auth.js`, the PR now removes (not sets) the `user-authenticated` localStorage key to avoid stale positives while not triggering cross-tab logout listeners that only react to `newValue === 'false'`. The `404.html` CTA logic is tightened to require *both* an explicit stored `true` flag and Firebase auth shard evidence before offering “Go to dashboard”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee40a1c4f34592de42f0d4ea4084f62e7745b959. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->