### PR TITLE
Merge dev0 into develop

### DIFF
--- a/404.html
+++ b/404.html
@@ -167,7 +167,10 @@
             : (localAuthFlag === 'false'
                 ? 'false'
                 : ((localAuthFlag === 'true') ? 'true' : null)));
-      const isAuthenticated = resolvedStoredAuth === 'true' || (resolvedStoredAuth !== 'false' && hasFirebaseAuthKeys());
+      // Require Firebase auth evidence in addition to the stored flag so a stale
+      // localStorage 'true' left behind by a passive sign-out in another tab doesn't
+      // falsely promote the CTA to "Go to dashboard" for unauthenticated visitors.
+      const isAuthenticated = resolvedStoredAuth !== 'false' && hasFirebaseAuthKeys();
       if (isAuthenticated) {
         cta.textContent = 'Go to dashboard';
         cta.setAttribute('href', '/dashboard.html');

--- a/404.html
+++ b/404.html
@@ -167,10 +167,12 @@
             : (localAuthFlag === 'false'
                 ? 'false'
                 : ((localAuthFlag === 'true') ? 'true' : null)));
-      // Require Firebase auth evidence in addition to the stored flag so a stale
-      // localStorage 'true' left behind by a passive sign-out in another tab doesn't
-      // falsely promote the CTA to "Go to dashboard" for unauthenticated visitors.
-      const isAuthenticated = resolvedStoredAuth !== 'false' && hasFirebaseAuthKeys();
+      // Require both an explicit stored 'true' flag and Firebase auth evidence so a
+      // stale localStorage 'true' left behind by a passive sign-out in another tab
+      // doesn't falsely promote the CTA, and a lone surviving Firebase shard (after a
+      // partial cleanup that removed the flag) doesn't either. Matches the strict
+      // hasStoredAuth && hasFirebaseKeys pattern used in js/page-access-control.js:187.
+      const isAuthenticated = resolvedStoredAuth === 'true' && hasFirebaseAuthKeys();
       if (isAuthenticated) {
         cta.textContent = 'Go to dashboard';
         cta.setAttribute('href', '/dashboard.html');

--- a/js/firebase-auth.js
+++ b/js/firebase-auth.js
@@ -511,6 +511,17 @@ class AuthManager {
         try {
           cleared.push(...clearFirebaseAuthShards(window.localStorage));
         } catch (_) {}
+        // Remove the stale localStorage 'user-authenticated' flag so new tabs with empty
+        // sessionStorage don't read a permanently stale 'true'. Use removeItem (not
+        // setItem('false')) because static-auth-guard.js and universal-logout.js only
+        // redirect on storage events where newValue === 'false'; a null newValue is a
+        // no-op for those listeners and therefore safe for other authenticated tabs.
+        try {
+          if (localStorage.getItem('user-authenticated') !== null) {
+            localStorage.removeItem('user-authenticated');
+            cleared.push('user-authenticated:local-removed');
+          }
+        } catch (_) {}
       }
       if (isExplicitSignOut) {
         try {

--- a/marketing/js/firebase-auth.js
+++ b/marketing/js/firebase-auth.js
@@ -426,6 +426,17 @@ class AuthManager {
         try {
           cleared.push(...clearFirebaseAuthShards(window.localStorage));
         } catch (_) {}
+        // Remove the stale localStorage 'user-authenticated' flag so new tabs with empty
+        // sessionStorage don't read a permanently stale 'true'. Use removeItem (not
+        // setItem('false')) because static-auth-guard.js and universal-logout.js only
+        // redirect on storage events where newValue === 'false'; a null newValue is a
+        // no-op for those listeners and therefore safe for other authenticated tabs.
+        try {
+          if (localStorage.getItem('user-authenticated') !== null) {
+            localStorage.removeItem('user-authenticated');
+            cleared.push('user-authenticated:local-removed');
+          }
+        } catch (_) {}
       }
       if (isExplicitSignOut) {
         try {


### PR DESCRIPTION
Sync `develop` with latest changes from `dev0`.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tweaks authentication state inference and passive sign-out cleanup, which could impact cross-tab login/logout behavior and what unauthenticated users see. Scope is small but touches auth gating signals used across the site.
> 
> **Overview**
> Tightens client-side auth detection to avoid false positives from stale storage.
> 
> The `404.html` primary CTA now only switches to "Go to dashboard" when **both** the stored `user-authenticated` flag is explicitly `true` *and* Firebase auth shards exist (previously either signal could suffice).
> 
> In both app and marketing `firebase-auth.js`, passive Firebase sign-out cleanup now additionally **removes** the stale localStorage `user-authenticated` flag (instead of leaving it behind), while avoiding cross-tab logout redirects by using `removeItem()` rather than writing `false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78e7326ee19cf9ad297cf57b67b6b8683aa6a683. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->