### PR TITLE
fix(auth): guard JobHackAIAuthPersistence usage in dashboard/account-setting

### DIFF
--- a/account-setting.html
+++ b/account-setting.html
@@ -20,9 +20,18 @@
   </style>
   <script src="js/auth-persistence.js"></script>
   <script>
-    const _accountSettingsAuthPersistence = window.JobHackAIAuthPersistence;
+    // Look up window.JobHackAIAuthPersistence per call (not eagerly) so that if
+    // auth-persistence.js fails to load (network/CDN error), these helpers fall back
+    // to direct storage access instead of throwing on an undefined reference.
     function getAccountSettingsAuthStores() {
-      return _accountSettingsAuthPersistence.getAuthPersistenceStores();
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.getAuthPersistenceStores === 'function') {
+        return ap.getAuthPersistenceStores();
+      }
+      const stores = [];
+      try { if (typeof sessionStorage !== 'undefined') stores.push(sessionStorage); } catch (_) {}
+      try { if (typeof localStorage !== 'undefined') stores.push(localStorage); } catch (_) {}
+      return stores;
     }
 
     function getAccountSettingsStoreKeys(store) {
@@ -39,7 +48,26 @@
     }
 
     function getAccountSettingsStoredValue(key) {
-      return _accountSettingsAuthPersistence.getCrossTabStoredValue(key);
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.getCrossTabStoredValue === 'function') {
+        return ap.getCrossTabStoredValue(key);
+      }
+      if (key === 'user-authenticated') {
+        let sessionValue = null, localValue = null;
+        try { sessionValue = sessionStorage.getItem(key); } catch (_) {}
+        try { localValue = localStorage.getItem(key); } catch (_) {}
+        if (sessionValue === 'true') return 'true';
+        if (sessionValue === 'false') return 'false';
+        if (localValue === 'false') return 'false';
+        if (localValue === 'true') return 'true';
+        return null;
+      }
+      try {
+        const local = localStorage.getItem(key);
+        if (local !== null) return local;
+      } catch (_) {}
+      try { return sessionStorage.getItem(key); } catch (_) {}
+      return null;
     }
 
     function setAccountSettingsSessionValue(key, value) {
@@ -73,7 +101,21 @@
     }
 
     function hasAccountSettingsFirebaseAuthShard() {
-      return _accountSettingsAuthPersistence.hasFirebaseAuthPersistence();
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.hasFirebaseAuthPersistence === 'function') {
+        return ap.hasFirebaseAuthPersistence();
+      }
+      return getAccountSettingsAuthStores().some(function (store) {
+        try {
+          for (let i = 0; i < store.length; i++) {
+            const k = store.key(i);
+            if (!k || k.indexOf('firebase:authUser:') !== 0) continue;
+            const v = store.getItem(k);
+            if (v && v !== 'null' && v.length > 10) return true;
+          }
+        } catch (_) {}
+        return false;
+      });
     }
 
     // CRITICAL: Remove account-protected class IMMEDIATELY if we have cached auth

--- a/dashboard.html
+++ b/dashboard.html
@@ -853,17 +853,61 @@
       return authManager.getCurrentUser?.() || null;
     }
 
-    const _dashboardAuthPersistence = window.JobHackAIAuthPersistence;
+    // Look up window.JobHackAIAuthPersistence per call (not eagerly) so that if
+    // auth-persistence.js fails to load (network/CDN error), these helpers fall back
+    // to direct storage access instead of throwing on an undefined reference.
     function getDashboardStoredValue(key) {
-      return _dashboardAuthPersistence.getCrossTabStoredValue(key);
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.getCrossTabStoredValue === 'function') {
+        return ap.getCrossTabStoredValue(key);
+      }
+      if (key === 'user-authenticated') {
+        let sessionValue = null, localValue = null;
+        try { sessionValue = sessionStorage.getItem(key); } catch (_) {}
+        try { localValue = localStorage.getItem(key); } catch (_) {}
+        if (sessionValue === 'true') return 'true';
+        if (sessionValue === 'false') return 'false';
+        if (localValue === 'false') return 'false';
+        if (localValue === 'true') return 'true';
+        return null;
+      }
+      try {
+        const local = localStorage.getItem(key);
+        if (local !== null) return local;
+      } catch (_) {}
+      try { return sessionStorage.getItem(key); } catch (_) {}
+      return null;
     }
 
     function setDashboardStoredValue(key, value) {
-      _dashboardAuthPersistence.setCrossTabStoredValue(key, value);
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.setCrossTabStoredValue === 'function') {
+        ap.setCrossTabStoredValue(key, value);
+        return;
+      }
+      try { sessionStorage.setItem(key, value); } catch (_) {}
+      try { localStorage.setItem(key, value); } catch (_) {}
     }
 
     function hasDashboardFirebaseAuthPersistence() {
-      return _dashboardAuthPersistence.hasFirebaseAuthPersistence();
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.hasFirebaseAuthPersistence === 'function') {
+        return ap.hasFirebaseAuthPersistence();
+      }
+      const stores = [];
+      try { if (typeof sessionStorage !== 'undefined') stores.push(sessionStorage); } catch (_) {}
+      try { if (typeof localStorage !== 'undefined') stores.push(localStorage); } catch (_) {}
+      return stores.some(function (store) {
+        try {
+          for (let i = 0; i < store.length; i++) {
+            const k = store.key(i);
+            if (!k || k.indexOf('firebase:authUser:') !== 0) continue;
+            const v = store.getItem(k);
+            if (v && v !== 'null' && v.length > 10) return true;
+          }
+        } catch (_) {}
+        return false;
+      });
     }
 
     function hasSessionTokens() {


### PR DESCRIPTION
## Summary

Fixes the cursor-bot Medium-severity finding on PR #790:

> `_dashboardAuthPersistence` captures `window.JobHackAIAuthPersistence` eagerly with no null guard.
> If `auth-persistence.js` fails to load (network error, CDN glitch), `_dashboardAuthPersistence` is
> `undefined` and every call to `getDashboardStoredValue` / `setDashboardStoredValue` throws,
> completely breaking the dashboard auth flow. The same unguarded pattern appears in
> `account-setting.html` with `_accountSettingsAuthPersistence`. In contrast,
> `inactivity-tracker.js` correctly guards with `ap && typeof ap.hasStoredAuthenticatedFlag === 'function'`.
> The old code used `localStorage.getItem(...)` directly and was resilient to this failure mode.

## Fix

- **`dashboard.html`**: drop the eager `_dashboardAuthPersistence` capture. `getDashboardStoredValue`, `setDashboardStoredValue`, and `hasDashboardFirebaseAuthPersistence` now look up `window.JobHackAIAuthPersistence` per call and guard with `typeof X === 'function'`. When the module is unavailable, fall back to inline direct-storage logic that mirrors `auth-persistence.js`:
  - tri-state `session → local` resolution for `'user-authenticated'`,
  - localStorage-first for other read keys,
  - write-to-both for set,
  - scan both stores for `firebase:authUser:*` shards.
- **`account-setting.html`**: same treatment for `getAccountSettingsAuthStores`, `getAccountSettingsStoredValue`, and `hasAccountSettingsFirebaseAuthShard`.

Matches the guarded pattern already used in `js/inactivity-tracker.js:103-106` and `:579-580`.

## Test plan

- [ ] Load `dashboard.html` and `account-setting.html` normally → auth helpers use the `JobHackAIAuthPersistence` module path (no regression).
- [ ] Block the request to `/js/auth-persistence.js` in DevTools (Network → block request URL) and reload the dashboard; auth helpers fall through to direct-storage fallbacks and the page does not throw `TypeError: Cannot read properties of undefined`.
- [ ] Same DevTools block on `account-setting.html`: profile skeleton still resolves (or correctly redirects on missing auth), no thrown errors in console.
- [ ] Playwright `app/tests/fixtures/auth-fixture.js` regression suite still passes for dashboard/account-setting read-only flows.

https://claude.ai/code/session_01X7bDL8ZruCghiuia3Y4i9c

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-side authentication/persistence checks on `dashboard.html` and `account-setting.html`; mistakes could cause false logouts or unintended access if fallbacks diverge from the shared module behavior.
> 
> **Overview**
> Prevents hard failures in `dashboard.html` and `account-setting.html` when `js/auth-persistence.js` is missing/unavailable by removing eager captures of `window.JobHackAIAuthPersistence` and resolving it *per call* with `typeof` guards.
> 
> When the helper module isn’t present, the pages now fall back to inline storage logic: tri-state resolution for `user-authenticated`, localStorage-first reads for other keys, write-to-both behavior for setters, and scanning `sessionStorage`/`localStorage` for `firebase:authUser:*` shards to detect cached Firebase auth.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 856a9f99a39f2ffe3e5f3e616fce3ff2b860c385. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->