### PR TITLE
Merge dev0 into develop

### DIFF
--- a/account-setting.html
+++ b/account-setting.html
@@ -20,9 +20,18 @@
   </style>
   <script src="js/auth-persistence.js"></script>
   <script>
-    const _accountSettingsAuthPersistence = window.JobHackAIAuthPersistence;
+    // Look up window.JobHackAIAuthPersistence per call (not eagerly) so that if
+    // auth-persistence.js fails to load (network/CDN error), these helpers fall back
+    // to direct storage access instead of throwing on an undefined reference.
     function getAccountSettingsAuthStores() {
-      return _accountSettingsAuthPersistence.getAuthPersistenceStores();
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.getAuthPersistenceStores === 'function') {
+        return ap.getAuthPersistenceStores();
+      }
+      const stores = [];
+      try { if (typeof sessionStorage !== 'undefined') stores.push(sessionStorage); } catch (_) {}
+      try { if (typeof localStorage !== 'undefined') stores.push(localStorage); } catch (_) {}
+      return stores;
     }
 
     function getAccountSettingsStoreKeys(store) {
@@ -39,7 +48,26 @@
     }
 
     function getAccountSettingsStoredValue(key) {
-      return _accountSettingsAuthPersistence.getCrossTabStoredValue(key);
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.getCrossTabStoredValue === 'function') {
+        return ap.getCrossTabStoredValue(key);
+      }
+      if (key === 'user-authenticated') {
+        let sessionValue = null, localValue = null;
+        try { sessionValue = sessionStorage.getItem(key); } catch (_) {}
+        try { localValue = localStorage.getItem(key); } catch (_) {}
+        if (sessionValue === 'true') return 'true';
+        if (sessionValue === 'false') return 'false';
+        if (localValue === 'false') return 'false';
+        if (localValue === 'true') return 'true';
+        return null;
+      }
+      try {
+        const local = localStorage.getItem(key);
+        if (local !== null) return local;
+      } catch (_) {}
+      try { return sessionStorage.getItem(key); } catch (_) {}
+      return null;
     }
 
     function setAccountSettingsSessionValue(key, value) {
@@ -73,7 +101,21 @@
     }
 
     function hasAccountSettingsFirebaseAuthShard() {
-      return _accountSettingsAuthPersistence.hasFirebaseAuthPersistence();
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.hasFirebaseAuthPersistence === 'function') {
+        return ap.hasFirebaseAuthPersistence();
+      }
+      return getAccountSettingsAuthStores().some(function (store) {
+        try {
+          for (let i = 0; i < store.length; i++) {
+            const k = store.key(i);
+            if (!k || k.indexOf('firebase:authUser:') !== 0) continue;
+            const v = store.getItem(k);
+            if (v && v !== 'null' && v.length > 10) return true;
+          }
+        } catch (_) {}
+        return false;
+      });
     }
 
     // CRITICAL: Remove account-protected class IMMEDIATELY if we have cached auth

--- a/dashboard.html
+++ b/dashboard.html
@@ -853,17 +853,61 @@
       return authManager.getCurrentUser?.() || null;
     }
 
-    const _dashboardAuthPersistence = window.JobHackAIAuthPersistence;
+    // Look up window.JobHackAIAuthPersistence per call (not eagerly) so that if
+    // auth-persistence.js fails to load (network/CDN error), these helpers fall back
+    // to direct storage access instead of throwing on an undefined reference.
     function getDashboardStoredValue(key) {
-      return _dashboardAuthPersistence.getCrossTabStoredValue(key);
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.getCrossTabStoredValue === 'function') {
+        return ap.getCrossTabStoredValue(key);
+      }
+      if (key === 'user-authenticated') {
+        let sessionValue = null, localValue = null;
+        try { sessionValue = sessionStorage.getItem(key); } catch (_) {}
+        try { localValue = localStorage.getItem(key); } catch (_) {}
+        if (sessionValue === 'true') return 'true';
+        if (sessionValue === 'false') return 'false';
+        if (localValue === 'false') return 'false';
+        if (localValue === 'true') return 'true';
+        return null;
+      }
+      try {
+        const local = localStorage.getItem(key);
+        if (local !== null) return local;
+      } catch (_) {}
+      try { return sessionStorage.getItem(key); } catch (_) {}
+      return null;
     }
 
     function setDashboardStoredValue(key, value) {
-      _dashboardAuthPersistence.setCrossTabStoredValue(key, value);
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.setCrossTabStoredValue === 'function') {
+        ap.setCrossTabStoredValue(key, value);
+        return;
+      }
+      try { sessionStorage.setItem(key, value); } catch (_) {}
+      try { localStorage.setItem(key, value); } catch (_) {}
     }
 
     function hasDashboardFirebaseAuthPersistence() {
-      return _dashboardAuthPersistence.hasFirebaseAuthPersistence();
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.hasFirebaseAuthPersistence === 'function') {
+        return ap.hasFirebaseAuthPersistence();
+      }
+      const stores = [];
+      try { if (typeof sessionStorage !== 'undefined') stores.push(sessionStorage); } catch (_) {}
+      try { if (typeof localStorage !== 'undefined') stores.push(localStorage); } catch (_) {}
+      return stores.some(function (store) {
+        try {
+          for (let i = 0; i < store.length; i++) {
+            const k = store.key(i);
+            if (!k || k.indexOf('firebase:authUser:') !== 0) continue;
+            const v = store.getItem(k);
+            if (v && v !== 'null' && v.length > 10) return true;
+          }
+        } catch (_) {}
+        return false;
+      });
     }
 
     function hasSessionTokens() {


### PR DESCRIPTION
Sync `develop` with latest changes from `dev0` (includes auth persistence guard fixes from #799).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-side auth caching/guard helpers used to decide whether to show protected pages or redirect to login, so regressions could incorrectly expose content briefly or log users out if edge cases are missed.
> 
> **Overview**
> Hardens `account-setting.html` and `dashboard.html` against `js/auth-persistence.js` failing to load by removing eager references to `window.JobHackAIAuthPersistence` and instead resolving it per call with safe fallbacks.
> 
> When the helper object is unavailable, both pages now fall back to direct `sessionStorage`/`localStorage` reads/writes (including special resolution for `user-authenticated`) and implement a storage scan fallback to detect persisted Firebase auth shards (`firebase:authUser:` keys) to keep auth gating behavior consistent under CDN/network failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9c2c43282939e8a31443ff101af1e16b569c094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->