### PR TITLE
Fix auth persistence fallback guards

### DIFF
--- a/account-setting.html
+++ b/account-setting.html
@@ -81,6 +81,10 @@
     }
 
     function getAccountSettingsFirebaseAuthData() {
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.getStoredFirebaseAuthRecord === 'function') {
+        return ap.getStoredFirebaseAuthRecord();
+      }
       for (const store of getAccountSettingsAuthStores()) {
         try {
           const firebaseKey = getAccountSettingsStoreKeys(store).find(key => key.startsWith('firebase:authUser:'));

--- a/js/auth-persistence.js
+++ b/js/auth-persistence.js
@@ -80,6 +80,26 @@
     }
   }
 
+  function getStoredFirebaseAuthRecord() {
+    var stores = getAuthPersistenceStores();
+    for (var s = 0; s < stores.length; s++) {
+      try {
+        var store = stores[s];
+        for (var i = 0; i < store.length; i++) {
+          var key = store.key(i);
+          if (!key || key.indexOf(FIREBASE_AUTH_STORAGE_KEY_PREFIX) !== 0) continue;
+          var rawValue = store.getItem(key);
+          if (!rawValue || rawValue === 'null') continue;
+          var parsed = JSON.parse(rawValue);
+          if (parsed && typeof parsed === 'object') {
+            return parsed;
+          }
+        }
+      } catch (_) {}
+    }
+    return null;
+  }
+
   function clearFirebaseAuthPersistence() {
     var stores = getAuthPersistenceStores();
     for (var s = 0; s < stores.length; s++) {
@@ -105,6 +125,7 @@
     setCrossTabStoredValue: setCrossTabStoredValue,
     hasStoredAuthenticatedFlag: hasStoredAuthenticatedFlag,
     hasFirebaseAuthPersistence: hasFirebaseAuthPersistence,
+    getStoredFirebaseAuthRecord: getStoredFirebaseAuthRecord,
     clearFirebaseAuthPersistence: clearFirebaseAuthPersistence
   };
 })(window);

--- a/js/login-page.js
+++ b/js/login-page.js
@@ -9,7 +9,20 @@ console.log('🔧 login-page.js VERSION: fix-auth-cache-loop-v1 - ' + new Date()
 import authManager, { waitForAuthReady, AUTH_PENDING } from './firebase-auth.js';
 
 function getResolvedStoredAuthFlagValue() {
-  return window.JobHackAIAuthPersistence.getResolvedStoredAuthFlagValue();
+  const ap = window.JobHackAIAuthPersistence;
+  if (ap && typeof ap.getResolvedStoredAuthFlagValue === 'function') {
+    return ap.getResolvedStoredAuthFlagValue();
+  }
+  let sessionValue = null;
+  let localValue = null;
+  try { sessionValue = sessionStorage.getItem('user-authenticated'); } catch (_) {}
+  try { localValue = localStorage.getItem('user-authenticated'); } catch (_) {}
+
+  if (sessionValue === 'true') return 'true';
+  if (sessionValue === 'false') return 'false';
+  if (localValue === 'false') return 'false';
+  if (localValue === 'true') return 'true';
+  return null;
 }
 
 function getStoredFirebaseAuthRecord() {
@@ -20,6 +33,11 @@ function getStoredFirebaseAuthRecord() {
   } catch (_) {}
   if (getResolvedStoredAuthFlagValue() !== 'true') {
     return null;
+  }
+  const ap = window.JobHackAIAuthPersistence;
+  if (ap && typeof ap.getStoredFirebaseAuthRecord === 'function') {
+    const record = ap.getStoredFirebaseAuthRecord();
+    if (record?.email) return record;
   }
   const storages = [sessionStorage, localStorage];
   for (const storage of storages) {

--- a/marketing/js/auth-persistence.js
+++ b/marketing/js/auth-persistence.js
@@ -77,6 +77,26 @@
     }
   }
 
+  function getStoredFirebaseAuthRecord() {
+    var stores = getAuthPersistenceStores();
+    for (var s = 0; s < stores.length; s++) {
+      try {
+        var store = stores[s];
+        for (var i = 0; i < store.length; i++) {
+          var key = store.key(i);
+          if (!key || key.indexOf(FIREBASE_AUTH_STORAGE_KEY_PREFIX) !== 0) continue;
+          var value = store.getItem(key);
+          if (!value || value === 'null') continue;
+          var parsed = JSON.parse(value);
+          if (parsed && typeof parsed === 'object') {
+            return parsed;
+          }
+        }
+      } catch (_) {}
+    }
+    return null;
+  }
+
   window.JobHackAIAuthPersistence = {
     FIREBASE_AUTH_STORAGE_KEY_PREFIX: FIREBASE_AUTH_STORAGE_KEY_PREFIX,
     getAuthPersistenceStores: getAuthPersistenceStores,
@@ -84,6 +104,7 @@
     getCrossTabStoredValue: getCrossTabStoredValue,
     setCrossTabStoredValue: setCrossTabStoredValue,
     hasStoredAuthenticatedFlag: hasStoredAuthenticatedFlag,
-    hasFirebaseAuthPersistence: hasFirebaseAuthPersistence
+    hasFirebaseAuthPersistence: hasFirebaseAuthPersistence,
+    getStoredFirebaseAuthRecord: getStoredFirebaseAuthRecord
   };
 })(window);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Guard login-page auth-persistence access and fall back to direct storage resolution when the shared helper is unavailable.
- Add a shared Firebase auth record reader to auth-persistence and use it from login/account settings when available.
- Keep page-level direct storage fallbacks for CDN/network failures that prevent auth-persistence.js from loading.

## Testing
- `node --check "js/auth-persistence.js"`
- `node --check "marketing/js/auth-persistence.js"`
- `node --input-type=module --check < "js/login-page.js"`
- Simulated missing-auth-persistence login fallback via Node VM/storage mock.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7dd2a214-7207-46eb-bb3a-7915f369f3c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7dd2a214-7207-46eb-bb3a-7915f369f3c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

