### PR TITLE
Merge pull request #801 from dlarosa92/cursor/fix-auth-persistence-guards-f3c6

### DIFF
--- a/account-setting.html
+++ b/account-setting.html
@@ -81,6 +81,10 @@
     }
 
     function getAccountSettingsFirebaseAuthData() {
+      const ap = window.JobHackAIAuthPersistence;
+      if (ap && typeof ap.getStoredFirebaseAuthRecord === 'function') {
+        return ap.getStoredFirebaseAuthRecord();
+      }
       for (const store of getAccountSettingsAuthStores()) {
         try {
           const firebaseKey = getAccountSettingsStoreKeys(store).find(key => key.startsWith('firebase:authUser:'));

--- a/js/auth-persistence.js
+++ b/js/auth-persistence.js
@@ -80,6 +80,26 @@
     }
   }
 
+  function getStoredFirebaseAuthRecord() {
+    var stores = getAuthPersistenceStores();
+    for (var s = 0; s < stores.length; s++) {
+      try {
+        var store = stores[s];
+        for (var i = 0; i < store.length; i++) {
+          var key = store.key(i);
+          if (!key || key.indexOf(FIREBASE_AUTH_STORAGE_KEY_PREFIX) !== 0) continue;
+          var rawValue = store.getItem(key);
+          if (!rawValue || rawValue === 'null') continue;
+          var parsed = JSON.parse(rawValue);
+          if (parsed && typeof parsed === 'object') {
+            return parsed;
+          }
+        }
+      } catch (_) {}
+    }
+    return null;
+  }
+
   function clearFirebaseAuthPersistence() {
     var stores = getAuthPersistenceStores();
     for (var s = 0; s < stores.length; s++) {
@@ -105,6 +125,7 @@
     setCrossTabStoredValue: setCrossTabStoredValue,
     hasStoredAuthenticatedFlag: hasStoredAuthenticatedFlag,
     hasFirebaseAuthPersistence: hasFirebaseAuthPersistence,
+    getStoredFirebaseAuthRecord: getStoredFirebaseAuthRecord,
     clearFirebaseAuthPersistence: clearFirebaseAuthPersistence
   };
 })(window);

--- a/js/login-page.js
+++ b/js/login-page.js
@@ -9,7 +9,20 @@ console.log('🔧 login-page.js VERSION: fix-auth-cache-loop-v1 - ' + new Date()
 import authManager, { waitForAuthReady, AUTH_PENDING } from './firebase-auth.js';
 
 function getResolvedStoredAuthFlagValue() {
-  return window.JobHackAIAuthPersistence.getResolvedStoredAuthFlagValue();
+  const ap = window.JobHackAIAuthPersistence;
+  if (ap && typeof ap.getResolvedStoredAuthFlagValue === 'function') {
+    return ap.getResolvedStoredAuthFlagValue();
+  }
+  let sessionValue = null;
+  let localValue = null;
+  try { sessionValue = sessionStorage.getItem('user-authenticated'); } catch (_) {}
+  try { localValue = localStorage.getItem('user-authenticated'); } catch (_) {}
+
+  if (sessionValue === 'true') return 'true';
+  if (sessionValue === 'false') return 'false';
+  if (localValue === 'false') return 'false';
+  if (localValue === 'true') return 'true';
+  return null;
 }
 
 function getStoredFirebaseAuthRecord() {
@@ -20,6 +33,11 @@ function getStoredFirebaseAuthRecord() {
   } catch (_) {}
   if (getResolvedStoredAuthFlagValue() !== 'true') {
     return null;
+  }
+  const ap = window.JobHackAIAuthPersistence;
+  if (ap && typeof ap.getStoredFirebaseAuthRecord === 'function') {
+    const record = ap.getStoredFirebaseAuthRecord();
+    if (record?.email) return record;
   }
   const storages = [sessionStorage, localStorage];
   for (const storage of storages) {

--- a/marketing/js/auth-persistence.js
+++ b/marketing/js/auth-persistence.js
@@ -77,6 +77,26 @@
     }
   }
 
+  function getStoredFirebaseAuthRecord() {
+    var stores = getAuthPersistenceStores();
+    for (var s = 0; s < stores.length; s++) {
+      try {
+        var store = stores[s];
+        for (var i = 0; i < store.length; i++) {
+          var key = store.key(i);
+          if (!key || key.indexOf(FIREBASE_AUTH_STORAGE_KEY_PREFIX) !== 0) continue;
+          var value = store.getItem(key);
+          if (!value || value === 'null') continue;
+          var parsed = JSON.parse(value);
+          if (parsed && typeof parsed === 'object') {
+            return parsed;
+          }
+        }
+      } catch (_) {}
+    }
+    return null;
+  }
+
   window.JobHackAIAuthPersistence = {
     FIREBASE_AUTH_STORAGE_KEY_PREFIX: FIREBASE_AUTH_STORAGE_KEY_PREFIX,
     getAuthPersistenceStores: getAuthPersistenceStores,
@@ -84,6 +104,7 @@
     getCrossTabStoredValue: getCrossTabStoredValue,
     setCrossTabStoredValue: setCrossTabStoredValue,
     hasStoredAuthenticatedFlag: hasStoredAuthenticatedFlag,
-    hasFirebaseAuthPersistence: hasFirebaseAuthPersistence
+    hasFirebaseAuthPersistence: hasFirebaseAuthPersistence,
+    getStoredFirebaseAuthRecord: getStoredFirebaseAuthRecord
   };
 })(window);


### PR DESCRIPTION
Implemented and verified.
Summary:
Fixed js/login-page.js crash by guarding window.JobHackAIAuthPersistence before use.
Added direct storage fallback logic for login initialization when auth-persistence.js fails to load.
Added shared getStoredFirebaseAuthRecord() helper to js/auth-persistence.js and marketing copy.
Updated login/account settings to use the shared Firebase auth record reader when available, while preserving inline fallback behavior for CDN/network failure cases.
Validation run:
node --check js/auth-persistence.js
node --check marketing/js/auth-persistence.js
node --input-type=module --check < js/login-page.js
Simulated missing window.JobHackAIAuthPersistence login fallback with Node VM/storage mock.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes login/account settings auth caching and redirect decisions by altering how persisted Firebase auth data is read and adding fallbacks when `auth-persistence.js` is missing. Risk is moderate because mistakes could cause incorrect auto-redirects or unintended logged-out states across tabs.
> 
> **Overview**
> Prevents runtime crashes and auth-cache redirect loops by **guarding all `window.JobHackAIAuthPersistence` calls** and adding direct `sessionStorage`/`localStorage` fallbacks on the login page.
> 
> Introduces a shared `getStoredFirebaseAuthRecord()` helper in both `js/auth-persistence.js` and `marketing/js/auth-persistence.js`, and updates `account-setting.html`/`js/login-page.js` to prefer this helper (while keeping inline storage inspection as a resilience fallback when the script/CDN fails).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa2cea271e1b9028e9add8348cb5efb50b9be211. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->