### PR TITLE
Merge dev0 into develop

### DIFF
--- a/js/firebase-auth.js
+++ b/js/firebase-auth.js
@@ -417,6 +417,31 @@ function decodeJwtPayload(token) {
   }
 }
 
+function restoreLinkedInUserFromStoredTokens(context = 'fallback') {
+  const candidates = [];
+  try {
+    const firebaseIdToken = getIdTokenSync();
+    if (firebaseIdToken) candidates.push(firebaseIdToken);
+  } catch (_) {}
+  try {
+    const oidcToken = sessionStorage.getItem('linkedin_oidc_id_token');
+    if (oidcToken && !candidates.includes(oidcToken)) candidates.push(oidcToken);
+  } catch (_) {}
+
+  for (const token of candidates) {
+    const payload = decodeJwtPayload(token);
+    if (!payload || !(payload.user_id || payload.sub)) continue;
+    const uid = payload.user_id || payload.sub;
+    const email = payload.email || '';
+    if (email && email.trim() !== '') {
+      console.log(`✅ Restored LinkedIn session from stored tokens (${context})`);
+      return { uid, email };
+    }
+  }
+
+  return null;
+}
+
 /**
  * Authentication Manager
  */
@@ -434,6 +459,7 @@ class AuthManager {
     this._pendingAuthState = null;
     this._explicitSignOutInProgress = false;
     this._linkedInSessionRestoreInFlight = false;
+    this._linkedInSessionRestorePromise = null;
     this._initializeAuthReady();
     this._redirectProcessing = this._isGoogleRedirectInProgress();
     this.setupAuthStateListener();
@@ -464,10 +490,9 @@ class AuthManager {
     try {
       const cleared = [];
       const isExplicitSignOut = reason === 'firebase-auth-signed-out' && this._explicitSignOutInProgress;
-      // Only explicit sign-out should write localStorage 'user-authenticated' = 'false'. Passive
-      // onAuthStateChanged(null) (e.g., a new tab under browserSessionPersistence with no session)
-      // must not mutate the shared key, because static-auth-guard.js redirects every other tab to
-      // /login.html on that storage event, logging authenticated users out of protected pages.
+      // Only explicit sign-out should mutate the shared localStorage auth flag. Passive
+      // onAuthStateChanged(null) is tab-local under browserSessionPersistence; changing the
+      // shared flag would perturb auth checks in other tabs.
       try {
         if (isExplicitSignOut) {
           localStorage.setItem('user-authenticated', 'false');
@@ -510,17 +535,6 @@ class AuthManager {
         // can safely be removed without affecting other tabs' active sessions.
         try {
           cleared.push(...clearFirebaseAuthShards(window.localStorage));
-        } catch (_) {}
-        // Remove the stale localStorage 'user-authenticated' flag so new tabs with empty
-        // sessionStorage don't read a permanently stale 'true'. Use removeItem (not
-        // setItem('false')) because static-auth-guard.js and universal-logout.js only
-        // redirect on storage events where newValue === 'false'; a null newValue is a
-        // no-op for those listeners and therefore safe for other authenticated tabs.
-        try {
-          if (localStorage.getItem('user-authenticated') !== null) {
-            localStorage.removeItem('user-authenticated');
-            cleared.push('user-authenticated:local-removed');
-          }
         } catch (_) {}
       }
       if (isExplicitSignOut) {
@@ -746,51 +760,37 @@ class AuthManager {
           const storedOidcToken = sessionStorage.getItem('linkedin_oidc_id_token');
           if (storedOidcToken) {
             if (this._linkedInSessionRestoreInFlight) {
-              console.log('⏳ LinkedIn SDK restore already in progress; waiting for next auth callback');
-              return;
-            }
-
-            this._linkedInSessionRestoreInFlight = true;
-            try {
-              // Wait for the SDK restore attempt to resolve before deciding this is a signed-out state.
-              // A successful restore will trigger a second onAuthStateChanged callback with the SDK user.
-              const provider = new OAuthProvider('oidc.linkedin.com');
-              const credential = provider.credential({ idToken: storedOidcToken });
-              await signInWithCredential(auth, credential);
-              console.log('✅ Signed into Firebase SDK using stored LinkedIn OIDC token');
-              effectiveUser = auth.currentUser;
-            } catch (err) {
-              console.warn('Could not restore SDK auth with stored OIDC token:', err);
-              // SDK sign-in failed - fallback to plain object by checking tokens
-              const idToken = getIdTokenSync();
-              if (idToken) {
-                const payload = decodeJwtPayload(idToken);
-                if (payload && (payload.user_id || payload.sub)) {
-                  const uid = payload.user_id || payload.sub;
-                  const email = payload.email || '';
-                  if (email && email.trim() !== '') {
-                    effectiveUser = { uid, email };
-                    console.log('✅ Restored LinkedIn session from sessionStorage tokens (fallback)');
-                  }
-                }
+              console.log('⏳ LinkedIn SDK restore already in progress; waiting for restore result');
+              const restorePromise = this._linkedInSessionRestorePromise;
+              try {
+                const result = restorePromise ? await restorePromise : null;
+                effectiveUser = result?.user || auth.currentUser || restoreLinkedInUserFromStoredTokens('restore in flight');
+              } catch (err) {
+                console.warn('LinkedIn SDK restore in flight failed:', err);
+                effectiveUser = restoreLinkedInUserFromStoredTokens('restore in flight fallback');
               }
-            } finally {
-              this._linkedInSessionRestoreInFlight = false;
+            } else {
+              this._linkedInSessionRestoreInFlight = true;
+              try {
+                // Wait for the SDK restore attempt to resolve before deciding this is a signed-out state.
+                // A successful restore will trigger a second onAuthStateChanged callback with the SDK user.
+                const provider = new OAuthProvider('oidc.linkedin.com');
+                const credential = provider.credential({ idToken: storedOidcToken });
+                this._linkedInSessionRestorePromise = signInWithCredential(auth, credential);
+                const result = await this._linkedInSessionRestorePromise;
+                console.log('✅ Signed into Firebase SDK using stored LinkedIn OIDC token');
+                effectiveUser = result?.user || auth.currentUser;
+              } catch (err) {
+                console.warn('Could not restore SDK auth with stored OIDC token:', err);
+                effectiveUser = restoreLinkedInUserFromStoredTokens('fallback');
+              } finally {
+                this._linkedInSessionRestoreInFlight = false;
+                this._linkedInSessionRestorePromise = null;
+              }
             }
           } else {
             // No OIDC token stored - fall back to plain object (legacy behavior)
-            const idToken = getIdTokenSync();
-            if (idToken) {
-              const payload = decodeJwtPayload(idToken);
-              if (payload && (payload.user_id || payload.sub)) {
-                const uid = payload.user_id || payload.sub;
-                const email = payload.email || '';
-                if (email && email.trim() !== '') {
-                  effectiveUser = { uid, email };
-                  console.log('✅ Restored LinkedIn session from sessionStorage tokens (plain object fallback)');
-                }
-              }
-            }
+            effectiveUser = restoreLinkedInUserFromStoredTokens('plain object fallback');
           }
         }
       }

--- a/js/linkedin-optimizer.js
+++ b/js/linkedin-optimizer.js
@@ -130,7 +130,7 @@ function getAuthState() {
     }
   } catch (_) {}
   return {
-    isAuthenticated: sessionFlag !== 'false' && hasSessionFirebaseKeys
+    isAuthenticated: sessionFlag === 'true' && hasSessionFirebaseKeys
   };
 }
 

--- a/marketing/js/firebase-auth.js
+++ b/marketing/js/firebase-auth.js
@@ -333,6 +333,31 @@ function decodeJwtPayload(token) {
   }
 }
 
+function restoreLinkedInUserFromStoredTokens(context = 'fallback') {
+  const candidates = [];
+  try {
+    const firebaseIdToken = getIdTokenSync();
+    if (firebaseIdToken) candidates.push(firebaseIdToken);
+  } catch (_) {}
+  try {
+    const oidcToken = sessionStorage.getItem('linkedin_oidc_id_token');
+    if (oidcToken && !candidates.includes(oidcToken)) candidates.push(oidcToken);
+  } catch (_) {}
+
+  for (const token of candidates) {
+    const payload = decodeJwtPayload(token);
+    if (!payload || !(payload.user_id || payload.sub)) continue;
+    const uid = payload.user_id || payload.sub;
+    const email = payload.email || '';
+    if (email && email.trim() !== '') {
+      console.log(`✅ Restored LinkedIn session from stored tokens (${context})`);
+      return { uid, email };
+    }
+  }
+
+  return null;
+}
+
 /**
  * Authentication Manager
  */
@@ -350,6 +375,7 @@ class AuthManager {
     this._pendingAuthState = null;
     this._explicitSignOutInProgress = false;
     this._linkedInSessionRestoreInFlight = false;
+    this._linkedInSessionRestorePromise = null;
     this._initializeAuthReady();
     this._redirectProcessing = this._isGoogleRedirectInProgress();
     this.setupAuthStateListener();
@@ -380,9 +406,9 @@ class AuthManager {
     try {
       const cleared = [];
       const isExplicitSignOut = reason === 'firebase-auth-signed-out' && this._explicitSignOutInProgress;
-      // Passive onAuthStateChanged(null) clears this tab's sessionStorage; with browserSessionPersistence,
-      // Firebase does not use localStorage for the live session, but legacy local firebase:authUser:* keys
-      // must be removed so static-auth-guard.js does not treat a new tab as authenticated.
+      // Only explicit sign-out should mutate the shared localStorage auth flag. Passive
+      // onAuthStateChanged(null) is tab-local under browserSessionPersistence; changing the
+      // shared flag would perturb auth checks in other tabs.
       try {
         if (isExplicitSignOut) {
           localStorage.setItem('user-authenticated', 'false');
@@ -425,17 +451,6 @@ class AuthManager {
         // can safely be removed without affecting other tabs' active sessions.
         try {
           cleared.push(...clearFirebaseAuthShards(window.localStorage));
-        } catch (_) {}
-        // Remove the stale localStorage 'user-authenticated' flag so new tabs with empty
-        // sessionStorage don't read a permanently stale 'true'. Use removeItem (not
-        // setItem('false')) because static-auth-guard.js and universal-logout.js only
-        // redirect on storage events where newValue === 'false'; a null newValue is a
-        // no-op for those listeners and therefore safe for other authenticated tabs.
-        try {
-          if (localStorage.getItem('user-authenticated') !== null) {
-            localStorage.removeItem('user-authenticated');
-            cleared.push('user-authenticated:local-removed');
-          }
         } catch (_) {}
       }
       if (isExplicitSignOut) {
@@ -661,51 +676,37 @@ class AuthManager {
           const storedOidcToken = sessionStorage.getItem('linkedin_oidc_id_token');
           if (storedOidcToken) {
             if (this._linkedInSessionRestoreInFlight) {
-              console.log('⏳ LinkedIn SDK restore already in progress; waiting for next auth callback');
-              return;
-            }
-
-            this._linkedInSessionRestoreInFlight = true;
-            try {
-              // Wait for the SDK restore attempt to resolve before deciding this is a signed-out state.
-              // A successful restore will trigger a second onAuthStateChanged callback with the SDK user.
-              const provider = new OAuthProvider('oidc.linkedin.com');
-              const credential = provider.credential({ idToken: storedOidcToken });
-              await signInWithCredential(auth, credential);
-              console.log('✅ Signed into Firebase SDK using stored LinkedIn OIDC token');
-              effectiveUser = auth.currentUser;
-            } catch (err) {
-              console.warn('Could not restore SDK auth with stored OIDC token:', err);
-              // SDK sign-in failed - fallback to plain object by checking tokens
-              const idToken = getIdTokenSync();
-              if (idToken) {
-                const payload = decodeJwtPayload(idToken);
-                if (payload && (payload.user_id || payload.sub)) {
-                  const uid = payload.user_id || payload.sub;
-                  const email = payload.email || '';
-                  if (email && email.trim() !== '') {
-                    effectiveUser = { uid, email };
-                    console.log('✅ Restored LinkedIn session from sessionStorage tokens (fallback)');
-                  }
-                }
+              console.log('⏳ LinkedIn SDK restore already in progress; waiting for restore result');
+              const restorePromise = this._linkedInSessionRestorePromise;
+              try {
+                const result = restorePromise ? await restorePromise : null;
+                effectiveUser = result?.user || auth.currentUser || restoreLinkedInUserFromStoredTokens('restore in flight');
+              } catch (err) {
+                console.warn('LinkedIn SDK restore in flight failed:', err);
+                effectiveUser = restoreLinkedInUserFromStoredTokens('restore in flight fallback');
               }
-            } finally {
-              this._linkedInSessionRestoreInFlight = false;
+            } else {
+              this._linkedInSessionRestoreInFlight = true;
+              try {
+                // Wait for the SDK restore attempt to resolve before deciding this is a signed-out state.
+                // A successful restore will trigger a second onAuthStateChanged callback with the SDK user.
+                const provider = new OAuthProvider('oidc.linkedin.com');
+                const credential = provider.credential({ idToken: storedOidcToken });
+                this._linkedInSessionRestorePromise = signInWithCredential(auth, credential);
+                const result = await this._linkedInSessionRestorePromise;
+                console.log('✅ Signed into Firebase SDK using stored LinkedIn OIDC token');
+                effectiveUser = result?.user || auth.currentUser;
+              } catch (err) {
+                console.warn('Could not restore SDK auth with stored OIDC token:', err);
+                effectiveUser = restoreLinkedInUserFromStoredTokens('fallback');
+              } finally {
+                this._linkedInSessionRestoreInFlight = false;
+                this._linkedInSessionRestorePromise = null;
+              }
             }
           } else {
             // No OIDC token stored - fall back to plain object (legacy behavior)
-            const idToken = getIdTokenSync();
-            if (idToken) {
-              const payload = decodeJwtPayload(idToken);
-              if (payload && (payload.user_id || payload.sub)) {
-                const uid = payload.user_id || payload.sub;
-                const email = payload.email || '';
-                if (email && email.trim() !== '') {
-                  effectiveUser = { uid, email };
-                  console.log('✅ Restored LinkedIn session from sessionStorage tokens (plain object fallback)');
-                }
-              }
-            }
+            effectiveUser = restoreLinkedInUserFromStoredTokens('plain object fallback');
           }
         }
       }


### PR DESCRIPTION
Sync  with latest changes from .

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core auth/session restoration paths (LinkedIn OIDC + Firebase) and the shared `user-authenticated` flag semantics, which could affect login/logout behavior across tabs and sites if incorrect.
> 
> **Overview**
> Improves LinkedIn fallback auth restoration by centralizing token-to-user reconstruction (`restoreLinkedInUserFromStoredTokens`) and by deduplicating concurrent SDK restore attempts via an in-flight promise instead of re-running/returning early.
> 
> Adjusts stale-auth cleanup to avoid mutating/removing the shared `localStorage` auth flag during passive `onAuthStateChanged(null)` cleanup, reducing cross-tab side effects, and tightens the LinkedIn Optimizer auth fallback to require an explicit session `user-authenticated === 'true'` plus session Firebase shards (instead of treating anything-but-`'false'` as authenticated).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65a5c54b96827893b1a233af22ae33d438cb083a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->