### PR TITLE
Fix passive Firebase auth shard cleanup

### DIFF
--- a/.github/workflows/nav-guardrails.yml
+++ b/.github/workflows/nav-guardrails.yml
@@ -5,8 +5,10 @@ on:
     branches: [main, dev0, develop]
     paths:
       - "dashboard.html"
+      - "js/firebase-auth.js"
       - "js/navigation.js"
       - "js/logo-link-env.js"
+      - "marketing/js/firebase-auth.js"
       - "marketing/js/navigation.js"
       - "marketing/js/logo-link-env.js"
       - "scripts/check-nav-guardrails.sh"
@@ -16,8 +18,10 @@ on:
     branches: [main, dev0, develop]
     paths:
       - "dashboard.html"
+      - "js/firebase-auth.js"
       - "js/navigation.js"
       - "js/logo-link-env.js"
+      - "marketing/js/firebase-auth.js"
       - "marketing/js/navigation.js"
       - "marketing/js/logo-link-env.js"
       - "scripts/check-nav-guardrails.sh"

--- a/js/firebase-auth.js
+++ b/js/firebase-auth.js
@@ -490,6 +490,10 @@ class AuthManager {
     try {
       const cleared = [];
       const isExplicitSignOut = reason === 'firebase-auth-signed-out' && this._explicitSignOutInProgress;
+      let hadSessionFirebaseAuthShard = false;
+      try {
+        hadSessionFirebaseAuthShard = hasFirebaseAuthShard(window.sessionStorage);
+      } catch (_) {}
       // Only explicit sign-out should mutate the shared localStorage auth flag. Passive
       // onAuthStateChanged(null) is tab-local under browserSessionPersistence; changing the
       // shared flag would perturb auth checks in other tabs.
@@ -529,10 +533,10 @@ class AuthManager {
       for (const storage of storagesToClear) {
         cleared.push(...clearFirebaseAuthShards(storage));
       }
-      if (!isExplicitSignOut && reason === 'firebase-auth-signed-out') {
-        // Session persistence stores live Firebase auth shards in sessionStorage.
-        // Any localStorage auth shards seen during passive cleanup are stale leftovers and
-        // can safely be removed without affecting other tabs' active sessions.
+      if (!isExplicitSignOut && reason === 'firebase-auth-signed-out' && hadSessionFirebaseAuthShard) {
+        // Only clear legacy localStorage shards when this tab already had session
+        // Firebase evidence. A cold passive null auth callback must not erase the
+        // shared fallback evidence other tabs and static pages can still inspect.
         try {
           cleared.push(...clearFirebaseAuthShards(window.localStorage));
         } catch (_) {}

--- a/marketing/js/firebase-auth.js
+++ b/marketing/js/firebase-auth.js
@@ -406,6 +406,10 @@ class AuthManager {
     try {
       const cleared = [];
       const isExplicitSignOut = reason === 'firebase-auth-signed-out' && this._explicitSignOutInProgress;
+      let hadSessionFirebaseAuthShard = false;
+      try {
+        hadSessionFirebaseAuthShard = hasFirebaseAuthShard(window.sessionStorage);
+      } catch (_) {}
       // Only explicit sign-out should mutate the shared localStorage auth flag. Passive
       // onAuthStateChanged(null) is tab-local under browserSessionPersistence; changing the
       // shared flag would perturb auth checks in other tabs.
@@ -445,10 +449,10 @@ class AuthManager {
       for (const storage of storagesToClear) {
         cleared.push(...clearFirebaseAuthShards(storage));
       }
-      if (!isExplicitSignOut && reason === 'firebase-auth-signed-out') {
-        // Session persistence stores live Firebase auth shards in sessionStorage.
-        // Any localStorage auth shards seen during passive cleanup are stale leftovers and
-        // can safely be removed without affecting other tabs' active sessions.
+      if (!isExplicitSignOut && reason === 'firebase-auth-signed-out' && hadSessionFirebaseAuthShard) {
+        // Only clear legacy localStorage shards when this tab already had session
+        // Firebase evidence. A cold passive null auth callback must not erase the
+        // shared fallback evidence other tabs and static pages can still inspect.
         try {
           cleared.push(...clearFirebaseAuthShards(window.localStorage));
         } catch (_) {}

--- a/scripts/check-nav-guardrails.sh
+++ b/scripts/check-nav-guardrails.sh
@@ -91,6 +91,22 @@ forbid_match "marketing/js/navigation.js" \
   "url\\.searchParams\\.set\\(AUTH_HANDOFF_QUERY_(AUTH|PLAN|TS)" \
   "marketing/js/navigation.js must not append auth-handoff query params to marketing links"
 
+# Guardrail: passive Firebase null callbacks must not clear shared localStorage
+# Firebase auth shards from cold tabs. Only tabs that already had sessionStorage
+# Firebase evidence may retire legacy localStorage shards.
+require_match "js/firebase-auth.js" \
+  "hadSessionFirebaseAuthShard[[:space:]]*=[[:space:]]*hasFirebaseAuthShard\\(window\\.sessionStorage\\)" \
+  "js/firebase-auth.js must record session Firebase evidence before passive cleanup"
+require_match "js/firebase-auth.js" \
+  "reason === 'firebase-auth-signed-out' && hadSessionFirebaseAuthShard" \
+  "js/firebase-auth.js passive local shard cleanup must require session Firebase evidence"
+require_match "marketing/js/firebase-auth.js" \
+  "hadSessionFirebaseAuthShard[[:space:]]*=[[:space:]]*hasFirebaseAuthShard\\(window\\.sessionStorage\\)" \
+  "marketing/js/firebase-auth.js must record session Firebase evidence before passive cleanup"
+require_match "marketing/js/firebase-auth.js" \
+  "reason === 'firebase-auth-signed-out' && hadSessionFirebaseAuthShard" \
+  "marketing/js/firebase-auth.js passive local shard cleanup must require session Firebase evidence"
+
 # Guardrail: prevent re-introducing the legacy dashboard copy.
 if [[ -f "app/public/dashboard.html" ]]; then
   error "Legacy file app/public/dashboard.html must not be present"


### PR DESCRIPTION
## Summary
- Guard passive Firebase signed-out cleanup so cold tabs do not erase shared localStorage Firebase auth shards
- Mirror the auth fix in the marketing auth module
- Add guardrails to prevent removing the session-evidence condition again

## Verification
- node --check js/firebase-auth.js
- node --check marketing/js/firebase-auth.js
- bash scripts/check-nav-guardrails.sh
- git diff --check
- npm --prefix app run build

## Notes
- Verified the dashboard storage report on dev0 with a second reviewer. The dual-write exists, but current reads are localStorage-first and navigation already mirrors plans, so no dashboard code change was made for that report.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches client-side auth persistence cleanup logic, where mistakes can cause incorrect logged-in/logged-out state across tabs and subdomains. Scope is small and guarded by CI checks, but impacts authentication UX.
> 
> **Overview**
> Prevents *passive* `onAuthStateChanged(null)` handling from clearing shared `localStorage` Firebase auth shards unless the tab already had session-based Firebase evidence, avoiding cold tabs/logged-out callbacks erasing other tabs’ fallback auth signals.
> 
> Mirrors the same conditional cleanup change in `marketing/js/firebase-auth.js`, and extends the nav guardrails workflow + `scripts/check-nav-guardrails.sh` to enforce that this session-evidence gate remains in place for both auth modules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cd139dd43646e78335117a674331615c7127eb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->