### PR TITLE
Add two SEO blog posts

### DIFF
--- a/marketing/blog.html
+++ b/marketing/blog.html
@@ -133,17 +133,17 @@
 
         <!-- Featured Post (static fallback for crawlers; replaced by JS) -->
         <div id="blogFeatured">
-          <a href="/blog/behavioral-interview-anxiety" class="blog-featured" aria-label="Read featured article: Behavioral Interview Anxiety: Why 85% of Job Seekers Feel Unprepared (And the Fix)">
+          <a href="/blog/below-1-0-leverage-gap-resume" class="blog-featured" aria-label="Read featured article: Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume">
             <div>
               <span class="blog-featured-label">Featured</span>
-              <h2 class="blog-featured-title">Behavioral Interview Anxiety: Why 85% of Job Seekers Feel Unprepared (And the Fix)</h2>
-              <p class="blog-featured-excerpt">The gap between your achievements and your ability to articulate them under pressure is where careers stall. Learn the SAO framework and text-based practice method that closes the Experience Gap.</p>
+              <h2 class="blog-featured-title">Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume</h2>
+              <p class="blog-featured-excerpt">The job market has tilted back toward employers. Learn why generic resumes get filtered out faster and how ATS-friendly resume optimization helps candidates adapt.</p>
               <div class="blog-featured-meta">
-                <span>April 5, 2026</span>
+                <span>April 28, 2026</span>
                 <span class="separator">&middot;</span>
-                <span>7 min read</span>
+                <span>6 min read</span>
                 <span class="separator">&middot;</span>
-                <span>Interview Prep</span>
+                <span>Resume</span>
               </div>
             </div>
             <div class="blog-featured-visual" aria-hidden="true">
@@ -159,6 +159,30 @@
 
         <!-- Post Grid (static fallback for crawlers; replaced by JS) -->
         <div class="blog-grid" id="blogGrid" aria-live="polite">
+          <a href="/blog/68-5-days-response-gap-job-search-burnout" class="blog-card">
+            <div class="blog-card-body">
+              <span class="blog-card-category">Job Search</span>
+              <h3 class="blog-card-title">68.5 Days of Nothing: The Psychological Toll of the 2026 Response Gap</h3>
+              <p class="blog-card-excerpt">Long hiring timelines can drain job seekers before interviews even begin. Learn how to protect your momentum, improve ATS alignment, and prepare while you wait.</p>
+              <div class="blog-card-meta">
+                <span>April 28, 2026</span>
+                <span class="separator">&middot;</span>
+                <span>6 min read</span>
+              </div>
+            </div>
+          </a>
+          <a href="/blog/behavioral-interview-anxiety" class="blog-card">
+            <div class="blog-card-body">
+              <span class="blog-card-category">Interview Prep</span>
+              <h3 class="blog-card-title">Behavioral Interview Anxiety: Why 85% of Job Seekers Feel Unprepared (And the Fix)</h3>
+              <p class="blog-card-excerpt">The gap between your achievements and your ability to articulate them under pressure is where careers stall. Learn the SAO framework and text-based practice method that closes the Experience Gap.</p>
+              <div class="blog-card-meta">
+                <span>April 5, 2026</span>
+                <span class="separator">&middot;</span>
+                <span>7 min read</span>
+              </div>
+            </div>
+          </a>
           <a href="/blog/the-2-percent-rule" class="blog-card">
             <div class="blog-card-body">
               <span class="blog-card-category">Job Search</span>
@@ -256,7 +280,7 @@
   <script src="js/auth-persistence.js"></script>
   <script src="js/navigation.js?v=20260208-1"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>
-  <script src="js/blog-data.js?v=20260405-1"></script>
+  <script src="js/blog-data.js?v=20260428-1"></script>
   <script>
     if (window.JobHackAINavigation && typeof window.JobHackAINavigation.initializeNavigation === 'function') {
       window.JobHackAINavigation.initializeNavigation();

--- a/marketing/blog/68-5-days-response-gap-job-search-burnout.html
+++ b/marketing/blog/68-5-days-response-gap-job-search-burnout.html
@@ -1,0 +1,246 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>68.5 Days of Nothing: The Psychological Toll of the 2026 Response Gap | JobHackAI Blog</title>
+  <meta name="description" content="Long hiring timelines can drain job seekers before interviews even begin. Learn how to protect momentum, improve ATS alignment, and prepare while you wait.">
+  <link rel="canonical" href="https://jobhackai.io/blog/68-5-days-response-gap-job-search-burnout">
+
+  <meta property="og:title" content="68.5 Days of Nothing: The Psychological Toll of the 2026 Response Gap">
+  <meta property="og:description" content="How the response gap affects job seekers and what to do while the hiring process stretches on.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://jobhackai.io/blog/68-5-days-response-gap-job-search-burnout">
+  <meta property="og:site_name" content="JobHackAI">
+  <meta property="og:image" content="https://cdn.marblism.com/ZgQyEP5PP0x.webp">
+  <meta property="article:published_time" content="2026-04-28">
+  <meta property="article:author" content="JobHackAI Team">
+  <meta property="article:section" content="Job Search">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="68.5 Days of Nothing: The 2026 Response Gap">
+  <meta name="twitter:description" content="How to protect your momentum, improve ATS alignment, and prepare for interviews while hiring timelines stretch on.">
+  <meta name="twitter:image" content="https://cdn.marblism.com/ZgQyEP5PP0x.webp">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "68.5 Days of Nothing: The Psychological Toll of the 2026 Response Gap",
+    "description": "Long hiring timelines can drain job seekers before interviews even begin. Learn how to protect momentum, improve ATS alignment, and prepare while you wait.",
+    "image": "https://cdn.marblism.com/ZgQyEP5PP0x.webp",
+    "author": {
+      "@type": "Organization",
+      "name": "JobHackAI",
+      "url": "https://jobhackai.io"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "JobHackAI",
+      "url": "https://jobhackai.io"
+    },
+    "datePublished": "2026-04-28",
+    "dateModified": "2026-04-28",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://jobhackai.io/blog/68-5-days-response-gap-job-search-burnout"
+    }
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://jobhackai.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://jobhackai.io/blog" },
+      { "@type": "ListItem", "position": 3, "name": "68.5 Days of Nothing", "item": "https://jobhackai.io/blog/68-5-days-response-gap-job-search-burnout" }
+    ]
+  }
+  </script>
+
+  <link rel="icon" type="image/png" href="../assets/jobhackai_icon_only_128.png">
+  <link rel="apple-touch-icon" href="../assets/jobhackai_icon_only_128.png">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap">
+  <link rel="stylesheet" href="../css/reset.css">
+  <link rel="stylesheet" href="../css/tokens.css">
+  <link rel="stylesheet" href="../css/main.css">
+  <link rel="stylesheet" href="../css/header.css">
+  <link rel="stylesheet" href="../css/footer.css">
+  <link rel="stylesheet" href="../css/marketing.css">
+  <link rel="stylesheet" href="../css/blog.css">
+  <script src="https://app.jobhackai.io/js/cookie-consent.js?v=20260206-1" defer></script>
+</head>
+<body>
+  <header class="site-header" id="top">
+    <div class="container">
+      <a href="https://jobhackai.io/" class="nav-logo" aria-label="Go to homepage">
+        <svg width="24" height="24" fill="none" stroke="#1F2937" stroke-width="2" xmlns="http://www.w3.org/2000/svg">
+          <rect x="3" y="7" width="18" height="13" rx="2"/>
+          <path d="M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2"/>
+        </svg>
+        <span>JOBHACKAI<sup>&trade;</sup></span>
+      </a>
+      <div class="nav-group">
+        <nav class="nav-links" role="navigation">
+          <!-- Static fallback for crawlers; replaced by navigation.js -->
+          <a href="https://jobhackai.io/">Home</a>
+          <a href="https://jobhackai.io/blog">Blog</a>
+          <a href="https://jobhackai.io/features">Features</a>
+        </nav>
+      </div>
+      <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobileNav">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+  </header>
+  <nav class="mobile-nav" id="mobileNav">
+    <!-- Static fallback for crawlers; replaced by navigation.js -->
+    <a href="https://jobhackai.io/">Home</a>
+    <a href="https://jobhackai.io/blog">Blog</a>
+    <a href="https://jobhackai.io/features">Features</a>
+  </nav>
+  <div class="mobile-nav-backdrop" id="mobileNavBackdrop"></div>
+  <script src="../js/mobile-menu.js?v=20250115-1"></script>
+
+  <main>
+    <div class="container">
+
+      <header class="post-header">
+        <nav class="post-breadcrumb" aria-label="Breadcrumb">
+          <a href="https://jobhackai.io/">Home</a>
+          <span aria-hidden="true">/</span>
+          <a href="https://jobhackai.io/blog">Blog</a>
+          <span aria-hidden="true">/</span>
+          <span aria-current="page">68.5 Days of Nothing</span>
+        </nav>
+        <span class="post-category-badge">Job Search</span>
+        <h1 class="post-title">68.5 Days of Nothing: The Psychological Toll of the 2026 Response Gap</h1>
+        <p class="post-subtitle">The silence of a modern job search is not just quiet. It has a weight. Here is how to protect your momentum while the hiring process stretches on.</p>
+        <div class="post-meta">
+          <span>April 28, 2026</span>
+          <span class="separator">&middot;</span>
+          <span>6 min read</span>
+          <span class="separator">&middot;</span>
+          <span>JobHackAI Team</span>
+        </div>
+      </header>
+
+      <article class="post-body">
+        <div class="prose">
+
+          <p><img src="https://cdn.marblism.com/ZgQyEP5PP0x.webp" alt="A quiet, cinematic image representing the silence and uncertainty of a long job search."></p>
+
+          <p>The silence of a modern job search is not just quiet. It has a weight.</p>
+
+          <p>In 2026, the gap between clicking "Apply" and hearing a human voice can feel like a chasm. It is no longer a few days or even a couple of weeks. Hiring-process research cited by <a href="https://blog.theinterviewguys.com/ai-screening-fatigue/">The Interview Guys</a> places the modern time-to-hire timeline at <strong>68.5 days</strong>, while job-search burnout affects a large share of candidates.</p>
+
+          <p>That is over two months of uncertainty. Two months of refreshing an inbox that does not refresh back. Two months of wondering if your resume even exists in a recruiter's database or if it was swallowed by an algorithm before a human ever saw your name.</p>
+
+          <p>This is not just a "slow market" problem. It is a psychological one. When the feedback loop is this broken, the toll on the candidate is not just financial. It is deeply personal.</p>
+
+          <h2>The Burnout Reality</h2>
+          <p><img src="https://cdn.marblism.com/3mxyD0Y7vFs.webp" alt="A quiet visual metaphor for waiting during a difficult job search."></p>
+
+          <p>We are seeing a spike in what many candidates describe as search fatigue. The pattern is simple: high-intensity effort followed by long periods of zero validation.</p>
+
+          <p>When you spend weeks in limbo, your brain starts to fill the silence with its own narrative. You start to doubt your skills. You question your <a href="https://jobhackai.io/blog/7-day-interview-prep-routine">career advancement strategies</a>. You begin to feel invisible in the machine.</p>
+
+          <p>Most candidates are working harder than ever - optimizing, networking, and tailoring - only to be met with a wall of silence. It is time to be honest about how hiring actually works in 2026 and how you can shorten that response gap without losing your mind.</p>
+
+          <h2>Breaking the Resume Black Hole</h2>
+          <p>Much of that wait happens because your resume is stuck in an "Under Review" status that may really mean "not yet parsed" or "not ranked high enough to review." If your document is not aligned with the Applicant Tracking System (ATS), it can stay in a digital pile a recruiter may never reach.</p>
+
+          <p><strong>Situation:</strong> You have sent out 50 applications and have not heard back in three weeks. You are starting to feel burnout creeping in, wondering if your experience is even relevant anymore.</p>
+
+          <p><strong>Action:</strong> You stop "spraying and praying" and use a dedicated <a href="https://jobhackai.io/features">resume optimization tool</a> to audit your current files. You run your resume through an <a href="https://jobhackai.io/blog/ats-optimization-playbook">ATS-alignment check</a> to see exactly where the keywords are missing and why the formatting may confuse the parser.</p>
+
+          <p><strong>Outcome:</strong> Instead of waiting passively, you create a recruiter-friendly asset that can surface more clearly in screening. The goal is not magic. The goal is to improve your odds of getting to the first human conversation faster.</p>
+
+          <h2>Overcoming Interview Performance Anxiety</h2>
+          <p>The irony of a long wait is that when you finally do get the call, you may be at your lowest point of confidence. You have been out of the game for weeks. Your communication skills feel rusty, and the stakes feel impossibly high because you do not know when the next opportunity will come.</p>
+
+          <p><strong>Situation:</strong> After a long stretch of silence, you finally land an interview for a role you actually want. Instead of being excited, you are afraid of blowing your one chance.</p>
+
+          <p><strong>Action:</strong> You dive into structured <a href="https://jobhackai.io/features">job interview preparation</a> using role-specific practice prompts. You use <a href="https://jobhackai.io/blog/mock-interview-online">mock interview sessions</a> to get comfortable talking about your wins again, replacing the limbo mindset with sharp, credible answers.</p>
+
+          <p><strong>Outcome:</strong> You walk into the interview feeling like a peer, not a supplicant. Because you have practiced the hardest behavioral questions, the wait does not own the conversation. You perform with the confidence of someone who can explain their value clearly.</p>
+
+          <h2>Practical Career Advancement Tips for 2026</h2>
+          <p>If you are currently in the middle of a search, you have to protect your psychology as much as your bank account. Here is how to navigate the response gap without letting it consume your day:</p>
+
+          <ol>
+            <li><strong>Stop counting days; count iterations.</strong> Do not focus only on how long it has been since you applied. Focus on how much you have improved your materials. If you have not heard back in 14 days, optimize your <a href="https://jobhackai.io/blog/linkedin-profile-optimization">LinkedIn profile</a> and resume instead of waiting passively.</li>
+            <li><strong>Set a shutdown time.</strong> The 2026 market is always on, but you cannot be. Constant refreshing increases stress. Pick a time every day when the search ends and you focus on something that gives immediate feedback.</li>
+            <li><strong>Use the 2% rule.</strong> Focus on the small margin of candidates who actually prepare. Most people spend nearly all their time applying and very little time preparing. Flip that. Spend more time on <a href="https://jobhackai.io/blog/behavioral-interview-anxiety">behavioral interview prep</a> so that when the wait is over, you can close the deal.</li>
+          </ol>
+
+          <h2>Taking Back Control</h2>
+          <p>The response gap is a systemic failure of modern hiring, but it does not have to become your personal identity.</p>
+
+          <p>The silence is often a sign that your materials are not speaking the same language as the systems they are being fed into. By focusing on <a href="https://jobhackai.io/blog/the-2-percent-rule">ATS alignment</a> and rigorous interview prep, you can give yourself a better shot at bypassing the black hole and getting to the conversation faster.</p>
+
+          <p>Do not let the silence define your worth. The gap is real, but so is your ability to bridge it.</p>
+
+          <p><img src="https://cdn.marblism.com/k61NIMkpLsL.webp" alt="A strategic break visual representing calm, control, and renewed job search focus."></p>
+
+        </div>
+
+        <div class="post-cta">
+          <h3>Cut through the noise.</h3>
+          <p>Use JobHackAI to improve your resume alignment, prepare for interviews, and stay ready when the next opportunity finally opens.</p>
+          <a class="btn btn-primary" href="https://app.jobhackai.io/login?plan=trial">Start Free Trial</a>
+        </div>
+      </article>
+
+    </div>
+  </main>
+
+  <!-- Footer (inline for crawler visibility) -->
+  <!-- Source: ../components/footer.html - update there and run ../scripts/sync-footer.sh -->
+  <footer class="site-footer">
+    <div class="footer-container">
+      <div class="footer-brand">
+        <svg class="footer-logo" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="3" y="7" width="18" height="13" rx="2" stroke="#1F2937" stroke-width="2"/>
+          <path d="M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2" stroke="#1F2937" stroke-width="2"/>
+        </svg>
+        <span class="footer-name">JOBHACKAI<sup>&trade;</sup></span>
+      </div>
+      <div class="footer-legal">
+        <p>&copy; 2026 JobHackAI. All rights reserved.</p>
+      </div>
+      <div class="footer-links">
+        <a href="https://jobhackai.io/blog">Blog</a>
+        <a href="https://app.jobhackai.io/help" data-app-path="/help">Help</a>
+        <a href="https://app.jobhackai.io/privacy" data-app-path="/privacy">Privacy</a>
+        <a href="https://app.jobhackai.io/terms" data-app-path="/terms">Terms</a>
+        <a href="https://app.jobhackai.io/cookies" data-app-path="/cookies">Cookies</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
+  <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
+  <script src="../js/auth-persistence.js"></script>
+  <script src="../js/navigation.js?v=20260208-1"></script>
+  <script src="../js/universal-logout.js?v=20260208-1"></script>
+  <script>
+    if (window.JobHackAINavigation && typeof window.JobHackAINavigation.initializeNavigation === 'function') {
+      window.JobHackAINavigation.initializeNavigation();
+    } else {
+      window.addEventListener('DOMContentLoaded', function() {
+        if (window.JobHackAINavigation && typeof window.JobHackAINavigation.initializeNavigation === 'function') {
+          window.JobHackAINavigation.initializeNavigation();
+        }
+      });
+    }
+  </script>
+</body>
+</html>

--- a/marketing/blog/below-1-0-leverage-gap-resume.html
+++ b/marketing/blog/below-1-0-leverage-gap-resume.html
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume | JobHackAI Blog</title>
+  <meta name="description" content="The job market has tilted back toward employers. Learn why generic resumes get filtered out faster and how ATS-friendly resume optimization helps candidates adapt.">
+  <link rel="canonical" href="https://jobhackai.io/blog/below-1-0-leverage-gap-resume">
+
+  <meta property="og:title" content="Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume">
+  <meta property="og:description" content="Why generic resumes get filtered out faster in an employer-leaning market, and how to adapt with ATS-friendly resume optimization.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://jobhackai.io/blog/below-1-0-leverage-gap-resume">
+  <meta property="og:site_name" content="JobHackAI">
+  <meta property="og:image" content="https://cdn.marblism.com/EtWCoh4Akuw.webp">
+  <meta property="article:published_time" content="2026-04-28">
+  <meta property="article:author" content="JobHackAI Team">
+  <meta property="article:section" content="Resume">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Below 1.0: The New Leverage Gap and Your Resume">
+  <meta name="twitter:description" content="How to adapt your resume when employers have more leverage and ATS filters do more of the first-pass screening.">
+  <meta name="twitter:image" content="https://cdn.marblism.com/EtWCoh4Akuw.webp">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume",
+    "description": "The job market has tilted back toward employers. Learn why generic resumes get filtered out faster and how ATS-friendly resume optimization helps candidates adapt.",
+    "image": "https://cdn.marblism.com/EtWCoh4Akuw.webp",
+    "author": {
+      "@type": "Organization",
+      "name": "JobHackAI",
+      "url": "https://jobhackai.io"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "JobHackAI",
+      "url": "https://jobhackai.io"
+    },
+    "datePublished": "2026-04-28",
+    "dateModified": "2026-04-28",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://jobhackai.io/blog/below-1-0-leverage-gap-resume"
+    }
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://jobhackai.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://jobhackai.io/blog" },
+      { "@type": "ListItem", "position": 3, "name": "Below 1.0", "item": "https://jobhackai.io/blog/below-1-0-leverage-gap-resume" }
+    ]
+  }
+  </script>
+
+  <link rel="icon" type="image/png" href="../assets/jobhackai_icon_only_128.png">
+  <link rel="apple-touch-icon" href="../assets/jobhackai_icon_only_128.png">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap">
+  <link rel="stylesheet" href="../css/reset.css">
+  <link rel="stylesheet" href="../css/tokens.css">
+  <link rel="stylesheet" href="../css/main.css">
+  <link rel="stylesheet" href="../css/header.css">
+  <link rel="stylesheet" href="../css/footer.css">
+  <link rel="stylesheet" href="../css/marketing.css">
+  <link rel="stylesheet" href="../css/blog.css">
+  <script src="https://app.jobhackai.io/js/cookie-consent.js?v=20260206-1" defer></script>
+</head>
+<body>
+  <header class="site-header" id="top">
+    <div class="container">
+      <a href="https://jobhackai.io/" class="nav-logo" aria-label="Go to homepage">
+        <svg width="24" height="24" fill="none" stroke="#1F2937" stroke-width="2" xmlns="http://www.w3.org/2000/svg">
+          <rect x="3" y="7" width="18" height="13" rx="2"/>
+          <path d="M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2"/>
+        </svg>
+        <span>JOBHACKAI<sup>&trade;</sup></span>
+      </a>
+      <div class="nav-group">
+        <nav class="nav-links" role="navigation">
+          <!-- Static fallback for crawlers; replaced by navigation.js -->
+          <a href="https://jobhackai.io/">Home</a>
+          <a href="https://jobhackai.io/blog">Blog</a>
+          <a href="https://jobhackai.io/features">Features</a>
+        </nav>
+      </div>
+      <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobileNav">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+  </header>
+  <nav class="mobile-nav" id="mobileNav">
+    <!-- Static fallback for crawlers; replaced by navigation.js -->
+    <a href="https://jobhackai.io/">Home</a>
+    <a href="https://jobhackai.io/blog">Blog</a>
+    <a href="https://jobhackai.io/features">Features</a>
+  </nav>
+  <div class="mobile-nav-backdrop" id="mobileNavBackdrop"></div>
+  <script src="../js/mobile-menu.js?v=20250115-1"></script>
+
+  <main>
+    <div class="container">
+
+      <header class="post-header">
+        <nav class="post-breadcrumb" aria-label="Breadcrumb">
+          <a href="https://jobhackai.io/">Home</a>
+          <span aria-hidden="true">/</span>
+          <a href="https://jobhackai.io/blog">Blog</a>
+          <span aria-hidden="true">/</span>
+          <span aria-current="page">Below 1.0</span>
+        </nav>
+        <span class="post-category-badge">Resume</span>
+        <h1 class="post-title">Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume</h1>
+        <p class="post-subtitle">When employer leverage rises, "good enough" resumes get filtered out faster. Here is what the below-1.0 market means for your applications and how to adapt.</p>
+        <div class="post-meta">
+          <span>April 28, 2026</span>
+          <span class="separator">&middot;</span>
+          <span>6 min read</span>
+          <span class="separator">&middot;</span>
+          <span>JobHackAI Team</span>
+        </div>
+      </header>
+
+      <article class="post-body">
+        <div class="prose">
+
+          <p><img src="https://cdn.marblism.com/EtWCoh4Akuw.webp" alt="A polished editorial image showing a modern laptop with a downward-trending market graph crossing below the 1.0 threshold."></p>
+
+          <p>For the last few years, the job market felt like a candidate's playground. You have heard the stories: people landing five offers in a week, signing bonuses for entry-level roles, and recruiters practically begging candidates to show up for a screening call.</p>
+
+          <p>That era is officially over.</p>
+
+          <p>Recent labor market analysis from <a href="https://www.hiringlab.org/2026/02/19/february-2026-labor-market-update-new-year-same-resolutions/">Indeed Hiring Lab</a> has pointed to a job openings-per-unemployed-person ratio around <strong>0.9</strong>, a sign that the market has tilted back toward employers.</p>
+
+          <p>In plain English? There are now more people looking for work than there are jobs available. For the first time in years, the "Leverage Gap" has flipped. Employers have the upper hand, and they know it.</p>
+
+          <p>If you have been applying for roles lately and wondering why your inbox is a graveyard of "unfortunately, we have decided to move forward with other candidates" emails, this is why. The rules have changed. Your resume - the one that worked fine in 2023 - may now be a liability.</p>
+
+          <p>Here is what the "Below 1.0" market actually means for your career and how you need to adapt to survive it.</p>
+
+          <h2>The Math of the Leverage Gap</h2>
+          <p>When the ratio of jobs to seekers is 2.0, recruiters have to be flexible. They may overlook a messy format or a missing keyword because they are under pressure to fill seats.</p>
+
+          <p>When the ratio is below 1.0, the opposite happens. A single job posting for a remote product manager or a mid-level analyst can pull in hundreds of applications quickly. Recruiters do not have time to look for reasons to hire you; they are looking for any reason to reject you just so they can get the pile down to a manageable size.</p>
+
+          <p><img src="https://cdn.marblism.com/Ld3sFrH2SnA.webp" alt="A refined data visualization showing a downward line chart crossing below the 1.0 threshold inside a clean app-style interface."></p>
+
+          <p>This is the Leverage Gap in action. In a high-leverage employer market, "good enough" is often the same as "rejected." To get noticed, you have to be more specific, more relevant, and easier to evaluate.</p>
+
+          <h2>The Death of the "Generalist" Resume</h2>
+          <p>In a below-1.0 market, the generalist is the first to get cut.</p>
+
+          <p>If you are applying for a role with a resume that says you are a "versatile professional with a background in marketing and sales," you are making the recruiter work too hard. The employer does not need a jack-of-all-trades; they may already have dozens of specialists in the pile who have done the exact job they are hiring for.</p>
+
+          <p>Your resume needs to be a laser-focused tool. It needs to speak the exact language of the job description. This is not about lying; it is about translation. You have to translate your experience into the specific outcomes the hiring manager is worried about right now.</p>
+
+          <h2>Why an ATS-Friendly Resume Is No Longer Optional</h2>
+          <p>Because of the sheer volume of applicants, companies are leaning harder than ever on Applicant Tracking Systems (ATS). If your document is not an <strong>ATS-friendly resume</strong>, it likely will not be seen by a human being.</p>
+
+          <p>Most people think "ATS-friendly" just means avoiding fancy graphics or unusual fonts. That is only half the battle. In a crowded market, the ATS is not just a filing cabinet. It can become a ranking engine, scoring your resume against the job description before the recruiter opens the application.</p>
+
+          <p>If you are not using a <a href="https://jobhackai.io/features">resume optimization tool</a> to check your keyword alignment and formatting, you are essentially guessing. In this market, guessing is a luxury candidates cannot afford.</p>
+
+          <p><img src="https://cdn.marblism.com/XzHs1-hcx59.webp" alt="A polished ATS optimization interface showing resume match scoring, keyword alignment, and structured feedback in a clean dashboard."></p>
+
+          <h2>The 2026 Optimization Playbook</h2>
+          <p>So, how do you actually win when the math is against you? You stop treating your job search like a numbers game and start treating it like a precision operation.</p>
+
+          <h3>1. Use a High-Quality Resume Checker</h3>
+          <p>Before you send a single application, run your document through a professional <strong>resume checker</strong>. You need to see what the machine sees. Does your skills section actually match the must-haves in the job post? Are your dates formatted in a way the system can read?</p>
+
+          <p>At JobHackAI, we built our <a href="https://jobhackai.io/blog/ats-optimization-playbook">resume optimization</a> features specifically to bridge this gap. We show you exactly where the red flags are so you can fix them before a recruiter ever sees them.</p>
+
+          <h3>2. Quantify Every Single Bullet Point</h3>
+          <p>In a high-leverage market, employers want proof of ROI. Do not tell them you "managed a team." Tell them you "led a team of 12 to increase quarterly revenue by 18% during a market downturn." Data beats adjectives every single time.</p>
+
+          <h3>3. Align Your LinkedIn</h3>
+          <p>Recruiters will check your LinkedIn profile after they read your resume. If the stories do not match, or if your LinkedIn looks like it has not been touched since 2021, you are creating doubt. Make sure your professional brand is consistent across all platforms. We have a full guide on <a href="https://jobhackai.io/blog/linkedin-profile-optimization">LinkedIn optimization here</a>.</p>
+
+          <h2>High-Stakes Job Interview Preparation</h2>
+          <p>If you manage to beat the below-1.0 ratio and land an interview, the pressure does not let up. In fact, it doubles.</p>
+
+          <p>Because the market is so competitive, the margin for error in an interview is razor-thin. Employers are looking for culture fit, technical depth, and immediate value. They are not hiring for "potential" as much as they used to; they are hiring for performance.</p>
+
+          <p>This is why <strong>job interview preparation</strong> is one of the most critical parts of the process. You cannot just wing it anymore. You need to have your stories ready, your behavioral answers structured with the STAR method, and your technical knowledge sharp.</p>
+
+          <p>We recommend a <a href="https://jobhackai.io/blog/7-day-interview-prep-routine">structured 7-day routine</a> to get your head in the game. Use mock interviews, record yourself, and refine your pitch until it is seamless. When there are 10 other qualified people in the lobby, the person who communicates their value most clearly wins.</p>
+
+          <h2>The Bottom Line</h2>
+          <p>The "Below 1.0" market is a wake-up call. The era of passive job seeking is over.</p>
+
+          <p>But here is the silver lining: most of your competition will not adapt. They will keep sending the same generic resumes to 50 jobs a day and wondering why they are not getting hits.</p>
+
+          <p>By focusing on a truly <strong>ATS-friendly resume</strong>, using the right <strong>resume optimization tool</strong>, and committing to serious <strong>job interview preparation</strong>, you are not just an applicant anymore. You are the candidate who makes the recruiter's decision easier.</p>
+
+          <p>Do not let the stats discourage you. Let them sharpen you.</p>
+
+        </div>
+
+        <div class="post-cta">
+          <h3>See how your resume stacks up.</h3>
+          <p>Ready to compare your resume against the new market reality? Use JobHackAI to find keyword gaps, ATS issues, and high-impact fixes before you apply.</p>
+          <a class="btn btn-primary" href="https://app.jobhackai.io/login?plan=trial">Start Free Trial</a>
+        </div>
+      </article>
+
+    </div>
+  </main>
+
+  <!-- Footer (inline for crawler visibility) -->
+  <!-- Source: ../components/footer.html - update there and run ../scripts/sync-footer.sh -->
+  <footer class="site-footer">
+    <div class="footer-container">
+      <div class="footer-brand">
+        <svg class="footer-logo" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="3" y="7" width="18" height="13" rx="2" stroke="#1F2937" stroke-width="2"/>
+          <path d="M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2" stroke="#1F2937" stroke-width="2"/>
+        </svg>
+        <span class="footer-name">JOBHACKAI<sup>&trade;</sup></span>
+      </div>
+      <div class="footer-legal">
+        <p>&copy; 2026 JobHackAI. All rights reserved.</p>
+      </div>
+      <div class="footer-links">
+        <a href="https://jobhackai.io/blog">Blog</a>
+        <a href="https://app.jobhackai.io/help" data-app-path="/help">Help</a>
+        <a href="https://app.jobhackai.io/privacy" data-app-path="/privacy">Privacy</a>
+        <a href="https://app.jobhackai.io/terms" data-app-path="/terms">Terms</a>
+        <a href="https://app.jobhackai.io/cookies" data-app-path="/cookies">Cookies</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
+  <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
+  <script src="../js/auth-persistence.js"></script>
+  <script src="../js/navigation.js?v=20260208-1"></script>
+  <script src="../js/universal-logout.js?v=20260208-1"></script>
+  <script>
+    if (window.JobHackAINavigation && typeof window.JobHackAINavigation.initializeNavigation === 'function') {
+      window.JobHackAINavigation.initializeNavigation();
+    } else {
+      window.addEventListener('DOMContentLoaded', function() {
+        if (window.JobHackAINavigation && typeof window.JobHackAINavigation.initializeNavigation === 'function') {
+          window.JobHackAINavigation.initializeNavigation();
+        }
+      });
+    }
+  </script>
+</body>
+</html>

--- a/marketing/js/blog-data.js
+++ b/marketing/js/blog-data.js
@@ -13,6 +13,26 @@
 
 window.BLOG_POSTS = [
   {
+    slug: 'below-1-0-leverage-gap-resume',
+    title: 'Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume',
+    excerpt: 'The job market has tilted back toward employers. Learn why generic resumes get filtered out faster and how ATS-friendly resume optimization helps candidates adapt.',
+    category: 'Resume',
+    date: '2026-04-28',
+    readTime: 6,
+    author: 'JobHackAI Team',
+    featured: true,
+  },
+  {
+    slug: '68-5-days-response-gap-job-search-burnout',
+    title: '68.5 Days of Nothing: The Psychological Toll of the 2026 Response Gap',
+    excerpt: 'Long hiring timelines can drain job seekers before interviews even begin. Learn how to protect your momentum, improve ATS alignment, and prepare while you wait.',
+    category: 'Job Search',
+    date: '2026-04-28',
+    readTime: 6,
+    author: 'JobHackAI Team',
+    featured: false,
+  },
+  {
     slug: 'behavioral-interview-anxiety',
     title: 'Behavioral Interview Anxiety: Why 85% of Job Seekers Feel Unprepared (And the Fix)',
     excerpt: 'The gap between your achievements and your ability to articulate them under pressure is where careers stall. Learn the SAO framework and text-based practice method that closes the Experience Gap.',
@@ -20,7 +40,7 @@ window.BLOG_POSTS = [
     date: '2026-04-05',
     readTime: 7,
     author: 'JobHackAI Team',
-    featured: true,
+    featured: false,
   },
   {
     slug: 'the-2-percent-rule',

--- a/marketing/sitemap.xml
+++ b/marketing/sitemap.xml
@@ -18,12 +18,24 @@
   <!-- Blog listing -->
   <url>
     <loc>https://jobhackai.io/blog</loc>
-    <lastmod>2026-04-05</lastmod>
+    <lastmod>2026-04-28</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Blog posts — add a new <url> block for each post you publish -->
+  <url>
+    <loc>https://jobhackai.io/blog/below-1-0-leverage-gap-resume</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://jobhackai.io/blog/68-5-days-response-gap-job-search-burnout</loc>
+    <lastmod>2026-04-28</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
   <url>
     <loc>https://jobhackai.io/blog/behavioral-interview-anxiety</loc>
     <lastmod>2026-04-05</lastmod>


### PR DESCRIPTION
## Summary
- add two new SEO marketing blog posts for the leverage gap and response gap topics
- update the blog listing fallback, BLOG_POSTS data, and sitemap entries
- keep the response-gap article spacing clean after removing the disliked inline image

## Verification
- `node --check marketing/js/blog-data.js`
- blog post resolver check for all BLOG_POSTS entries
- `git diff --check`
- local preview verified at `http://127.0.0.1:4173/blog` and both new clean URLs

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk marketing-only change adding static HTML content and updating blog metadata/sitemap; main risk is broken links or incorrect SEO metadata if slugs/dates mismatch.
> 
> **Overview**
> Adds two new SEO blog posts ("Below 1.0" and "68.5 Days of Nothing") as static HTML pages with full meta/OG/JSON-LD and CTAs.
> 
> Updates `marketing/blog.html` to feature the new resume article, include the new post in the static fallback grid, and bumps the `blog-data.js` cache-buster.
> 
> Extends `marketing/js/blog-data.js` with both posts (and switches the featured flag from `behavioral-interview-anxiety` to the new "Below 1.0" post), and updates `marketing/sitemap.xml` `lastmod` plus adds URL entries for the new slugs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e9497b0700dd383d76f6d6ab8bf0e1ae1411562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->