### PR TITLE
Fix blog CTA + lead-magnet email links to use app.jobhackai.io

### DIFF
--- a/app/functions/api/lead-magnet.js
+++ b/app/functions/api/lead-magnet.js
@@ -59,7 +59,7 @@ function checklistHtml() {
         <li>No graphics, icons, or color blocks behind text</li>
         <li>Length: 1 page if &lt;10 yrs experience, 2 pages otherwise</li>
       </ol>
-      <p style="margin-top:1.5rem;">Want JobHackAI to score and rewrite your resume against any job description? <a href="https://jobhackai.io/pricing-a.html" style="color:#0077B5;">Start your free 3-day trial</a> — converts to $29/mo, cancel anytime.</p>
+      <p style="margin-top:1.5rem;">Want JobHackAI to score and rewrite your resume against any job description? <a href="https://app.jobhackai.io/pricing-a" style="color:#0077B5;">Start your free 3-day trial</a> — converts to $29/mo, cancel anytime.</p>
       <p style="font-size:0.8rem;color:#6B7280;margin-top:2rem;">Sent because you requested the checklist on jobhackai.io. Reply to this email if you didn't.</p>
     </div>
   `;

--- a/js/blog-cta.js
+++ b/js/blog-cta.js
@@ -28,7 +28,7 @@
     wrap.innerHTML = `
       <h3 style="margin:0 0 0.5rem;color:#0B3D91;font-size:1.15rem;">Ready to put this into practice?</h3>
       <p style="margin:0 0 1rem;color:#1F2937;font-size:0.95rem;">${topic.label}. Try 3 days free, then $29/mo. Cancel anytime.</p>
-      <a class="btn-primary" href="https://jobhackai.io/pricing-a.html" data-cta="${topic.cta}" style="display:inline-block;">${topic.label}</a>
+      <a class="btn-primary" href="https://app.jobhackai.io/pricing-a" data-cta="${topic.cta}" style="display:inline-block;">${topic.label}</a>
     `;
     return wrap;
   }


### PR DESCRIPTION
## Summary

Resolves the Cursor Bugbot finding on PR #808 ("Blog CTA links to nonexistent page on marketing domain").

Both `js/blog-cta.js:31` and `app/functions/api/lead-magnet.js:62` hardcoded `https://jobhackai.io/pricing-a.html`, but `pricing-a.html` only ships on the **app** domain (`app.jobhackai.io`). The marketing `_redirects` file maps `/pricing` and `/pricing.html` to the app domain but has no rule for `/pricing-a.html` — so blog readers and lead-magnet email recipients clicking the CTA were 404'ing on the marketing host.

## Changes

- `js/blog-cta.js`: `https://jobhackai.io/pricing-a.html` → `https://app.jobhackai.io/pricing-a`
- `app/functions/api/lead-magnet.js` (`checklistHtml()`): same swap

Matches the convention already used in `marketing/features.html:77` and the redirect target in `marketing/_redirects`.

## Why this is a separate PR

PR #810 (cookie-consent on login.html) was auto-merged from this same branch before this second commit landed, so the URL fix never made it into any PR. This PR carries just commit `56d35de` so it can land on `dev0` and ride into `develop` via PR #808, which will resolve the Bugbot comment there.

## Test plan

- [ ] Open any blog post on the marketing domain; confirm the end-of-post CTA link points to `https://app.jobhackai.io/pricing-a` and resolves to the pricing page (not 404).
- [ ] Submit the homepage lead-magnet form; confirm the checklist email's "Start your free 3-day trial" link points to `https://app.jobhackai.io/pricing-a` and resolves.

https://claude.ai/code/session_01NQfDN73SWideekv7fkz4ye

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQfDN73SWideekv7fkz4ye)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates hardcoded outbound CTA URLs to prevent 404s; no behavior changes beyond link destination.
> 
> **Overview**
> Fixes broken pricing CTAs by updating hardcoded links from the marketing domain to the app domain.
> 
> The blog end-of-post CTA (`js/blog-cta.js`) and the lead-magnet checklist email template (`app/functions/api/lead-magnet.js`) now link to `https://app.jobhackai.io/pricing-a` instead of `https://jobhackai.io/pricing-a.html`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56d35dea330628b6da86055c7b8cd03541dcdb49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->