### PR TITLE
Match extensionless /pricing-a|b in variant regex

### DIFF
--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -582,7 +582,7 @@
         const label = el.getAttribute('data-cta') || 'unknown';
         const plan = el.getAttribute('data-plan') || undefined;
         const path = (window.location.pathname || '').toLowerCase();
-        const variantMatch = path.match(/pricing-([ab])\.html$/);
+        const variantMatch = path.match(/pricing-([ab])(?:\.html)?\/?$/);
         if (window.JHA?.trackEventSafe) {
           window.JHA.trackEventSafe('cta_click', {
             cta_label: label,
@@ -600,7 +600,7 @@
   // Fire pricing_variant_view exactly once per page load, on pricing-a/b.
   function trackPricingVariantOnce() {
     const path = (window.location.pathname || '').toLowerCase();
-    const m = path.match(/pricing-([ab])\.html$/);
+    const m = path.match(/pricing-([ab])(?:\.html)?\/?$/);
     if (!m) return;
     if (window.JHA?.trackEventSafe) {
       window.JHA.trackEventSafe('pricing_variant_view', { pricing_variant: m[1] });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only adjusts a pathname-matching regex used to label analytics events, with no changes to consent logic or data handling.
> 
> **Overview**
> Updates pricing-variant detection in `js/cookie-consent.js` so analytics events (`cta_click` and `pricing_variant_view`) recognize `/pricing-a` and `/pricing-b` URLs even when they are *extensionless* and/or have a trailing slash (by making `.html` optional in the regex).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7399e4d368d5cec1122e65e55289dc8990239325. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->