### PR TITLE
Fix two Bugbot findings on dff0370 (Clarity queue + leads table)

### DIFF
--- a/app/functions/api/lead-magnet.js
+++ b/app/functions/api/lead-magnet.js
@@ -165,8 +165,13 @@ async function recordLead(env, { email, asset, source }) {
         ).bind(email, asset, source || null).run();
         return;
       } catch (insertErr) {
-        // First-run case (or table dropped): create it once per isolate
-        // and retry. Subsequent requests skip the DDL entirely.
+        // First-run case (or table dropped externally): reset the cached
+        // flag so ensureLeadsTable re-runs the DDL, then retry the INSERT.
+        // Without the reset, a table dropped after the first successful
+        // ensure would never be recreated for the lifetime of the isolate
+        // (which can be hours), and every subsequent INSERT would silently
+        // fall back to KV.
+        _leadsTableEnsured = false;
         const ensured = await ensureLeadsTable(db);
         if (ensured) {
           await db.prepare(

--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -590,8 +590,16 @@
   // Queues / bootstraps Clarity like gtagSafe: init() may still be awaiting
   // server consent when identifyUser runs, so window.clarity may not exist yet.
   window.JHA.clarityIdentifySafe = function(userId) {
-    if (!userId || !hasAnalyticsConsent() || !CLARITY_PROJECT_ID) return;
+    if (!userId || !CLARITY_PROJECT_ID) return;
     const id = String(userId);
+    if (!hasAnalyticsConsent()) {
+      // Consent undecided: queue so identify fires after "Accept Analytics".
+      // Explicit reject: drop. Reject-all clears _pendingClarityIdentify.
+      if (getConsent() === null && _pendingClarityIdentify.length < MAX_PENDING_CALLS) {
+        _pendingClarityIdentify.push(id);
+      }
+      return;
+    }
     try { loadClarityScript(); } catch (_) { /* ignore */ }
     if (typeof window.clarity === 'function') {
       try { window.clarity('identify', id); } catch (_) { /* ignore */ }


### PR DESCRIPTION
## Summary

Resolves two Cursor Bugbot findings on commit `dff0370`:

1. **Clarity identify silently dropped when consent undecided** (`js/cookie-consent.js`)
2. **Cached flag prevents `leads` table recreation after drop** (`app/functions/api/lead-magnet.js`)

## Findings

### 1. `clarityIdentifySafe` mirrors `gtagSafe` queuing

`clarityIdentifySafe` returned early on `!hasAnalyticsConsent()` without distinguishing **explicitly declined** from **no decision yet**. `gtagSafe` handles this correctly — when `getConsent() === null` it pushes onto `_pendingGtagCalls` so the call replays after "Accept Analytics".

When `identifyUser` fires during signup before the user has touched the consent banner, the GA `user_id` was correctly queued via `gtagSafe`, but the Clarity `identify` call was silently dropped. If the user later accepted analytics, the Clarity session was no longer attributable to that user.

**Fix**: branch on `getConsent() === null` and push onto the existing `_pendingClarityIdentify` queue (already flushed by `loadClarityScript()` / accept handlers and cleared on reject — no new infrastructure needed).

### 2. `recordLead` resets `_leadsTableEnsured` before recovery

The module-level `_leadsTableEnsured` flag was a one-way latch — set `true` after the first successful `CREATE TABLE IF NOT EXISTS` and never reset. If the `leads` table was dropped externally while the Worker isolate was alive:

1. INSERT fails
2. catch calls `ensureLeadsTable(db)`
3. cached flag short-circuits DDL → returns `true` without recreating the table
4. retry INSERT also fails
5. every subsequent request silently falls back to KV until the isolate recycles (could be hours)

**Fix**: reset `_leadsTableEnsured = false` in the catch path so the recovery actually runs `CREATE TABLE IF NOT EXISTS` before retrying. The cached fast path on the success branch is preserved.

## Test plan

- [ ] `node --check` passes for both files (verified locally before commit)
- [ ] In an incognito window with no prior consent decision, hit a flow that calls `identifyUser` (e.g. signup) BEFORE clicking the consent banner. Confirm `_pendingClarityIdentify` contains the uid (DevTools), then click "Accept Analytics" and confirm `clarity('identify', uid)` is called from the flush.
- [ ] Reject analytics on a fresh visit and confirm subsequent `clarityIdentifySafe(uid)` calls neither queue nor fire.
- [ ] In a staging Worker, drop the `leads` table after a successful submission, submit again, and confirm the row lands in the recreated D1 table (not KV).

https://claude.ai/code/session_01NQfDN73SWideekv7fkz4ye

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQfDN73SWideekv7fkz4ye)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes analytics consent/queuing behavior and modifies D1 write recovery logic for lead capture; mistakes could affect tracking attribution or lead persistence.
> 
> **Overview**
> Fixes analytics attribution by updating `clarityIdentifySafe` to **queue Clarity `identify` calls when consent is undecided** (matching the existing GA queuing behavior) and only drop them on explicit reject.
> 
> Improves lead capture resilience by resetting the module-level `_leadsTableEnsured` cache when a D1 insert fails, ensuring `ensureLeadsTable()` actually re-runs DDL to recreate the `leads` table before retrying the insert (instead of falling back to KV for the rest of the isolate lifetime).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 747b0c67440ef0fb3989066538736c504f6e7c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->