### PR TITLE
Fix three Bugbot findings on 28872d4 (dead toggle, GA4 idempotency, apiBase fallback)

### DIFF
--- a/app/functions/api/stripe-webhook.js
+++ b/app/functions/api/stripe-webhook.js
@@ -84,13 +84,17 @@ export async function onRequest(context) {
 
   // Helper to update plan in D1 (source of truth) with timestamp-based ordering protection
   // Prevents out-of-order webhooks from overwriting newer states with older data
+  // Returns true when the row was written, false when the update was skipped
+  // (no uid, or out-of-order event). Callers gate downstream side effects
+  // like GA4 conversion events on this return value so a stale or replayed
+  // webhook doesn't double-count conversions in GA4.
   const updatePlanInD1 = async (uid, planData, eventTimestampSeconds) => {
-    if (!uid) return;
+    if (!uid) return false;
     try {
       // Get current plan_updated_at timestamp for ordering check
       if (eventTimestampSeconds !== undefined && Number.isFinite(eventTimestampSeconds)) {
         const currentPlanData = await getUserPlanData(env, uid);
-        
+
         if (currentPlanData && currentPlanData.planUpdatedAt) {
           // Convert stored ISO 8601 datetime to Unix timestamp for comparison
           const storedTimestamp = Math.floor(new Date(currentPlanData.planUpdatedAt).getTime() / 1000);
@@ -98,7 +102,7 @@ export async function onRequest(context) {
 
           if (eventTimestamp < storedTimestamp) {
             console.log(`⏭️ [WEBHOOK] Skipping out-of-order event: event.created=${eventTimestamp} < stored=${storedTimestamp} for uid=${uid}`);
-            return; // Skip update - this event is older than what we already have
+            return false; // Skip update - this event is older than what we already have
           }
         }
       }
@@ -142,6 +146,7 @@ export async function onRequest(context) {
           console.warn('[WEBHOOK] KV cache invalidation error:', kvErr);
         }
       }
+      return true;
     } catch (error) {
       console.error('[WEBHOOK] Error updating plan in D1:', error);
       throw error;
@@ -239,7 +244,7 @@ export async function onRequest(context) {
         }
 
         console.log(`✍️ WRITING TO D1: users.plan = ${effectivePlan} for uid=${uid}`);
-        await updatePlanInD1(uid, {
+        const planApplied = await updatePlanInD1(uid, {
           plan: effectivePlan,
           stripeCustomerId: customerId,
           stripeSubscriptionId: subscriptionId,
@@ -248,53 +253,57 @@ export async function onRequest(context) {
           currentPeriodEnd: subscription?.current_period_end ? new Date(subscription.current_period_end * 1000).toISOString() : null,
           hasEverPaid: isPaidPlan(effectivePlan) ? 1 : undefined
         }, event.created);
-        console.log(`✅ D1 WRITE SUCCESS: ${uid} → ${effectivePlan}`);
+        console.log(`✅ D1 WRITE ${planApplied ? 'SUCCESS' : 'SKIPPED (out-of-order)'}: ${uid} → ${effectivePlan}`);
 
         // GA4 conversion: trial_start for $0 trials, purchase for paid plans.
         // Use a synthetic client_id keyed on uid (the user_id config from
         // the browser merges these sessions in GA4's identity graph).
         // Telemetry is fire-and-forget via context.waitUntil so a slow GA4
         // endpoint can't push the webhook past Stripe's ~20s timeout.
-        let planAmount = null;
-        if (sess?.amount_total != null) {
-          const total = Number(sess.amount_total);
-          if (Number.isFinite(total)) planAmount = total / 100;
-        }
-        if (planAmount == null) {
-          planAmount = subscriptionPriceAmountDollars(subscription);
-        }
-        if (planAmount == null) {
-          planAmount = hardcodedPlanAmountDollars(effectivePlan);
-        }
-        if (effectivePlan === 'trial') {
-          context.waitUntil(sendGa4Event(env, {
-            clientId: `server.${uid}`,
-            userId: uid,
-            name: 'trial_start',
-            params: {
-              plan: 'trial',
-              source: 'stripe_checkout',
-              session_id: sessionId
-            }
-          }));
-        } else if (isPaidPlan(effectivePlan)) {
-          context.waitUntil(sendGa4Event(env, {
-            clientId: `server.${uid}`,
-            userId: uid,
-            name: 'purchase',
-            params: {
-              transaction_id: sessionId,
-              currency: (sess?.currency || 'usd').toUpperCase(),
-              value: planAmount,
-              plan: effectivePlan,
-              items: [{
-                item_id: priceId || effectivePlan,
-                item_name: effectivePlan,
-                price: planAmount,
-                quantity: 1
-              }]
-            }
-          }));
+        // Skip on stale/replayed webhooks (planApplied === false) so we
+        // don't inflate trial_start / purchase counts in GA4.
+        if (planApplied) {
+          let planAmount = null;
+          if (sess?.amount_total != null) {
+            const total = Number(sess.amount_total);
+            if (Number.isFinite(total)) planAmount = total / 100;
+          }
+          if (planAmount == null) {
+            planAmount = subscriptionPriceAmountDollars(subscription);
+          }
+          if (planAmount == null) {
+            planAmount = hardcodedPlanAmountDollars(effectivePlan);
+          }
+          if (effectivePlan === 'trial') {
+            context.waitUntil(sendGa4Event(env, {
+              clientId: `server.${uid}`,
+              userId: uid,
+              name: 'trial_start',
+              params: {
+                plan: 'trial',
+                source: 'stripe_checkout',
+                session_id: sessionId
+              }
+            }));
+          } else if (isPaidPlan(effectivePlan)) {
+            context.waitUntil(sendGa4Event(env, {
+              clientId: `server.${uid}`,
+              userId: uid,
+              name: 'purchase',
+              params: {
+                transaction_id: sessionId,
+                currency: (sess?.currency || 'usd').toUpperCase(),
+                value: planAmount,
+                plan: effectivePlan,
+                items: [{
+                  item_id: priceId || effectivePlan,
+                  item_name: effectivePlan,
+                  price: planAmount,
+                  quantity: 1
+                }]
+              }
+            }));
+          }
         }
       } else {
         console.warn(`⚠️ SKIPPED PLAN UPDATE: effectivePlan=${effectivePlan}, uid=${uid}`);
@@ -471,13 +480,56 @@ export async function onRequest(context) {
         isTrialConversion: previousPlan === 'trial' && effectivePlan !== 'trial' && status === 'active'
       });
       
-      if (previousPlan === 'trial' && effectivePlan !== 'trial' && status === 'active') {
+      const isTrialConversion = previousPlan === 'trial' && effectivePlan !== 'trial' && status === 'active';
+
+      if (isTrialConversion) {
         console.log(`🎉 TRIAL CONVERTED: ${uid} → ${effectivePlan} (trial expired, subscription now active)`);
 
+        // Reset usage when converting from trial to paid plan
+        // This ensures users get a fresh start with their new plan limits
+        if (['essential', 'pro', 'premium'].includes(effectivePlan)) {
+          console.log('[WEBHOOK] Resetting usage for trial conversion', {
+            uid,
+            fromPlan: previousPlan,
+            toPlan: effectivePlan
+          });
+
+          // Reset interview questions usage (uses feature_daily_usage table)
+          await resetFeatureDailyUsage(env, uid, 'interview_questions').catch((error) => {
+            console.error('[WEBHOOK] Failed to reset interview questions usage (non-blocking):', error);
+          });
+
+          // Reset resume feedback usage (uses usage_events table)
+          await resetUsageEvents(env, uid, 'resume_feedback').catch((error) => {
+            console.error('[WEBHOOK] Failed to reset resume feedback usage (non-blocking):', error);
+          });
+        }
+      }
+
+      console.log(`✍️ UPDATING D1: users.plan = ${effectivePlan} for uid=${uid}`);
+      const planApplied = await updatePlanInD1(uid, {
+        plan: effectivePlan,
+        stripeCustomerId: customerId,
+        stripeSubscriptionId: sub.id,
+        subscriptionStatus: status,
+        trialEndsAt: trialEndsAtISO,
+        currentPeriodEnd: sub.current_period_end ? new Date(sub.current_period_end * 1000).toISOString() : null,
+        cancelAt: cancelAt || null, // null clears the field (undefined is skipped)
+        scheduledPlan: scheduledPlan || null, // null clears the field (undefined is skipped)
+        scheduledAt: scheduledAt || null, // null clears the field (undefined is skipped)
+        hasEverPaid: isPaidPlan(effectivePlan) ? 1 : undefined
+      }, event.created);
+
+      console.log(`✅ D1 UPDATE ${planApplied ? 'SUCCESS' : 'SKIPPED (out-of-order)'}: ${uid} → ${effectivePlan}${trialEndsAtISO ? ` (trial ends: ${trialEndsAtISO})` : ''}`);
+
+      if (planApplied && isTrialConversion) {
         // GA4 conversion: trial → paid is a real `purchase`. Without this
         // event, blog/social attribution loses the highest-value step.
         // Fire-and-forget via context.waitUntil so the webhook returns
         // immediately and Stripe doesn't retry on a slow GA4 endpoint.
+        // Gated on planApplied so a stale or replayed webhook (whose D1
+        // write was skipped by updatePlanInD1's ordering check) doesn't
+        // double-count the conversion in GA4.
         const convertedPlanAmount =
           subscriptionPriceAmountDollars(sub) ?? hardcodedPlanAmountDollars(effectivePlan);
         context.waitUntil(sendGa4Event(env, {
@@ -498,43 +550,7 @@ export async function onRequest(context) {
             }]
           }
         }));
-
-        // Reset usage when converting from trial to paid plan
-        // This ensures users get a fresh start with their new plan limits
-        if (['essential', 'pro', 'premium'].includes(effectivePlan)) {
-          console.log('[WEBHOOK] Resetting usage for trial conversion', {
-            uid,
-            fromPlan: previousPlan,
-            toPlan: effectivePlan
-          });
-          
-          // Reset interview questions usage (uses feature_daily_usage table)
-          await resetFeatureDailyUsage(env, uid, 'interview_questions').catch((error) => {
-            console.error('[WEBHOOK] Failed to reset interview questions usage (non-blocking):', error);
-          });
-          
-          // Reset resume feedback usage (uses usage_events table)
-          await resetUsageEvents(env, uid, 'resume_feedback').catch((error) => {
-            console.error('[WEBHOOK] Failed to reset resume feedback usage (non-blocking):', error);
-          });
-        }
       }
-      
-      console.log(`✍️ UPDATING D1: users.plan = ${effectivePlan} for uid=${uid}`);
-      await updatePlanInD1(uid, {
-        plan: effectivePlan,
-        stripeCustomerId: customerId,
-        stripeSubscriptionId: sub.id,
-        subscriptionStatus: status,
-        trialEndsAt: trialEndsAtISO,
-        currentPeriodEnd: sub.current_period_end ? new Date(sub.current_period_end * 1000).toISOString() : null,
-        cancelAt: cancelAt || null, // null clears the field (undefined is skipped)
-        scheduledPlan: scheduledPlan || null, // null clears the field (undefined is skipped)
-        scheduledAt: scheduledAt || null, // null clears the field (undefined is skipped)
-        hasEverPaid: isPaidPlan(effectivePlan) ? 1 : undefined
-      }, event.created);
-      
-      console.log(`✅ D1 UPDATE SUCCESS: ${uid} → ${effectivePlan}${trialEndsAtISO ? ` (trial ends: ${trialEndsAtISO})` : ''}`);
     }
 
     if (event.type === 'customer.subscription.deleted') {

--- a/js/lead-magnet.js
+++ b/js/lead-magnet.js
@@ -12,7 +12,18 @@
   }
 
   function apiBase() {
-    return window.JHA.apiBase;
+    if (window.JHA && typeof window.JHA.apiBase === 'string') {
+      return window.JHA.apiBase;
+    }
+    // Fallback when cookie-consent.js failed to load (ad blocker, network
+    // error). Mirrors the logic there so the lead-magnet form still posts
+    // to the correct backend instead of throwing on `undefined.apiBase`.
+    const hostname = (window.location.hostname || '').toLowerCase();
+    const isAppDomain = hostname.startsWith('app.') ||
+      hostname.startsWith('dev.') ||
+      hostname.startsWith('qa.') ||
+      hostname === 'localhost';
+    return isAppDomain ? '' : 'https://app.jobhackai.io';
   }
 
   ready(function () {

--- a/js/login-page.js
+++ b/js/login-page.js
@@ -124,7 +124,7 @@ function safeFallbackInit() {
     if (banner) banner.style.display = 'none';
     
     // Minimal password toggle handlers (shows error on click)
-    ['toggleLoginPassword', 'toggleSignupPassword', 'toggleConfirmPassword'].forEach(id => {
+    ['toggleLoginPassword', 'toggleSignupPassword'].forEach(id => {
       const btn = document.getElementById(id);
       if (btn) {
         btn.onclick = () => {
@@ -1303,7 +1303,6 @@ document.addEventListener('DOMContentLoaded', async function() {
   // Setup toggles for all password fields
   setupPasswordToggle('toggleLoginPassword', 'loginPassword', 'loginPasswordEyeIcon');
   setupPasswordToggle('toggleSignupPassword', 'signupPassword', 'signupPasswordEyeIcon');
-  setupPasswordToggle('toggleConfirmPassword', 'confirmPassword', 'confirmPasswordEyeIcon');
   
   console.log('[AUTH INIT COMPLETE] All initialization successful');
   } catch (err) {


### PR DESCRIPTION
## Summary

Resolves three Cursor Bugbot findings on commit `28872d4`:

1. **Removed confirm-password HTML but JS toggle setup remains** (`js/login-page.js`)
2. **GA4 events fire on skipped out-of-order updates** (`app/functions/api/stripe-webhook.js`)
3. **Lead-magnet `apiBase()` crashes if cookie-consent fails to load** (`js/lead-magnet.js`)

## Findings

### 1. Dead `confirmPassword` toggle wiring

`login.html` no longer ships `#confirmPassword` / `#toggleConfirmPassword` / `#confirmPasswordEyeIcon`, but `login-page.js` still:
- Passes those IDs to `setupPasswordToggle(...)` at the main wire-up
- Lists `'toggleConfirmPassword'` in the fallback `forEach` that wires the "service unavailable" click handler

`setupPasswordToggle` has null guards (`if (!toggleBtn || !passwordInput || !icon) return;`), so this isn't crashing today — but the references are dead code and would become a trap if a future refactor relaxes those guards. Drop both.

### 2. GA4 fires on stale/replayed Stripe webhooks

`updatePlanInD1` silently `return;`s when an event's `event.created` is older than the row's stored `planUpdatedAt`. Its three callers unconditionally fired GA4 conversion events afterwards:

- `checkout.session.completed` → `trial_start` (line 270)
- `checkout.session.completed` → `purchase` (line 281)
- `customer.subscription.updated` → `purchase` for trial→paid (line 483, fires *before* the D1 update)

A stale or replayed Stripe webhook that correctly skipped the D1 write was still posting to GA4's Measurement Protocol — double-counting `trial_start` and `purchase` and inflating revenue.

**Fix:**
- `updatePlanInD1` now returns `true` on success and `false` on skip (no `uid`, or out-of-order). Errors still throw — they don't return `false`.
- All three callers capture the return value as `planApplied`; the GA4 `context.waitUntil(sendGa4Event(...))` calls are gated on it.
- For the trial→paid site, the GA4 event was restructured to fire **after** the D1 update so it can be gated on `planApplied`. Same intent, same params; usage-reset side effects keep their existing position.
- WRITE/UPDATE logs now distinguish `SUCCESS` from `SKIPPED (out-of-order)` so the skip shows up in logs.

### 3. Defensive `apiBase()` fallback

`apiBase()` did `return window.JHA.apiBase` with no defensive check. `window.JHA` is initialized by `cookie-consent.js`; if that script is blocked (ad blocker, network error, CSP), `window.JHA` is `undefined` and `.apiBase` throws `TypeError`. The submit handler's outer `try/catch` swallows the error, so the user sees a generic message and the form silently breaks.

**Fix:** branch on `window.JHA && typeof window.JHA.apiBase === 'string'`, then fall back to the same hostname-based logic `cookie-consent.js` uses (`app|dev|qa|localhost → ''`, else `https://app.jobhackai.io`). The form keeps working when the consent script never loaded.

## Test plan

- [x] `node --check` passes for `login-page.js`, `lead-magnet.js`, `cookie-consent.js`, `stripe-webhook.js`
- [ ] Open `/login` in a browser; confirm no console errors and the existing login/signup password toggles still work
- [ ] Open the homepage with `cookie-consent.js` blocked in DevTools (Network → block request URL); submit the lead-magnet form and confirm the request still goes to `https://app.jobhackai.io/api/lead-magnet` and the success message renders
- [ ] Replay a fresh `checkout.session.completed` event with Stripe CLI; confirm `trial_start` (or `purchase`) shows up in GA4 DebugView
- [ ] Replay an older (out-of-order) `checkout.session.completed` event for the same uid; confirm the WRITE log says `SKIPPED (out-of-order)` and **no** GA4 event fires
- [ ] Same idempotency check for the trial→paid path on `customer.subscription.updated`

https://claude.ai/code/session_01NQfDN73SWideekv7fkz4ye

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQfDN73SWideekv7fkz4ye)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe webhook plan-update flow and GA4 conversion emission; a logic mistake could suppress legitimate conversion tracking or change plan-side effects, though changes are small and guarded.
> 
> **Overview**
> Improves Stripe webhook idempotency by making `updatePlanInD1` return whether a plan write was actually applied (vs skipped due to missing `uid` or out-of-order timestamps), and uses that signal to **gate GA4 Measurement Protocol events** so stale/replayed webhooks don’t double-count `trial_start`/`purchase` conversions (including the trial→paid path, which now fires after the D1 update). Logging now distinguishes successful writes from out-of-order skips.
> 
> Hardens frontend scripts by adding a hostname-based `apiBase()` fallback in `lead-magnet.js` when `cookie-consent.js`/`window.JHA` is unavailable, and removes dead confirm-password toggle wiring from `login-page.js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 703c762db0e1d3ba0887bad120b256f1b9824100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->