### PR TITLE
Gate trial-conversion usage reset on planApplied

### DIFF
--- a/app/functions/api/stripe-webhook.js
+++ b/app/functions/api/stripe-webhook.js
@@ -484,26 +484,6 @@ export async function onRequest(context) {
 
       if (isTrialConversion) {
         console.log(`🎉 TRIAL CONVERTED: ${uid} → ${effectivePlan} (trial expired, subscription now active)`);
-
-        // Reset usage when converting from trial to paid plan
-        // This ensures users get a fresh start with their new plan limits
-        if (['essential', 'pro', 'premium'].includes(effectivePlan)) {
-          console.log('[WEBHOOK] Resetting usage for trial conversion', {
-            uid,
-            fromPlan: previousPlan,
-            toPlan: effectivePlan
-          });
-
-          // Reset interview questions usage (uses feature_daily_usage table)
-          await resetFeatureDailyUsage(env, uid, 'interview_questions').catch((error) => {
-            console.error('[WEBHOOK] Failed to reset interview questions usage (non-blocking):', error);
-          });
-
-          // Reset resume feedback usage (uses usage_events table)
-          await resetUsageEvents(env, uid, 'resume_feedback').catch((error) => {
-            console.error('[WEBHOOK] Failed to reset resume feedback usage (non-blocking):', error);
-          });
-        }
       }
 
       console.log(`✍️ UPDATING D1: users.plan = ${effectivePlan} for uid=${uid}`);
@@ -523,6 +503,30 @@ export async function onRequest(context) {
       console.log(`✅ D1 UPDATE ${planApplied ? 'SUCCESS' : 'SKIPPED (out-of-order)'}: ${uid} → ${effectivePlan}${trialEndsAtISO ? ` (trial ends: ${trialEndsAtISO})` : ''}`);
 
       if (planApplied && isTrialConversion) {
+        // Reset usage when converting from trial to paid plan
+        // This ensures users get a fresh start with their new plan limits.
+        // Gated on planApplied so a stale or replayed webhook (whose D1
+        // write was skipped by updatePlanInD1's ordering check) doesn't
+        // wipe out usage the user has legitimately accumulated since the
+        // real conversion was already processed.
+        if (['essential', 'pro', 'premium'].includes(effectivePlan)) {
+          console.log('[WEBHOOK] Resetting usage for trial conversion', {
+            uid,
+            fromPlan: previousPlan,
+            toPlan: effectivePlan
+          });
+
+          // Reset interview questions usage (uses feature_daily_usage table)
+          await resetFeatureDailyUsage(env, uid, 'interview_questions').catch((error) => {
+            console.error('[WEBHOOK] Failed to reset interview questions usage (non-blocking):', error);
+          });
+
+          // Reset resume feedback usage (uses usage_events table)
+          await resetUsageEvents(env, uid, 'resume_feedback').catch((error) => {
+            console.error('[WEBHOOK] Failed to reset resume feedback usage (non-blocking):', error);
+          });
+        }
+
         // GA4 conversion: trial → paid is a real `purchase`. Without this
         // event, blog/social attribution loses the highest-value step.
         // Fire-and-forget via context.waitUntil so the webhook returns


### PR DESCRIPTION
## Summary

Resolves the Cursor Bugbot finding on commit `074de0f` (the merge of PR #814): "Usage reset not gated on plan-write success" (Medium severity).

## Finding

PR #814 introduced `planApplied` in `updatePlanInD1`'s three callers to prevent GA4 double-counting on stale / out-of-order webhooks, and correctly gated the trial→paid `purchase` event on it. But in the `customer.subscription.updated` handler, the usage reset block (`resetFeatureDailyUsage` + `resetUsageEvents`) was left sitting *above* the D1 write inside `if (isTrialConversion) { ... }` and ran unconditionally — even when `updatePlanInD1` later returned `false` because the event was older than the row's stored `planUpdatedAt`.

### Concrete bad scenario

1. Real `customer.subscription.updated` arrives with the trial→paid transition. D1 updates, GA4 fires, usage resets.
2. User spends part of their new paid-plan quota over the next hour.
3. Stripe redelivers an older webhook (delayed delivery, retry storm, etc.).
4. `updatePlanInD1` correctly skips the D1 write (out-of-order check). PR #814 correctly skips the GA4 event.
5. **But the usage reset still runs**, wiping the quota the user has been legitimately spending against their paid plan.

## Fix

Move the usage reset block into the same `if (planApplied && isTrialConversion)` block that already gates the GA4 `purchase` event, sitting after the D1 write. Now both side effects of the trial→paid conversion are gated together.

The "🎉 TRIAL CONVERTED" log stays *before* the D1 write — it only announces detection of the transition, and the `✅ D1 UPDATE SKIPPED (out-of-order)` log right below makes the actual outcome explicit.

## Test plan

- [x] `node --check app/functions/api/stripe-webhook.js` passes
- [ ] Replay a fresh `customer.subscription.updated` event with `previous_attributes.status='trialing'` → `status='active'`. Confirm: D1 updates, `feature_daily_usage` row for `interview_questions` resets, `usage_events` for `resume_feedback` resets, GA4 `purchase` fires.
- [ ] Replay an *older* `customer.subscription.updated` for the same uid. Confirm: log says `D1 UPDATE SKIPPED (out-of-order)`, no usage reset, no GA4 event.
- [ ] Same idempotency check for the non-conversion case (e.g. `cancel_at` change) — confirm no spurious resets.

https://claude.ai/code/session_01NQfDN73SWideekv7fkz4ye

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQfDN73SWideekv7fkz4ye)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Stripe webhook billing/usage side effects; incorrect gating could cause missed or repeated usage resets during trial→paid conversions, but the change is small and makes behavior more idempotent.
> 
> **Overview**
> Prevents stale/out-of-order `customer.subscription.updated` webhooks from wiping a user’s paid-plan quota by moving the trial→paid usage reset (`resetFeatureDailyUsage`/`resetUsageEvents`) to run *only* when `updatePlanInD1` actually applies the plan change (`planApplied === true`).
> 
> Keeps the conversion detection log, but reorders the D1 write earlier so both usage resets and the GA4 `purchase` conversion remain consistently gated on the same ordering/idempotency check.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d064b3681662c55f35a4178e0cda0e2ea1a56900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->