### PR TITLE
Wire conversion analytics + ship Phase-3 conversion fixes

### DIFF
--- a/app/functions/api/lead-magnet.js
+++ b/app/functions/api/lead-magnet.js
@@ -199,16 +199,21 @@ async function recordLead(env, { email, asset, source }) {
   } catch (e) {
     console.warn('[LEAD-MAGNET] D1 insert failed, falling back to KV:', e?.message || e);
   }
-  try {
-    if (env.JOBHACKAI_KV) {
+  if (env.JOBHACKAI_KV) {
+    try {
       const key = `lead:${asset}:${Date.now()}:${crypto.randomUUID()}`;
       await env.JOBHACKAI_KV.put(key, JSON.stringify({ email, asset, source, ts: new Date().toISOString() }), {
         expirationTtl: 60 * 60 * 24 * 365 // 1 year
       });
+      return;
+    } catch (e) {
+      console.warn('[LEAD-MAGNET] KV fallback failed (non-blocking):', e?.message || e);
+      return;
     }
-  } catch (e) {
-    console.warn('[LEAD-MAGNET] KV fallback failed (non-blocking):', e?.message || e);
   }
+  // Neither D1 nor KV is available — surface this so a misconfigured
+  // environment doesn't drop leads silently while still returning 200.
+  console.warn(`[LEAD-MAGNET] Lead dropped: no D1 or KV binding available (asset=${asset}, email=${redactEmailForLog(email)}, source=${source || 'unknown'})`);
 }
 
 export async function onRequest(context) {

--- a/app/functions/api/stripe-webhook.js
+++ b/app/functions/api/stripe-webhook.js
@@ -42,8 +42,14 @@ function subscriptionPriceAmountDollars(subscription) {
   return n / 100;
 }
 
+// Returns null for unrecognized plans so callers can detect a missing price
+// (e.g. a new paid plan added to isPaidPlan but not mapped here) instead of
+// silently sending value: 0 to GA4 and distorting revenue reports.
 function hardcodedPlanAmountDollars(plan) {
-  return plan === 'essential' ? 29 : plan === 'pro' ? 59 : plan === 'premium' ? 99 : 0;
+  if (plan === 'essential') return 29;
+  if (plan === 'pro') return 59;
+  if (plan === 'premium') return 99;
+  return null;
 }
 
 export async function onRequest(context) {
@@ -263,17 +269,15 @@ export async function onRequest(context) {
         // Skip on stale/replayed webhooks (planApplied === false) so we
         // don't inflate trial_start / purchase counts in GA4.
         if (planApplied) {
-          let planAmount = null;
+          let sessionAmount = null;
           if (sess?.amount_total != null) {
             const total = Number(sess.amount_total);
-            if (Number.isFinite(total)) planAmount = total / 100;
+            if (Number.isFinite(total)) sessionAmount = total / 100;
           }
-          if (planAmount == null) {
-            planAmount = subscriptionPriceAmountDollars(subscription);
-          }
-          if (planAmount == null) {
-            planAmount = hardcodedPlanAmountDollars(effectivePlan);
-          }
+          const planAmount =
+            sessionAmount ??
+            subscriptionPriceAmountDollars(subscription) ??
+            hardcodedPlanAmountDollars(effectivePlan);
           if (effectivePlan === 'trial') {
             context.waitUntil(sendGa4Event(env, {
               clientId: `server.${uid}`,
@@ -286,23 +290,27 @@ export async function onRequest(context) {
               }
             }));
           } else if (isPaidPlan(effectivePlan)) {
-            context.waitUntil(sendGa4Event(env, {
-              clientId: `server.${uid}`,
-              userId: uid,
-              name: 'purchase',
-              params: {
-                transaction_id: sessionId,
-                currency: (sess?.currency || 'usd').toUpperCase(),
-                value: planAmount,
-                plan: effectivePlan,
-                items: [{
-                  item_id: priceId || effectivePlan,
-                  item_name: effectivePlan,
-                  price: planAmount,
-                  quantity: 1
-                }]
-              }
-            }));
+            if (planAmount == null) {
+              console.warn(`[WEBHOOK] purchase event skipped: could not determine planAmount for plan=${effectivePlan} session=${sessionId}`);
+            } else {
+              context.waitUntil(sendGa4Event(env, {
+                clientId: `server.${uid}`,
+                userId: uid,
+                name: 'purchase',
+                params: {
+                  transaction_id: sessionId,
+                  currency: (sess?.currency || 'usd').toUpperCase(),
+                  value: planAmount,
+                  plan: effectivePlan,
+                  items: [{
+                    item_id: priceId || effectivePlan,
+                    item_name: effectivePlan,
+                    price: planAmount,
+                    quantity: 1
+                  }]
+                }
+              }));
+            }
           }
         }
       } else {
@@ -538,24 +546,28 @@ export async function onRequest(context) {
         if (isPaidPlan(effectivePlan)) {
           const convertedPlanAmount =
             subscriptionPriceAmountDollars(sub) ?? hardcodedPlanAmountDollars(effectivePlan);
-          context.waitUntil(sendGa4Event(env, {
-            clientId: `server.${uid}`,
-            userId: uid,
-            name: 'purchase',
-            params: {
-              transaction_id: `${sub.id}.trial_converted`,
-              currency: (sub?.currency || 'usd').toUpperCase(),
-              value: convertedPlanAmount,
-              plan: effectivePlan,
-              converted_from: 'trial',
-              items: [{
-                item_id: pId || effectivePlan,
-                item_name: effectivePlan,
-                price: convertedPlanAmount,
-                quantity: 1
-              }]
-            }
-          }));
+          if (convertedPlanAmount == null) {
+            console.warn(`[WEBHOOK] trial-conversion purchase event skipped: could not determine planAmount for plan=${effectivePlan} subId=${sub?.id}`);
+          } else {
+            context.waitUntil(sendGa4Event(env, {
+              clientId: `server.${uid}`,
+              userId: uid,
+              name: 'purchase',
+              params: {
+                transaction_id: `${sub.id}.trial_converted`,
+                currency: (sub?.currency || 'usd').toUpperCase(),
+                value: convertedPlanAmount,
+                plan: effectivePlan,
+                converted_from: 'trial',
+                items: [{
+                  item_id: pId || effectivePlan,
+                  item_name: effectivePlan,
+                  price: convertedPlanAmount,
+                  quantity: 1
+                }]
+              }
+            }));
+          }
         }
       }
     }


### PR DESCRIPTION
Instrumentation (Phase 1)
- Move GA4 ID to a window.JHA_CONFIG override (still defaults to current ID)
- Load Microsoft Clarity alongside GA4 once analytics consent is granted
- Add site-wide delegated `cta_click` tracking on every `[data-cta]` element
- Fire `pricing_variant_view` once on pricing-a/pricing-b loads
- Fire `sign_up` GA4 event + set GA `user_id` from Firebase UID after signup
- Server-side `trial_start` and `purchase` events from the Stripe webhook
  (checkout.session.completed and trial→paid conversion) via GA4 Measurement
  Protocol; gated on GA4_MEASUREMENT_ID + GA4_API_SECRET env vars
- Tag the major CTAs (hero, pricing table + mobile cards, callout, lead
  magnet, blog) with `data-cta` for clean attribution

Conversion fixes (Phase 3)
- Add meta description, OG tags, Twitter card, and a quantified `<title>`
  to root index.html (marketing/index.html title/headline updated too)
- Rewrite hero on both landings to lead with the 3× callbacks promise and
  surface the "no credit card required" trust signal above the fold
- Drop confirm-password requirement from login.html signup form (and tolerate
  the field if present in cached pages)
- Add a "No credit card required" badge above every Start-Free-Trial button
  on pricing-a.html
- Replace single Alex R. testimonial with a 3-card testimonial grid on both
  landings
- Add /api/lead-magnet endpoint + homepage email-capture form for the
  12-Point ATS Resume Checklist; fires `generate_lead` GA4 event
- Auto-inject a topic-aware end-of-post CTA into all 9 blog posts and fire
  `blog_cta_view` so we can attribute blog → trial conversions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new unauthenticated email-capture API and modifies Stripe webhook processing to emit server-side GA4 conversion events, which can impact data integrity and webhook reliability if misconfigured. UI/marketing changes are low risk but touch consent/analytics loading behavior across many pages.
> 
> **Overview**
> **Conversion analytics is expanded end-to-end.** `cookie-consent.js` now supports env overrides for GA ID, loads Microsoft Clarity when analytics consent is granted, queues/flushes pre-load GA/Clarity calls, and adds delegated `cta_click` + `pricing_variant_view` tracking via `data-cta` tags; `analytics.js` is refactored to route through these safe wrappers and adds `identifyUser`.
> 
> **Server-side conversions are instrumented.** `stripe-webhook.js` posts GA4 Measurement Protocol `trial_start`/`purchase` events (fire-and-forget) and gates side effects on whether `updatePlanInD1` actually applied the plan update to avoid double-counting/replays.
> 
> **New top-of-funnel lead capture is introduced.** Adds `POST /api/lead-magnet` to record leads to D1 (KV fallback), rate-limit/dedupe via KV, and email the ATS checklist; the homepage/marketing pages add a lead-magnet form + handler (`js/lead-magnet.js`) and blog posts load `js/blog-cta.js` to inject/track an end-of-post CTA.
> 
> **Marketing/signup conversion fixes.** Updates landing-page SEO/meta and hero/testimonial copy, adds “no credit card required” badges on trial CTAs, relaxes signup confirm-password (UI + validation), and bumps `cookie-consent.js`/`main.js`/`analytics.js` version pins across pages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1656d71d8c1384438ce98b998862e13cb9f8fa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->