### PR TITLE
fix(pricing-a): remove inaccurate "No credit card required" trial badge

### DIFF
--- a/pricing-a.html
+++ b/pricing-a.html
@@ -137,7 +137,6 @@
               <td></td>
               <td><button class="btn-primary stripe-checkout-btn" data-plan="free" data-amount="0" data-cta="pricing-table-free">Create Free Account</button></td>
               <td>
-                <span class="trial-no-card-badge" style="display:inline-block;background:#E6F4EA;color:#0B6B2E;font-weight:700;font-size:0.78rem;padding:3px 8px;border-radius:999px;margin-bottom:0.4rem;">No credit card required</span>
                 <button class="btn-primary stripe-checkout-btn" data-plan="trial" data-amount="0" data-cta="pricing-table-trial">Start Free Trial</button>
                 <div class="trial-subtext" aria-live="polite"></div>
                 <p style="font-size:0.75rem;color:#666;margin-top:0.35rem;">Converts to $29/mo after 3-day trial. Cancel anytime.</p>
@@ -235,7 +234,6 @@
                 Priority Review
               </li>
             </ul>
-            <span class="trial-no-card-badge" style="display:inline-block;background:#E6F4EA;color:#0B6B2E;font-weight:700;font-size:0.85rem;padding:4px 10px;border-radius:999px;margin-bottom:0.6rem;">No credit card required</span>
             <button class="btn-primary stripe-checkout-btn" data-plan="trial" data-amount="0" data-cta="pricing-mobile-trial">Start Free Trial</button>
             <div class="trial-subtext" aria-live="polite"></div>
             <p style="font-size:0.75rem;color:#666;margin-top:0.35rem;">Converts to $29/mo after 3-day trial. Cancel anytime.</p>


### PR DESCRIPTION
## Summary
- Removes the "No credit card required" badge from both the desktop pricing table and the mobile trial card in `pricing-a.html`.
- The badge contradicted Stripe checkout, which uses `payment_method_collection: 'always'` (`app/functions/api/stripe-checkout.js:334`) so the 3-day trial can auto-convert to $29/mo. Users who clicked "Start Free Trial" expecting no card would immediately be prompted for payment details, eroding trust.
- The existing trial subtext ("Converts to $29/mo after 3-day trial. Cancel anytime.") already communicates trial terms accurately, so no replacement copy is needed.

Reported by Cursor BugBot (commit `aed022e`).

## Test plan
- [ ] Open `pricing-a.html` in a browser (desktop width) — the trial column shows the "Start Free Trial" button without the green "No credit card required" badge above it.
- [ ] Resize to mobile / open the mobile pricing card — the trial card shows the button without the badge; the locked-feature list and trial conversion subtext are unchanged.
- [ ] Click "Start Free Trial" and confirm the Stripe checkout still loads the trial subscription (unchanged behavior).
- [ ] Visual check: vertical spacing in both views is reasonable now that the badge is gone.

https://claude.ai/code/session_015zqo7R8RD7YVXCLxGtuSHD

---
_Generated by [Claude Code](https://claude.ai/code/session_015zqo7R8RD7YVXCLxGtuSHD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: static copy removal in `pricing-a.html` with no changes to Stripe/checkout logic. Main risk is minor layout/spacing regressions on the pricing page.
> 
> **Overview**
> Removes the green *“No credit card required”* badge from the 3-day trial signup area in `pricing-a.html` for both the desktop pricing table and the mobile trial card, leaving the existing trial conversion subtext and CTAs unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eb30a1dec4d848c55c77bfcf1ec927fae7b95db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->