### PR TITLE
test(e2e): drop stale #confirmPassword fill from signup specs

### DIFF
--- a/app/tests/e2e/auth.spec.js
+++ b/app/tests/e2e/auth.spec.js
@@ -167,7 +167,6 @@ test.describe('Authentication', () => {
       await page.fill('#lastName', 'Signup');
       await page.fill('#signupEmail', signupEmail);
       await page.fill('#signupPassword', signupPassword);
-      await page.fill('#confirmPassword', signupPassword);
 
       // Accept Terms of Service
       await page.check('#acceptTerms');

--- a/app/tests/e2e/terms-checkpoints.spec.js
+++ b/app/tests/e2e/terms-checkpoints.spec.js
@@ -54,7 +54,6 @@ test.describe('Terms Checkpoints', () => {
       await page.fill('#lastName', 'Terms');
       await page.fill('#signupEmail', signupEmail);
       await page.fill('#signupPassword', signupPassword);
-      await page.fill('#confirmPassword', signupPassword);
 
       const acceptTermsCheckbox = page.locator('#acceptTerms');
       await expect(acceptTermsCheckbox).not.toBeChecked();


### PR DESCRIPTION
## Summary
Drops the now-stale `page.fill('#confirmPassword', signupPassword)` line from two e2e signup specs:
- `app/tests/e2e/auth.spec.js:170` (was the "should sign up and reach verify-email" test)
- `app/tests/e2e/terms-checkpoints.spec.js:57` (was the "signup requires terms acceptance" test)

## Background
The `#confirmPassword` input was intentionally removed from `login.html` in commit `3d198d8` ("Wire conversion analytics + ship Phase-3 conversion fixes") on 2026-05-05 — part of a conversion-rate fix to reduce signup friction. PR #814 even followed up to clean dead JS toggle wiring for it. But these two specs were never updated, so they kept calling `page.fill('#confirmPassword', ...)`, which timed out after 20s waiting for a locator that no longer exists.

The failure didn't surface earlier because PRs into `dev0` only run the smoke suite (`TEST_ENV=dev`), which doesn't include these specs. The full QA suite (`TEST_ENV=qa`) only runs on dev0→develop merges, so the regression sat hidden until that merge triggered it.

## Why update the tests vs. re-adding the field
- The form change has been live for ~6 days and the conversion-rate rationale for removing the second password field is sound.
- The signup form has a show/hide eye toggle on the password input, which is the intended mitigation for typo risk.
- Re-adding the field would undo a deliberate optimization to satisfy a stale test.

## Test plan
- [ ] Run the full e2e suite (`TEST_ENV=qa`) on this branch and confirm `auth.spec.js:150` ("should sign up and reach verify-email with working resend flow") and `terms-checkpoints.spec.js:33` ("signup requires terms acceptance before submit can proceed") both pass.
- [ ] Confirm no other e2e spec references `#confirmPassword` (verified locally: `grep -rn "confirmPassword" app/tests/ tests/` returns nothing).

https://claude.ai/code/session_015zqo7R8RD7YVXCLxGtuSHD

---
_Generated by [Claude Code](https://claude.ai/code/session_015zqo7R8RD7YVXCLxGtuSHD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change that updates selectors to match the current signup UI and should only affect e2e suite stability.
> 
> **Overview**
> Removes the stale `page.fill('#confirmPassword', ...)` step from two signup e2e specs (`auth.spec.js` and `terms-checkpoints.spec.js`) so they no longer wait on a non-existent confirm-password field during signup flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ff122bc89450dc99a36eb8b09ba5ad688029c8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->