### PR TITLE
feat(analytics): wire Microsoft Clarity project ID (wskzma4clw)

### DIFF
--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -15,7 +15,8 @@
   const GA_MEASUREMENT_ID = (window.JHA_CONFIG && window.JHA_CONFIG.GA_ID) || 'G-X48E90B00S';
   const GA_SCRIPT_URL = `https://www.googletagmanager.com/gtag/js?l=dataLayer&id=${GA_MEASUREMENT_ID}`;
   // Microsoft Clarity project ID — optional; loads only if configured.
-  const CLARITY_PROJECT_ID = (window.JHA_CONFIG && window.JHA_CONFIG.CLARITY_ID) || '';
+  // Override per-environment via window.JHA_CONFIG.CLARITY_ID, else use the production project.
+  const CLARITY_PROJECT_ID = (window.JHA_CONFIG && window.JHA_CONFIG.CLARITY_ID) || 'wskzma4clw';
 
   // Domain-aware API routing: marketing site (jobhackai.io) routes API calls
   // to app.jobhackai.io so consent persists in D1 across both domains.


### PR DESCRIPTION
## Summary
One-line change: defaults `CLARITY_PROJECT_ID` in `js/cookie-consent.js` from `''` (Clarity disabled) to `'wskzma4clw'` (production Clarity project). Once this ships through dev0 → develop → main, Clarity starts collecting session recordings and heatmaps on both `jobhackai.io` (marketing) and `app.jobhackai.io` (app), gated on the user's analytics-consent decision.

## Why this approach (default vs. inline `window.JHA_CONFIG`)
`cookie-consent.js` already supports a `window.JHA_CONFIG.CLARITY_ID` override path. We could've added an inline `<script>window.JHA_CONFIG={CLARITY_ID:'wskzma4clw'}</script>` to every HTML head (~30 files), but the cleaner move is to change the *default*. The override path is preserved for future per-environment config (e.g., a separate Clarity project for QA).

## How to verify after deploy

1. After this lands on `main` and Cloudflare Pages deploys both `jobhackai-app-marketing-seo` (jobhackai.io) and `jobhackai-app-prod` (app.jobhackai.io), visit either domain in an incognito window.
2. Accept the analytics cookie banner.
3. Open DevTools → Network → filter for `clarity.ms`. You should see requests to `https://www.clarity.ms/tag/wskzma4clw` and `https://www.clarity.ms/collect`.
4. After ~5 minutes, log into [clarity.microsoft.com](https://clarity.microsoft.com) → JOBHACKAI project. You should see your own session in the recordings list.
5. Heatmaps populate after a few sessions accumulate (usually within a day).

## What this does NOT change
- GA4 wiring — unchanged. Existing GA4 events (`page_view`, `cta_click`, `sign_up`, `trial_start`, `purchase`, etc.) keep flowing to the same property.
- The cookie-consent flow — Clarity stays gated on analytics consent. If a user declines analytics, Clarity does not load.
- No HTML files are modified.

https://claude.ai/code/session_015zqo7R8RD7YVXCLxGtuSHD

---
_Generated by [Claude Code](https://claude.ai/code/session_015zqo7R8RD7YVXCLxGtuSHD)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables a new third-party analytics recorder (Clarity) in production by default, which can have privacy/compliance implications if consent gating is misconfigured. Code change is small and localized to the consent/analytics loader.
> 
> **Overview**
> **Enables Microsoft Clarity in production by default** by setting `CLARITY_PROJECT_ID` to `wskzma4clw` in `js/cookie-consent.js` (while still allowing per-environment override via `window.JHA_CONFIG.CLARITY_ID`).
> 
> With analytics consent granted, Clarity will now load alongside GA; previously Clarity was effectively disabled unless explicitly configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cedee2a5850dd8d4e448323bce30e0b4e285af3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->