### PR TITLE
feat(analytics): wire Microsoft Clarity project ID

### DIFF
--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -15,7 +15,8 @@
   const GA_MEASUREMENT_ID = (window.JHA_CONFIG && window.JHA_CONFIG.GA_ID) || 'G-X48E90B00S';
   const GA_SCRIPT_URL = `https://www.googletagmanager.com/gtag/js?l=dataLayer&id=${GA_MEASUREMENT_ID}`;
   // Microsoft Clarity project ID — optional; loads only if configured.
-  const CLARITY_PROJECT_ID = (window.JHA_CONFIG && window.JHA_CONFIG.CLARITY_ID) || '';
+  // Override per-environment via window.JHA_CONFIG.CLARITY_ID, else use the production project.
+  const CLARITY_PROJECT_ID = (window.JHA_CONFIG && window.JHA_CONFIG.CLARITY_ID) || 'wskzma4clw';
 
   // Domain-aware API routing: marketing site (jobhackai.io) routes API calls
   // to app.jobhackai.io so consent persists in D1 across both domains.


### PR DESCRIPTION
## Summary

- Sets a default Microsoft Clarity project ID in `js/cookie-consent.js` when `window.JHA_CONFIG.CLARITY_ID` is not provided, so Clarity can load in production without extra config.
- Documents that per-environment overrides still go through `window.JHA_CONFIG.CLARITY_ID`.

## Test plan

- [ ] Load the marketing site with analytics cookies accepted and confirm Clarity initializes when no `CLARITY_ID` override is set.
- [ ] Confirm a `JHA_CONFIG.CLARITY_ID` override still replaces the default in non-production or custom setups.
- [ ] Smoke-check cookie consent / GA behavior unchanged aside from Clarity wiring.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small configuration change that only affects whether Clarity loads when analytics consent is granted; no changes to consent logic or data handling paths.
> 
> **Overview**
> **Enables Microsoft Clarity to load by default in production** by setting `CLARITY_PROJECT_ID` to a production project ID when `window.JHA_CONFIG.CLARITY_ID` is not provided.
> 
> Keeps the existing per-environment override behavior via `window.JHA_CONFIG.CLARITY_ID` and updates the inline comment to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aeb6453233355845b5429d66b5491df2bd1f8ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->