### PR TITLE
Promote develop to main (Microsoft Clarity)

### DIFF
--- a/js/cookie-consent.js
+++ b/js/cookie-consent.js
@@ -15,7 +15,8 @@
   const GA_MEASUREMENT_ID = (window.JHA_CONFIG && window.JHA_CONFIG.GA_ID) || 'G-X48E90B00S';
   const GA_SCRIPT_URL = `https://www.googletagmanager.com/gtag/js?l=dataLayer&id=${GA_MEASUREMENT_ID}`;
   // Microsoft Clarity project ID — optional; loads only if configured.
-  const CLARITY_PROJECT_ID = (window.JHA_CONFIG && window.JHA_CONFIG.CLARITY_ID) || '';
+  // Override per-environment via window.JHA_CONFIG.CLARITY_ID, else use the production project.
+  const CLARITY_PROJECT_ID = (window.JHA_CONFIG && window.JHA_CONFIG.CLARITY_ID) || 'wskzma4clw';
 
   // Domain-aware API routing: marketing site (jobhackai.io) routes API calls
   // to app.jobhackai.io so consent persists in D1 across both domains.


### PR DESCRIPTION
## Summary

- Promotes the current `develop` branch to `main`, bringing in the Microsoft Clarity integration merged via #821 and promoted through `dev0` (#822).
- **User-visible change:** `js/cookie-consent.js` now uses a default Clarity project ID when `window.JHA_CONFIG.CLARITY_ID` is not set, while still allowing per-environment overrides through `JHA_CONFIG`.

## Test plan

- [ ] After merge/deploy, load the production marketing site, accept analytics cookies, and confirm Clarity receives events for the expected project.
- [ ] Confirm environments that set `JHA_CONFIG.CLARITY_ID` still use the override and do not rely on the baked-in default.
- [ ] Quick regression: GA / gtag and cookie consent flows still behave as before.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables Microsoft Clarity by default when analytics consent is granted, which changes production tracking behavior and has privacy/telemetry implications. Low code complexity, but incorrect IDs or unexpected activation could affect data collection.
> 
> **Overview**
> Sets a **default Microsoft Clarity project ID** in `js/cookie-consent.js` so Clarity loads (when analytics consent is granted) even if `window.JHA_CONFIG.CLARITY_ID` is not provided, while still allowing per-environment overrides via `JHA_CONFIG`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f46fc60eab33577d686928a7b8e460cf81f4e2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->