### PR TITLE
feat(blog): publish "The Credibility Deficit" article

### DIFF
--- a/marketing/blog.html
+++ b/marketing/blog.html
@@ -133,15 +133,15 @@
 
         <!-- Featured Post (static fallback for crawlers; replaced by JS) -->
         <div id="blogFeatured">
-          <a href="/blog/below-1-0-leverage-gap-resume" class="blog-featured" aria-label="Read featured article: Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume">
+          <a href="/blog/credibility-deficit-age-of-autocomplete" class="blog-featured" aria-label="Read featured article: The Credibility Deficit: How We Lost Our Voice in the Age of Autocomplete">
             <div>
               <span class="blog-featured-label">Featured</span>
-              <h2 class="blog-featured-title">Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume</h2>
-              <p class="blog-featured-excerpt">The job market has tilted back toward employers. Learn why generic resumes get filtered out faster and how ATS-friendly resume optimization helps candidates adapt.</p>
+              <h2 class="blog-featured-title">The Credibility Deficit: How We Lost Our Voice in the Age of Autocomplete</h2>
+              <p class="blog-featured-excerpt">AI-polished resumes get past ATS filters but fail in the interview. Learn how to break the autocomplete trap and stand out as a real, verifiable person.</p>
               <div class="blog-featured-meta">
-                <span>April 28, 2026</span>
+                <span>May 23, 2026</span>
                 <span class="separator">&middot;</span>
-                <span>6 min read</span>
+                <span>7 min read</span>
                 <span class="separator">&middot;</span>
                 <span>Resume</span>
               </div>
@@ -159,6 +159,18 @@
 
         <!-- Post Grid (static fallback for crawlers; replaced by JS) -->
         <div class="blog-grid" id="blogGrid" aria-live="polite">
+          <a href="/blog/below-1-0-leverage-gap-resume" class="blog-card">
+            <div class="blog-card-body">
+              <span class="blog-card-category">Resume</span>
+              <h3 class="blog-card-title">Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume</h3>
+              <p class="blog-card-excerpt">The job market has tilted back toward employers. Learn why generic resumes get filtered out faster and how ATS-friendly resume optimization helps candidates adapt.</p>
+              <div class="blog-card-meta">
+                <span>April 28, 2026</span>
+                <span class="separator">&middot;</span>
+                <span>6 min read</span>
+              </div>
+            </div>
+          </a>
           <a href="/blog/68-5-days-response-gap-job-search-burnout" class="blog-card">
             <div class="blog-card-body">
               <span class="blog-card-category">Job Search</span>
@@ -280,7 +292,7 @@
   <script src="js/auth-persistence.js"></script>
   <script src="js/navigation.js?v=20260208-1"></script>
   <script src="js/universal-logout.js?v=20260208-1"></script>
-  <script src="js/blog-data.js?v=20260428-1"></script>
+  <script src="js/blog-data.js?v=20260523-1"></script>
   <script>
     if (window.JobHackAINavigation && typeof window.JobHackAINavigation.initializeNavigation === 'function') {
       window.JobHackAINavigation.initializeNavigation();

--- a/marketing/blog/credibility-deficit-age-of-autocomplete.html
+++ b/marketing/blog/credibility-deficit-age-of-autocomplete.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>The Credibility Deficit: How We Lost Our Voice in the Age of Autocomplete | JobHackAI Blog</title>
+  <meta name="description" content="When AI writes everyone's resume, the polished version of you becomes a liability in the interview. Learn how to stand out by being unmistakably human.">
+  <link rel="canonical" href="https://jobhackai.io/blog/credibility-deficit-age-of-autocomplete">
+
+  <meta property="og:title" content="The Credibility Deficit: How We Lost Our Voice in the Age of Autocomplete">
+  <meta property="og:description" content="AI-polished resumes get past ATS filters but fail in the interview. Learn how to break the autocomplete trap and stand out as a real, verifiable person.">
+  <meta property="og:type" content="article">
+  <meta property="og:url" content="https://jobhackai.io/blog/credibility-deficit-age-of-autocomplete">
+  <meta property="og:site_name" content="JobHackAI">
+  <meta property="og:image" content="https://cdn.marblism.com/Ry93_rswV17.webp">
+  <meta property="article:published_time" content="2026-05-23">
+  <meta property="article:author" content="JobHackAI Team">
+  <meta property="article:section" content="Resume">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="The Credibility Deficit: The Age of Autocomplete">
+  <meta name="twitter:description" content="How AI-polished resumes lost their signal value, and how to win the new verification check with your real voice.">
+  <meta name="twitter:image" content="https://cdn.marblism.com/Ry93_rswV17.webp">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "The Credibility Deficit: How We Lost Our Voice in the Age of Autocomplete",
+    "description": "When AI writes everyone's resume, the polished version of you becomes a liability in the interview. Learn how to stand out by being unmistakably human.",
+    "image": "https://cdn.marblism.com/Ry93_rswV17.webp",
+    "author": {
+      "@type": "Organization",
+      "name": "JobHackAI",
+      "url": "https://jobhackai.io"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "JobHackAI",
+      "url": "https://jobhackai.io"
+    },
+    "datePublished": "2026-05-23",
+    "dateModified": "2026-05-23",
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://jobhackai.io/blog/credibility-deficit-age-of-autocomplete"
+    }
+  }
+  </script>
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    "itemListElement": [
+      { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://jobhackai.io/" },
+      { "@type": "ListItem", "position": 2, "name": "Blog", "item": "https://jobhackai.io/blog" },
+      { "@type": "ListItem", "position": 3, "name": "The Credibility Deficit", "item": "https://jobhackai.io/blog/credibility-deficit-age-of-autocomplete" }
+    ]
+  }
+  </script>
+
+  <link rel="icon" type="image/png" href="../assets/jobhackai_icon_only_128.png">
+  <link rel="apple-touch-icon" href="../assets/jobhackai_icon_only_128.png">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap">
+  <link rel="stylesheet" href="../css/reset.css">
+  <link rel="stylesheet" href="../css/tokens.css">
+  <link rel="stylesheet" href="../css/main.css">
+  <link rel="stylesheet" href="../css/header.css">
+  <link rel="stylesheet" href="../css/footer.css">
+  <link rel="stylesheet" href="../css/marketing.css">
+  <link rel="stylesheet" href="../css/blog.css">
+  <script src="https://app.jobhackai.io/js/cookie-consent.js?v=20260506-1" defer></script>
+</head>
+<body>
+  <header class="site-header" id="top">
+    <div class="container">
+      <a href="https://jobhackai.io/" class="nav-logo" aria-label="Go to homepage">
+        <svg width="24" height="24" fill="none" stroke="#1F2937" stroke-width="2" xmlns="http://www.w3.org/2000/svg">
+          <rect x="3" y="7" width="18" height="13" rx="2"/>
+          <path d="M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2"/>
+        </svg>
+        <span>JOBHACKAI<sup>&trade;</sup></span>
+      </a>
+      <div class="nav-group">
+        <nav class="nav-links" role="navigation">
+          <!-- Static fallback for crawlers; replaced by navigation.js -->
+          <a href="https://jobhackai.io/">Home</a>
+          <a href="https://jobhackai.io/blog">Blog</a>
+          <a href="https://jobhackai.io/features">Features</a>
+        </nav>
+      </div>
+      <button class="mobile-toggle" aria-label="Open navigation menu" aria-expanded="false" aria-controls="mobileNav">
+        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="3" y1="12" x2="21" y2="12"></line>
+          <line x1="3" y1="6" x2="21" y2="6"></line>
+          <line x1="3" y1="18" x2="21" y2="18"></line>
+        </svg>
+      </button>
+    </div>
+  </header>
+  <nav class="mobile-nav" id="mobileNav">
+    <!-- Static fallback for crawlers; replaced by navigation.js -->
+    <a href="https://jobhackai.io/">Home</a>
+    <a href="https://jobhackai.io/blog">Blog</a>
+    <a href="https://jobhackai.io/features">Features</a>
+  </nav>
+  <div class="mobile-nav-backdrop" id="mobileNavBackdrop"></div>
+  <script src="../js/mobile-menu.js?v=20250115-1"></script>
+
+  <main>
+    <div class="container">
+
+      <header class="post-header">
+        <nav class="post-breadcrumb" aria-label="Breadcrumb">
+          <a href="https://jobhackai.io/">Home</a>
+          <span aria-hidden="true">/</span>
+          <a href="https://jobhackai.io/blog">Blog</a>
+          <span aria-hidden="true">/</span>
+          <span aria-current="page">The Credibility Deficit</span>
+        </nav>
+        <span class="post-category-badge">Resume</span>
+        <h1 class="post-title">The Credibility Deficit: How We Lost Our Voice in the Age of Autocomplete</h1>
+        <p class="post-subtitle">When AI writes everyone's resume, the only thing worth selling is the one signal it cannot fake - proof that you are a real person who can do the work.</p>
+        <div class="post-meta">
+          <span>May 23, 2026</span>
+          <span class="separator">&middot;</span>
+          <span>7 min read</span>
+          <span class="separator">&middot;</span>
+          <span>JobHackAI Team</span>
+        </div>
+      </header>
+
+      <article class="post-body">
+        <div class="prose">
+
+          <p><img src="https://cdn.marblism.com/Ry93_rswV17.webp" alt="A polished editorial image of a candidate sitting across from a hiring manager, a resume on the table between them, suggesting the gap between the document and the real person."></p>
+
+          <p>Elias had a secret, though by early 2026, it was a secret he shared with roughly eighty percent of the white-collar workforce. His resume was a masterpiece of synthetic perfection. It was balanced, it was rhythmic, and it was - in a very literal sense - inhuman.</p>
+
+          <p>He had fed his career history into a sophisticated language model, whispered a few prompts about "impact" and "synergy," and watched as the machine transformed his moderately successful tenure at a mid-sized logistics firm into a prose poem of professional triumph. The Applicant Tracking Systems (ATS) loved it. The keywords were all there, glowing like radioactive isotopes. He was "leveraging" things he had barely touched. He was "spearheading" initiatives he had mostly attended as a passive observer in the back row of a Zoom call.</p>
+
+          <p>But when Elias finally sat down across from a senior director at a fintech startup, the air in the room changed. The director looked at the paper - a document that claimed Elias was a "strategic visionary in cross-functional scalability" - and then looked at the nervous man who was currently struggling to remember the specific API he had supposedly "optimized for 40% efficiency."</p>
+
+          <p>In that moment, the document became a liability. Elias was not just a candidate anymore; he was a counterfeit.</p>
+
+          <p>We are currently living through the Great Verification Crisis. As AI-generated content becomes the default setting for professional communication, we have inadvertently traded our credibility for convenience. And in a world where everyone sounds perfect on paper, the most expensive commodity on the market is not skill - it is trust.</p>
+
+          <h2>The Rise of the Polished Ghost</h2>
+          <p>For decades, the resume was a proxy for the person. It was a flawed document, certainly, but it carried the weight of intent. If a resume was well-written, it suggested the candidate was diligent. If it was formatted correctly, it suggested an eye for detail.</p>
+
+          <p>Today, those signals have been severed. When anyone can generate a Harvard-grade cover letter in twelve seconds, a well-written letter no longer signals diligence; it signals an internet connection.</p>
+
+          <p>The data is beginning to reflect this institutional fatigue. Recent surveys indicate that nearly 49% of U.S. hiring managers now automatically dismiss applications they suspect were authored by AI. It is not necessarily a bias against technology; it is a defense mechanism against the "Ghost in the Cubicle." Recruiters are drowning in a sea of identical excellence. When every candidate is a "dynamic leader with a track record of driving growth," no one is.</p>
+
+          <p>We have reached the "Uncanny Valley" of hiring. The resumes look human, but they feel hollow. They hit the right notes, but the melody is missing.</p>
+
+          <p><img src="https://cdn.marblism.com/sH4kpUZCPeF.webp" alt="A tired recruiter at a desk surrounded by stacks of nearly identical resumes, representing recruiter fatigue in the age of AI-generated applications."></p>
+
+          <h2>The Autocomplete Trap</h2>
+          <p>The problem is not the AI itself; it is the way we have allowed it to dictate our identity. We use AI as a ghostwriter rather than a drafting tool, letting it fill in the blanks of our professional lives with the safest, most generic language possible.</p>
+
+          <p>This is the "Autocomplete Trap." By seeking to offend no one and appeal to every algorithm, we end up saying nothing at all. We lose the specific, gritty details that actually make us employable - the time the server crashed at 3 AM and you stayed up with the lead dev to fix it, or the awkward client meeting you turned around with a well-timed joke and a pivot in strategy.</p>
+
+          <p>These are the things AI cannot invent because AI was not there. But because these details do not always fit the "optimized" template, we leave them out. We trade our stories for "competencies."</p>
+
+          <div class="callout">
+            <div class="callout-label">Key Takeaway</div>
+            <p>The Autocomplete Trap removes the only signals you have left: the gritty, specific, true details a machine cannot invent because it was not in the room.</p>
+          </div>
+
+          <p>And this is where the <a href="https://jobhackai.io/blog/below-1-0-leverage-gap-resume">leverage gap</a> begins to widen. Candidates think they are gaining an edge by looking perfect, but they are actually losing the only thing that makes them a "low-risk" hire: their humanity.</p>
+
+          <h2>The Verification Check: Where the Resume Dies</h2>
+          <p>If the resume is the hook, the interview is the haul. But in the age of autocomplete, the gap between the two has become a chasm.</p>
+
+          <p>Recruiters are responding to the credibility deficit by moving human judgment later in the process and making it significantly more intense. We are seeing a surge in proctored skills tests, live technical audits, and behavioral interviews that feel more like depositions than conversations.</p>
+
+          <p>If your resume says you are a "master of Python," you had better be prepared to code it on a whiteboard while three people watch you sweat. If you claim to have "transformed corporate culture," you need to be able to name the people you influenced and the specific conversations that mattered.</p>
+
+          <p>The tragedy of the modern job search is that many talented people are being rejected not because they are not qualified, but because they cannot live up to the fictionalized version of themselves they sent ahead in a PDF. They are failing the "verification check."</p>
+
+          <p><img src="https://cdn.marblism.com/zbhbwGyzqst.webp" alt="A close-up of a job interview moment showing the gap between a polished resume on the table and the candidate's real-time answers."></p>
+
+          <h2>How to Stay Human (and Get Hired)</h2>
+          <p>So, how do you navigate a market that is increasingly skeptical of everything you put in writing? The answer is not to go back to a typewriter. It is to use technology to amplify your humanity, not replace it.</p>
+
+          <h3>1. Use AI as a Mirror, Not a Mask</h3>
+          <p>At <a href="https://jobhackai.io">JobHackAI</a>, we talk a lot about an "Interview-First" approach. This means your primary goal should not be just to "get noticed" by an algorithm; it should be to get <em>ready</em> for the human who comes next.</p>
+
+          <p>Use AI to find the gaps in your experience or to help you structure your thoughts. But the words? The specific examples? Those must be yours. If you cannot say it out loud in a <a href="https://jobhackai.io/blog/mock-interview-online">mock interview</a>, do not put it on the page.</p>
+
+          <h3>2. The Power of the "Gritty Detail"</h3>
+          <p><strong>Generic:</strong> "Improved team productivity by 20%."</p>
+          <p><strong>Human:</strong> "I started a daily 10-minute stand-up that finally got the designers and the engineers talking to each other. By the third week, we stopped missing our Friday deployment windows."</p>
+
+          <p>The second one is harder for an AI to fake. It contains a story, a conflict, and a resolution. It is verifiable.</p>
+
+          <h3>3. Build Parallel Proof</h3>
+          <p>In a credibility deficit, you need more than one source of truth. Your LinkedIn profile should not just be a copy-paste of your resume. It should be a living record of your professional brand. <a href="https://jobhackai.io/blog/linkedin-profile-optimization">LinkedIn optimization</a> is not about more keywords; it is about creating a consistent narrative that backs up the person who shows up to the interview.</p>
+
+          <h3>4. Practice the "Proof of Work"</h3>
+          <p>Since the interview is now a verification exercise, your <a href="https://jobhackai.io/blog/7-day-interview-prep-routine">interview prep routine</a> needs to change. You should not just be memorizing answers; you should be practicing the art of demonstrating your skills in real-time.</p>
+
+          <p><img src="https://cdn.marblism.com/OCrYsNrQAUk.webp" alt="A candidate practicing answers in a mock interview session, building the verifiable communication skills employers now expect."></p>
+
+          <h2>The Return of the Individual</h2>
+          <p>There is a certain irony in the fact that the more we automate the world, the more we value the things that cannot be automated.</p>
+
+          <p>The "Credibility Deficit" is a challenge, but for the sharp candidate, it is also an opportunity. While everyone else is leaning into the comfort of autocomplete, the person who dares to be specific, honest, and slightly unpolished will be the one who stands out.</p>
+
+          <p>The recruiters are tired. They are bored of the "strategic visionaries." They are desperate for a real person who can solve a real problem and explain, in plain English, how they are going to do it.</p>
+
+          <p>Do not let the machine take your voice. Use the tools to clear the path, but make sure you are the one walking down it. Because at the end of the day, a company does not hire a resume. It hires a person.</p>
+
+          <p>Make sure they can find you.</p>
+
+          <p><img src="https://cdn.marblism.com/4W6b0gZJ-Wx.webp" alt="A candidate and a hiring manager sharing a genuine, unscripted moment of connection across a desk."></p>
+
+          <h2>The Bottom Line</h2>
+          <p>If you are feeling the weight of the search, you are not alone. The silence can be deafening - we have written about the <a href="https://jobhackai.io/blog/68-5-days-response-gap-job-search-burnout">response gap</a> and how to handle the psychological toll of the hunt.</p>
+
+          <p>Use AI to sharpen your edges, not to draw your face. Lead with the gritty details only you can tell. Practice saying them out loud until they sound like you on your best day. Stay grounded, stay human, and keep hacking.</p>
+
+        </div>
+
+        <div class="post-cta">
+          <h3>Train for the verification check.</h3>
+          <p>Get instant AI feedback on your resume, LinkedIn profile, and interview answers - so the person on paper matches the person in the room.</p>
+          <a class="btn btn-primary" href="https://app.jobhackai.io/login?plan=trial">Start Free Trial</a>
+        </div>
+      </article>
+
+    </div>
+  </main>
+
+  <!-- Footer (inline for crawler visibility) -->
+  <!-- Source: ../components/footer.html - update there and run ../scripts/sync-footer.sh -->
+  <footer class="site-footer">
+    <div class="footer-container">
+      <div class="footer-brand">
+        <svg class="footer-logo" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <rect x="3" y="7" width="18" height="13" rx="2" stroke="#1F2937" stroke-width="2"/>
+          <path d="M8 7V5a2 2 0 012-2h4a2 2 0 012 2v2" stroke="#1F2937" stroke-width="2"/>
+        </svg>
+        <span class="footer-name">JOBHACKAI<sup>&trade;</sup></span>
+      </div>
+      <div class="footer-legal">
+        <p>&copy; 2026 JobHackAI. All rights reserved.</p>
+      </div>
+      <div class="footer-links">
+        <a href="https://jobhackai.io/blog">Blog</a>
+        <a href="https://app.jobhackai.io/help" data-app-path="/help">Help</a>
+        <a href="https://app.jobhackai.io/privacy" data-app-path="/privacy">Privacy</a>
+        <a href="https://app.jobhackai.io/terms" data-app-path="/terms">Terms</a>
+        <a href="https://app.jobhackai.io/cookies" data-app-path="/cookies">Cookies</a>
+      </div>
+    </div>
+  </footer>
+
+  <script src="../js/component-loader.js?v=20260206-1"></script>
+  <script src="../js/plan-cache.js"></script>
+  <script type="module" src="../js/firebase-auth.js?v=20260207-2"></script>
+  <script src="../js/auth-persistence.js"></script>
+  <script src="../js/navigation.js?v=20260208-1"></script>
+  <script src="../js/universal-logout.js?v=20260208-1"></script>
+  <script>
+    if (window.JobHackAINavigation && typeof window.JobHackAINavigation.initializeNavigation === 'function') {
+      window.JobHackAINavigation.initializeNavigation();
+    } else {
+      window.addEventListener('DOMContentLoaded', function() {
+        if (window.JobHackAINavigation && typeof window.JobHackAINavigation.initializeNavigation === 'function') {
+          window.JobHackAINavigation.initializeNavigation();
+        }
+      });
+    }
+  </script>
+<script src="https://app.jobhackai.io/js/blog-cta.js?v=20260505-1" defer></script>
+</body>
+</html>

--- a/marketing/js/blog-data.js
+++ b/marketing/js/blog-data.js
@@ -13,6 +13,16 @@
 
 window.BLOG_POSTS = [
   {
+    slug: 'credibility-deficit-age-of-autocomplete',
+    title: 'The Credibility Deficit: How We Lost Our Voice in the Age of Autocomplete',
+    excerpt: 'AI-polished resumes get past ATS filters but fail in the interview. Learn how to break the autocomplete trap and stand out as a real, verifiable person.',
+    category: 'Resume',
+    date: '2026-05-23',
+    readTime: 7,
+    author: 'JobHackAI Team',
+    featured: true,
+  },
+  {
     slug: 'below-1-0-leverage-gap-resume',
     title: 'Below 1.0: How the New Leverage Gap Is Rewriting the Rules of Your Resume',
     excerpt: 'The job market has tilted back toward employers. Learn why generic resumes get filtered out faster and how ATS-friendly resume optimization helps candidates adapt.',
@@ -20,7 +30,7 @@ window.BLOG_POSTS = [
     date: '2026-04-28',
     readTime: 6,
     author: 'JobHackAI Team',
-    featured: true,
+    featured: false,
   },
   {
     slug: '68-5-days-response-gap-job-search-burnout',

--- a/marketing/sitemap.xml
+++ b/marketing/sitemap.xml
@@ -18,12 +18,18 @@
   <!-- Blog listing -->
   <url>
     <loc>https://jobhackai.io/blog</loc>
-    <lastmod>2026-04-28</lastmod>
+    <lastmod>2026-05-23</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
 
   <!-- Blog posts — add a new <url> block for each post you publish -->
+  <url>
+    <loc>https://jobhackai.io/blog/credibility-deficit-age-of-autocomplete</loc>
+    <lastmod>2026-05-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
   <url>
     <loc>https://jobhackai.io/blog/below-1-0-leverage-gap-resume</loc>
     <lastmod>2026-04-28</lastmod>


### PR DESCRIPTION
## Summary
- Adds new marketing blog post `marketing/blog/credibility-deficit-age-of-autocomplete.html` ("The Credibility Deficit: How We Lost Our Voice in the Age of Autocomplete") using the standard `post-template.html` structure, design tokens, and shared header/footer.
- Registers the post in `marketing/js/blog-data.js` and promotes it to `featured: true` (demotes the prior featured post, `below-1-0-leverage-gap-resume`, to `featured: false`) so it leads the blog index to help drive traffic.
- Adds the new URL to `marketing/sitemap.xml` and bumps the blog-listing `lastmod` to `2026-05-23`.
- Updates the static-fallback featured card and post grid in `marketing/blog.html` so crawlers see the same ordering as the JS-rendered list, and bumps the `blog-data.js` cache-bust query to `v=20260523-1`.

## Article details
- Slug: `credibility-deficit-age-of-autocomplete`
- Category: `Resume`
- Date: `2026-05-23` &middot; 7 min read &middot; JobHackAI Team
- Internal links preserved from source content: `below-1-0-leverage-gap-resume`, `mock-interview-online`, `linkedin-profile-optimization`, `7-day-interview-prep-routine`, `68-5-days-response-gap-job-search-burnout`, `/features` (via JobHackAI homepage link).
- Hero image / og:image: `https://cdn.marblism.com/Ry93_rswV17.webp`. Body uses 4 additional in-line images supplied with the article and one `.callout` "Key Takeaway" block consistent with `blog.css`.
- Source-content typography normalized to match existing posts: straight ASCII quotes/apostrophes and ` - ` for em-dashes; section `<h3>`/`<h4>` headings remapped to `<h2>`/`<h3>` to align with the rest of the blog.

## Test plan
- [ ] Preview the Cloudflare Pages deploy and confirm `/blog` shows "The Credibility Deficit" as the featured card and the prior featured post in the grid.
- [ ] Open `/blog/credibility-deficit-age-of-autocomplete` directly and verify hero image, headings, callout, inline images, and CTA render correctly on desktop and mobile.
- [ ] Confirm breadcrumb, category badge, internal links, and "Start Free Trial" CTA all work.
- [ ] Validate that the `noindex` line was not carried over from the template (post is indexable).
- [ ] Quick check: `sitemap.xml` lists the new URL and JSON-LD `Article` + `BreadcrumbList` parse cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VgDZpKtaFP4BSmwuFLWtF8)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to static marketing content, blog metadata, and sitemap updates with no impact to core app logic or security-sensitive flows.
> 
> **Overview**
> **Publishes a new blog post** at `marketing/blog/credibility-deficit-age-of-autocomplete.html`, including SEO metadata (OG/Twitter + JSON-LD) and standard header/footer/CTA markup.
> 
> Updates the blog listing to **feature the new post** by adding it to `marketing/js/blog-data.js` (and demoting the previously featured post), refreshing `marketing/blog.html`’s static crawler fallback featured card/grid, and bumping the `blog-data.js` cache-bust version.
> 
> Adds the new post URL to `marketing/sitemap.xml` and updates the blog index `lastmod` to `2026-05-23`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e842c51d3007df64286e79bfcc77aa325e66102. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->