### PR TITLE
fix(headers): apply voice-interview mic policy and OpenAI CSP at the middleware layer

### DIFF
--- a/app/functions/_lib/__tests__/middleware-headers.test.mjs
+++ b/app/functions/_lib/__tests__/middleware-headers.test.mjs
@@ -1,0 +1,75 @@
+// Middleware security-header test suite (standalone, no framework)
+// Run: node app/functions/_lib/__tests__/middleware-headers.test.mjs
+//
+// Guards the voice-interview header carve-out: app/functions/_middleware.js
+// force-sets STANDARD_SECURITY_HEADERS on every route (overriding whatever
+// the static _headers layer produced), so the same-origin microphone
+// exception and the OpenAI Realtime connect-src allowance must be applied
+// at the middleware layer or /voice-interview cannot getUserMedia() or POST
+// the WebRTC SDP offer to api.openai.com.
+
+import assert from 'node:assert/strict';
+import { onRequest } from '../../_middleware.js';
+
+async function run(path, { env = {}, nextHeaders = {} } = {}) {
+  const res = await onRequest({
+    request: { url: `https://dev.jobhackai.io${path}` },
+    next: async () => new Response('body', { headers: nextHeaders }),
+    env
+  });
+  return res.headers;
+}
+
+let passed = 0;
+let failed = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ✅ ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  ❌ ${name}`);
+    console.error(`     ${err.message}`);
+  }
+}
+
+console.log('middleware security headers test suite\n');
+
+await test('/voice-interview gets same-origin microphone', async () => {
+  const h = await run('/voice-interview');
+  assert.equal(h.get('permissions-policy'), 'camera=(), microphone=(self), geolocation=()');
+});
+
+await test('/voice-interview.html and trailing slash get the same carve-out', async () => {
+  const html = await run('/voice-interview.html');
+  assert.equal(html.get('permissions-policy'), 'camera=(), microphone=(self), geolocation=()');
+  const slash = await run('/voice-interview/');
+  assert.equal(slash.get('permissions-policy'), 'camera=(), microphone=(self), geolocation=()');
+});
+
+await test('every other route keeps the locked-down default', async () => {
+  for (const path of ['/', '/dashboard', '/pricing', '/api/plan/me']) {
+    const h = await run(path);
+    assert.equal(h.get('permissions-policy'), 'camera=(), microphone=(), geolocation=()', `path ${path}`);
+  }
+});
+
+await test('CSP connect-src permits the OpenAI Realtime endpoint', async () => {
+  const h = await run('/voice-interview');
+  const csp = h.get('content-security-policy') || '';
+  const connect = csp.split(';').find((d) => d.trim().startsWith('connect-src')) || '';
+  assert.ok(connect.includes('https://api.openai.com'), 'connect-src must include https://api.openai.com');
+});
+
+await test('middleware overrides conflicting headers from the asset layer', async () => {
+  // Simulates _headers (or an upstream) sending a different value: the
+  // middleware's set() must win so behavior is deterministic per route.
+  const locked = await run('/dashboard', { nextHeaders: { 'permissions-policy': 'microphone=(self)' } });
+  assert.equal(locked.get('permissions-policy'), 'camera=(), microphone=(), geolocation=()');
+  const voice = await run('/voice-interview', { nextHeaders: { 'permissions-policy': 'microphone=()' } });
+  assert.equal(voice.get('permissions-policy'), 'camera=(), microphone=(self), geolocation=()');
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/app/functions/_lib/debug-access.js
+++ b/app/functions/_lib/debug-access.js
@@ -9,7 +9,7 @@ export const CONTENT_SECURITY_POLICY = [
   "font-src 'self' data: https://fonts.gstatic.com",
   "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
   "script-src 'self' 'unsafe-inline' https://www.gstatic.com https://www.googleapis.com https://apis.google.com https://accounts.google.com https://www.googletagmanager.com https://www.google-analytics.com https://www.google.com https://js.stripe.com https://checkout.stripe.com https://*.firebaseapp.com",
-  "connect-src 'self' https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com https://firebaseinstallations.googleapis.com https://www.googleapis.com https://api.stripe.com https://checkout.stripe.com https://www.google-analytics.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://*.firebaseio.com https://*.firebasedatabase.app https://*.firebaseapp.com",
+  "connect-src 'self' https://identitytoolkit.googleapis.com https://securetoken.googleapis.com https://firestore.googleapis.com https://firebaseinstallations.googleapis.com https://www.googleapis.com https://api.stripe.com https://checkout.stripe.com https://www.google-analytics.com https://region1.google-analytics.com https://stats.g.doubleclick.net https://*.firebaseio.com https://*.firebasedatabase.app https://*.firebaseapp.com https://api.openai.com",
   "frame-src 'self' https://accounts.google.com https://*.google.com https://*.firebaseapp.com https://js.stripe.com https://hooks.stripe.com https://checkout.stripe.com",
   "worker-src 'self' blob:",
   "manifest-src 'self'",

--- a/app/functions/_middleware.js
+++ b/app/functions/_middleware.js
@@ -35,6 +35,13 @@ export async function onRequest({ request, next, env }) {
     h.set(name, value);
   }
 
+  // Voice interview needs the same-origin microphone. Mirrors the
+  // /voice-interview rule in app/public/_headers: middleware set() overrides
+  // the _headers layer on every route, so the exception must live here too.
+  if (pathname === '/voice-interview' || pathname === '/voice-interview.html') {
+    h.set('permissions-policy', 'camera=(), microphone=(self), geolocation=()');
+  }
+
   // QA-only: prevent indexing and disable caching
   if (env.ENVIRONMENT === 'qa') {
     h.set('x-qa-mw', 'hit');


### PR DESCRIPTION
# Follow-up to #835: the middleware was overwriting the header fixes

## Root cause

After #835 deployed, /voice-interview still blocked the microphone (`document.featurePolicy.allowsFeature('microphone') === false`, `[Violation] Permissions policy violation: microphone is not allowed in this document`). The visual changes shipped, but `app/functions/_middleware.js` runs on **every** route in the app project (root Pages middleware wraps static asset serves too) and force-`set()`s `STANDARD_SECURITY_HEADERS` after `next()` — replacing whatever the static `_headers` layer produced. Two casualties:

1. `permissions-policy: microphone=()` stomped the `/voice-interview` carve-out added to `app/public/_headers` in #835.
2. The middleware's `CONTENT_SECURITY_POLICY` (`app/functions/_lib/debug-access.js`) omitted `https://api.openai.com` in `connect-src`, stomping #835's CSP fix — even with the mic working, the browser's WebRTC SDP POST to `api.openai.com/v1/realtime/calls` would have been blocked next.

## Changes

- **`app/functions/_middleware.js`** — after the standard header loop, carve out `/voice-interview` (and `/voice-interview.html`) with `microphone=(self)`, mirroring the `_headers` rule. All other routes keep the locked-down default.
- **`app/functions/_lib/debug-access.js`** — append `https://api.openai.com` to `connect-src` in `CONTENT_SECURITY_POLICY` (kept in sync with `_headers`).
- **`app/functions/_lib/__tests__/middleware-headers.test.mjs`** — new standalone test (5 passing): carve-out on `/voice-interview`, `.html`, and trailing-slash variants; locked default on `/`, `/dashboard`, `/pricing`, `/api/plan/me`; OpenAI present in connect-src; middleware override semantics vs conflicting asset-layer headers.

The `_headers` rules from #835 stay: they're correct at the asset layer and are the only header source Pages applies to plain static responses if the middleware is ever removed.

## Post-deploy verification

1. `curl -sI https://dev.jobhackai.io/voice-interview | grep -i permissions-policy` → `camera=(), microphone=(self), geolocation=()`
2. Hard-refresh /voice-interview → console: `document.featurePolicy.allowsFeature('microphone')` → `true`
3. Start the interview → **native** Chrome mic prompt → session connects with no CSP violation → complete a short session → scorecard renders
4. Spot-check another page (e.g. /dashboard) still sends `microphone=()`

## Console noise that is zone-level, not repo (dashboard decisions)

- `beacon.min.js` CSP error: Cloudflare **Web Analytics auto-injection** on the jobhackai.io zone; either disable it for dev or allow `https://static.cloudflareinsights.com` in script-src later.
- `rocket-loader.min.js` preload warnings: **Rocket Loader** is enabled on the zone and rewrites script loading — recommend turning it off for dev.jobhackai.io (it interferes with ES modules/Firebase timing).
- `clarity.ms` CSP block (pre-existing — cookie-consent loads Microsoft Clarity, CSP has never allowed it) and the `document-domain` Permissions-Policy warning (third-party Google/Firebase responses) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016FSezPYaFi6BF7eLK6WrqK

---
_Generated by [Claude Code](https://claude.ai/code/session_016FSezPYaFi6BF7eLK6WrqK)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes global security headers on every route; incorrect path matching or CSP edits could weaken mic lockdown site-wide or block third-party APIs, but scope is narrow and covered by tests.
> 
> **Overview**
> **Fixes voice interview being broken after global middleware overwrote static `_headers` rules from #835.**
> 
> `_middleware.js` now re-applies the **`/voice-interview`** and **`/voice-interview.html`** **`permissions-policy`** carve-out (`microphone=(self)`) *after* it sets `STANDARD_SECURITY_HEADERS`, so same-origin mic access works again. All other routes keep the locked-down default.
> 
> **`CONTENT_SECURITY_POLICY`** in `debug-access.js` adds **`https://api.openai.com`** to **`connect-src`**, matching `_headers`, so WebRTC / Realtime calls to OpenAI are not blocked by CSP.
> 
> A new standalone test file **`middleware-headers.test.mjs`** locks in per-route mic policy, OpenAI in `connect-src`, and that middleware wins over conflicting upstream headers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a39cead40aaa52cd3923204018edac9abbbc8d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->