### PR TITLE
feat(voice): nav entry, history rail with progress tracking, and S + A = O parity

### DIFF
--- a/app/functions/_lib/__tests__/voice-history.test.mjs
+++ b/app/functions/_lib/__tests__/voice-history.test.mjs
@@ -45,8 +45,11 @@ function fakeDb(state) {
     }
     if (q.startsWith('DELETE FROM voice_sessions WHERE user_id = ?')) {
       const userId = binds[0];
+      const keepInFlight = q.includes("status NOT IN ('created', 'active')");
       const before = state.sessions.length;
-      state.sessions = state.sessions.filter((s) => s.user_id !== userId);
+      state.sessions = state.sessions.filter((s) =>
+        s.user_id !== userId || (keepInFlight && (s.status === 'created' || s.status === 'active'))
+      );
       return { run: { meta: { changes: before - state.sessions.length } } };
     }
     throw new Error(`fakeDb: unhandled SQL: ${q}`);
@@ -253,6 +256,21 @@ await test('clear removes only the caller\'s sessions', async () => {
   assert.equal(state.sessions.length, 1);
   assert.equal(state.sessions[0].user_id, 2, 'other users\' history is untouched');
   assert.equal(await clearVoiceSessions(env, 1), 0, 'clearing again is a no-op');
+});
+
+await test('clear never deletes an in-flight (created/active) session', async () => {
+  const state = { sessions: [
+    sessionRow({ id: 'done-1', user_id: 1, status: 'completed' }),
+    sessionRow({ id: 'gone-1', user_id: 1, status: 'abandoned' }),
+    sessionRow({ id: 'live-1', user_id: 1, status: 'active' }),
+    sessionRow({ id: 'fresh-1', user_id: 1, status: 'created' })
+  ] };
+  const env = makeEnv(state);
+
+  assert.equal(await clearVoiceSessions(env, 1), 2, 'completed + abandoned rows cleared');
+  const remaining = state.sessions.map((s) => s.id).sort();
+  assert.deepEqual(remaining, ['fresh-1', 'live-1'],
+    'the live session row must survive so /complete can still save the interview');
 });
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/app/functions/_lib/__tests__/voice-history.test.mjs
+++ b/app/functions/_lib/__tests__/voice-history.test.mjs
@@ -39,8 +39,11 @@ function fakeDb(state) {
     }
     if (q.startsWith('DELETE FROM voice_sessions WHERE id = ? AND user_id = ?')) {
       const [id, userId] = binds;
+      const keepInFlight = q.includes("status NOT IN ('created', 'active')");
       const before = state.sessions.length;
-      state.sessions = state.sessions.filter((s) => !(String(s.id) === String(id) && s.user_id === userId));
+      state.sessions = state.sessions.filter((s) =>
+        !(String(s.id) === String(id) && s.user_id === userId
+          && !(keepInFlight && (s.status === 'created' || s.status === 'active'))));
       return { run: { meta: { changes: before - state.sessions.length } } };
     }
     if (q.startsWith('DELETE FROM voice_sessions WHERE user_id = ?')) {
@@ -197,6 +200,8 @@ await test('lapsed-paid user (no active plan) also keeps only the most recent ag
   const sessions = await listVoiceSessions(makeEnv(state), 1, LAPSED_PAID_ENT, NOW);
   assert.equal(sessions.length, 1, 'only the most recent row is carved out');
   assert.equal(sessions[0].reportAvailable, false);
+  assert.equal(sessions[0].overall, null,
+    'a locked expired row must not leak its score, even with fullAccess and an unstripped scorecard');
 });
 
 await test('paid user\'s aged sessions are excluded from the list (typed rule)', async () => {
@@ -256,6 +261,21 @@ await test('clear removes only the caller\'s sessions', async () => {
   assert.equal(state.sessions.length, 1);
   assert.equal(state.sessions[0].user_id, 2, 'other users\' history is untouched');
   assert.equal(await clearVoiceSessions(env, 1), 0, 'clearing again is a no-op');
+});
+
+await test('delete refuses in-flight (created/active) sessions', async () => {
+  const state = { sessions: [
+    sessionRow({ id: 'live-2', user_id: 1, status: 'active' }),
+    sessionRow({ id: 'fresh-2', user_id: 1, status: 'created' }),
+    sessionRow({ id: 'done-2', user_id: 1, status: 'completed' })
+  ] };
+  const env = makeEnv(state);
+
+  assert.equal(await deleteVoiceSession(env, 1, 'live-2'), false, 'active session must survive');
+  assert.equal(await deleteVoiceSession(env, 1, 'fresh-2'), false, 'created session must survive');
+  assert.equal(state.sessions.length, 3);
+  assert.equal(await deleteVoiceSession(env, 1, 'done-2'), true, 'completed sessions delete normally');
+  assert.equal(state.sessions.length, 2);
 });
 
 await test('clear never deletes an in-flight (created/active) session', async () => {

--- a/app/functions/_lib/__tests__/voice-history.test.mjs
+++ b/app/functions/_lib/__tests__/voice-history.test.mjs
@@ -1,0 +1,259 @@
+// Voice session history test suite (standalone, no framework)
+// Run: node app/functions/_lib/__tests__/voice-history.test.mjs
+//
+// Covers the history rail acceptance criteria:
+// - list returns at most 10 newest completed sessions, ownership enforced
+// - free user's aged session (90-day lapse) stays listed with reportAvailable:false
+// - paid/entitled user's aged sessions are excluded, like typed sessions
+// - overall score only surfaces with full access + a ready scorecard
+// - delete and clear enforce ownership in SQL
+
+import assert from 'node:assert/strict';
+import {
+  listVoiceSessions,
+  deleteVoiceSession,
+  clearVoiceSessions,
+  isSessionExpired,
+  hasActiveVoicePlan,
+  sessionFullAccess,
+  parseDbTime,
+  HISTORY_LIMIT,
+  HISTORY_RETENTION_DAYS
+} from '../voice-history.js';
+
+// ---------- Minimal in-memory fake D1 ----------
+
+function fakeDb(state) {
+  // state: { sessions: Array<row> } — rows use the voice_sessions column names
+  const exec = (sql, binds) => {
+    const q = sql.replace(/\s+/g, ' ').trim();
+
+    if (q.startsWith('SELECT id, role, seniority, status, entitlement_mode')) {
+      const userId = binds[0];
+      const rows = state.sessions
+        .filter((s) => s.user_id === userId && s.status === 'completed')
+        .sort((a, b) => (a.started_at < b.started_at ? 1 : -1))
+        .slice(0, 25)
+        .map((s) => ({ ...s }));
+      return { all: { results: rows } };
+    }
+    if (q.startsWith('DELETE FROM voice_sessions WHERE id = ? AND user_id = ?')) {
+      const [id, userId] = binds;
+      const before = state.sessions.length;
+      state.sessions = state.sessions.filter((s) => !(String(s.id) === String(id) && s.user_id === userId));
+      return { run: { meta: { changes: before - state.sessions.length } } };
+    }
+    if (q.startsWith('DELETE FROM voice_sessions WHERE user_id = ?')) {
+      const userId = binds[0];
+      const before = state.sessions.length;
+      state.sessions = state.sessions.filter((s) => s.user_id !== userId);
+      return { run: { meta: { changes: before - state.sessions.length } } };
+    }
+    throw new Error(`fakeDb: unhandled SQL: ${q}`);
+  };
+
+  return {
+    prepare(sql) {
+      return {
+        bind(...binds) {
+          return {
+            async first() { return exec(sql, binds).first ?? null; },
+            async all() { return exec(sql, binds).all ?? { results: [] }; },
+            async run() {
+              const r = exec(sql, binds);
+              return r.run ?? { meta: { changes: 0 } };
+            }
+          };
+        }
+      };
+    }
+  };
+}
+
+function makeEnv(state) {
+  return { DB: fakeDb(state) };
+}
+
+// Fixed "now" so age math is deterministic.
+const NOW = Date.parse('2026-07-01T12:00:00Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+function dbTime(daysAgo) {
+  return new Date(NOW - daysAgo * DAY).toISOString().replace('T', ' ').replace(/\.\d{3}Z$/, '');
+}
+
+let nextId = 0;
+function sessionRow(over = {}) {
+  nextId += 1;
+  return {
+    id: `s-${nextId}`,
+    user_id: 1,
+    role: 'Data Engineer',
+    seniority: 'Senior',
+    status: 'completed',
+    entitlement_mode: 'free',
+    started_at: dbTime(1),
+    duration_seconds: 840,
+    scorecard_json: JSON.stringify({ overall: 78 }),
+    ...over
+  };
+}
+
+const FREE_ENT = { unlimited: false, sessionsRemaining: 0, hasEverPaid: false };
+const SUB_ENT = { unlimited: true, sessionsRemaining: 0, hasEverPaid: true };
+const PACK_ENT = { unlimited: false, sessionsRemaining: 3, hasEverPaid: true };
+const LAPSED_PAID_ENT = { unlimited: false, sessionsRemaining: 0, hasEverPaid: true };
+
+let passed = 0;
+let failed = 0;
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  ✅ ${name}`);
+  } catch (err) {
+    failed++;
+    console.error(`  ❌ ${name}`);
+    console.error(`     ${err.message}`);
+  }
+}
+
+// ---------- Tests ----------
+
+console.log('voice-history test suite\n');
+
+await test('parseDbTime handles D1 datetime and ISO strings as UTC', () => {
+  assert.equal(parseDbTime('2026-07-01 12:00:00'), Date.parse('2026-07-01T12:00:00Z'));
+  assert.equal(parseDbTime('2026-07-01T12:00:00Z'), Date.parse('2026-07-01T12:00:00Z'));
+  assert.ok(Number.isNaN(parseDbTime(null)));
+});
+
+await test('isSessionExpired flips at the 90-day boundary', () => {
+  assert.equal(isSessionExpired(dbTime(89), NOW), false);
+  assert.equal(isSessionExpired(dbTime(91), NOW), true);
+  assert.equal(isSessionExpired(null, NOW), false, 'unparseable dates are not treated as expired');
+  assert.equal(HISTORY_RETENTION_DAYS, 90);
+});
+
+await test('hasActiveVoicePlan: unlimited or usable pack credits; hasEverPaid alone is not a plan', () => {
+  assert.equal(hasActiveVoicePlan(SUB_ENT), true);
+  assert.equal(hasActiveVoicePlan(PACK_ENT), true);
+  assert.equal(hasActiveVoicePlan(FREE_ENT), false);
+  assert.equal(hasActiveVoicePlan(LAPSED_PAID_ENT), false);
+});
+
+await test('sessionFullAccess mirrors the session GET gate', () => {
+  assert.equal(sessionFullAccess({ entitlement_mode: 'pack' }, FREE_ENT), true, 'paid session is always unlocked');
+  assert.equal(sessionFullAccess({ entitlement_mode: 'free' }, FREE_ENT), false);
+  assert.equal(sessionFullAccess({ entitlement_mode: 'free' }, SUB_ENT), true);
+  assert.equal(sessionFullAccess({ entitlement_mode: 'free' }, LAPSED_PAID_ENT), true, 'hasEverPaid keeps the free session unlocked');
+});
+
+await test('list returns at most 10 newest sessions with ownership enforced', async () => {
+  const state = { sessions: [] };
+  for (let i = 0; i < 14; i++) {
+    state.sessions.push(sessionRow({ user_id: 1, started_at: dbTime(i + 1), entitlement_mode: 'subscription' }));
+  }
+  state.sessions.push(sessionRow({ user_id: 2, started_at: dbTime(0.5), entitlement_mode: 'subscription' }));
+
+  const sessions = await listVoiceSessions(makeEnv(state), 1, SUB_ENT, NOW);
+  assert.equal(sessions.length, HISTORY_LIMIT);
+  assert.ok(sessions.every((s) => s.sessionId.startsWith('s-')));
+  assert.ok(!sessions.some((s) => state.sessions.find((r) => r.id === s.sessionId)?.user_id === 2),
+    'another user\'s session must never be listed');
+  // Newest first
+  const t = sessions.map((s) => parseDbTime(s.createdAt));
+  for (let i = 1; i < t.length; i++) assert.ok(t[i - 1] >= t[i], 'ordered newest first');
+});
+
+await test('incomplete sessions (created/active/abandoned) are not listed', async () => {
+  const state = { sessions: [
+    sessionRow({ status: 'completed' }),
+    sessionRow({ status: 'created' }),
+    sessionRow({ status: 'active' }),
+    sessionRow({ status: 'abandoned' })
+  ] };
+  const sessions = await listVoiceSessions(makeEnv(state), 1, FREE_ENT, NOW);
+  assert.equal(sessions.length, 1);
+});
+
+await test('free user\'s aged session stays listed with reportAvailable:false (retention carve-out)', async () => {
+  const state = { sessions: [sessionRow({ entitlement_mode: 'free', started_at: dbTime(120) })] };
+  const sessions = await listVoiceSessions(makeEnv(state), 1, FREE_ENT, NOW);
+  assert.equal(sessions.length, 1, 'the single free-taste row survives the 90-day lapse');
+  assert.equal(sessions[0].reportAvailable, false);
+  assert.equal(sessions[0].overall, null, 'no score leaks on a locked free row');
+  assert.equal(sessions[0].role, 'Data Engineer', 'row metadata remains');
+});
+
+await test('lapsed-paid user (no active plan) also keeps only the most recent aged row', async () => {
+  const state = { sessions: [
+    sessionRow({ entitlement_mode: 'pack', started_at: dbTime(100) }),
+    sessionRow({ entitlement_mode: 'pack', started_at: dbTime(150) })
+  ] };
+  const sessions = await listVoiceSessions(makeEnv(state), 1, LAPSED_PAID_ENT, NOW);
+  assert.equal(sessions.length, 1, 'only the most recent row is carved out');
+  assert.equal(sessions[0].reportAvailable, false);
+});
+
+await test('paid user\'s aged sessions are excluded from the list (typed rule)', async () => {
+  const state = { sessions: [
+    sessionRow({ entitlement_mode: 'subscription', started_at: dbTime(120) }),
+    sessionRow({ entitlement_mode: 'subscription', started_at: dbTime(5) })
+  ] };
+  const sessions = await listVoiceSessions(makeEnv(state), 1, SUB_ENT, NOW);
+  assert.equal(sessions.length, 1);
+  assert.equal(sessions[0].reportAvailable, true);
+  assert.equal(isSessionExpired(sessions[0].createdAt, NOW), false, 'only the recent session remains');
+});
+
+await test('overall appears only with full access and a ready scorecard', async () => {
+  const state = { sessions: [
+    sessionRow({ entitlement_mode: 'free', scorecard_json: JSON.stringify({ overall: 71 }) }),
+    sessionRow({ entitlement_mode: 'free', scorecard_json: null, started_at: dbTime(2) })
+  ] };
+
+  // Free user: scored row shows no overall (partial), unscored row is 'scoring'
+  const freeList = await listVoiceSessions(makeEnv(state), 1, FREE_ENT, NOW);
+  assert.equal(freeList[0].overall, null);
+  assert.equal(freeList[0].fullAccess, false);
+  assert.equal(freeList[0].status, 'ready');
+  assert.equal(freeList[1].status, 'scoring');
+  assert.equal(freeList[1].overall, null);
+
+  // Entitled user: same free-taste session unlocks retroactively
+  const paidList = await listVoiceSessions(makeEnv(state), 1, SUB_ENT, NOW);
+  assert.equal(paidList[0].overall, 71);
+  assert.equal(paidList[0].fullAccess, true);
+});
+
+await test('delete enforces ownership', async () => {
+  const state = { sessions: [
+    sessionRow({ id: 'mine', user_id: 1 }),
+    sessionRow({ id: 'theirs', user_id: 2 })
+  ] };
+  const env = makeEnv(state);
+
+  assert.equal(await deleteVoiceSession(env, 1, 'theirs'), false, 'cannot delete another user\'s session');
+  assert.equal(state.sessions.length, 2);
+  assert.equal(await deleteVoiceSession(env, 1, 'mine'), true);
+  assert.equal(state.sessions.length, 1);
+  assert.equal(await deleteVoiceSession(env, 1, 'mine'), false, 'second delete is a miss');
+});
+
+await test('clear removes only the caller\'s sessions', async () => {
+  const state = { sessions: [
+    sessionRow({ user_id: 1 }),
+    sessionRow({ user_id: 1 }),
+    sessionRow({ user_id: 2 })
+  ] };
+  const env = makeEnv(state);
+
+  assert.equal(await clearVoiceSessions(env, 1), 2);
+  assert.equal(state.sessions.length, 1);
+  assert.equal(state.sessions[0].user_id, 2, 'other users\' history is untouched');
+  assert.equal(await clearVoiceSessions(env, 1), 0, 'clearing again is a no-op');
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/app/functions/_lib/voice-history.js
+++ b/app/functions/_lib/voice-history.js
@@ -1,0 +1,146 @@
+/**
+ * Voice mock interview session history.
+ *
+ * Query/shaping logic for the history rail endpoints, kept out of the route
+ * handlers so it can be unit-tested against a fake D1 (same pattern as
+ * voice-entitlements.js). Retention mirrors the typed mock interview rule
+ * (90 days, enforced by workers/retention-cleaner) with one voice-only
+ * carve-out: a user with no active voice plan keeps their most recent
+ * session row visible in history past 90 days, with the report locked
+ * (reportAvailable: false). Paid/entitled users' aged sessions disappear
+ * from the list exactly like typed sessions do.
+ */
+
+import { getDb } from './db.js';
+
+export const HISTORY_LIMIT = 10;
+export const HISTORY_RETENTION_DAYS = 90;
+
+/**
+ * Parse a D1 datetime ("YYYY-MM-DD HH:MM:SS", UTC) or ISO string to epoch ms.
+ */
+export function parseDbTime(value) {
+  if (!value) return NaN;
+  let s = String(value);
+  if (!s.includes('T')) s = s.replace(' ', 'T');
+  if (!s.endsWith('Z') && !/[+-]\d\d:?\d\d$/.test(s)) s += 'Z';
+  return new Date(s).getTime();
+}
+
+/**
+ * Whether the session is past the 90-day retention window.
+ */
+export function isSessionExpired(startedAt, nowMs = Date.now()) {
+  const started = parseDbTime(startedAt);
+  if (!Number.isFinite(started)) return false;
+  return nowMs - started > HISTORY_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+}
+
+/**
+ * An "active voice plan" for retention purposes: unlimited subscription or
+ * usable pack credits (the handoff's "unlimited false and no pack credits"
+ * rule, inverted). hasEverPaid alone does NOT keep aged rows listed.
+ */
+export function hasActiveVoicePlan(ent) {
+  return !!(ent && (ent.unlimited || ent.sessionsRemaining > 0));
+}
+
+/**
+ * Full-report access for a session row, mirroring GET /api/voice/session/:id:
+ * paid sessions, currently entitled users, or anyone who has ever paid.
+ */
+export function sessionFullAccess(row, ent) {
+  return row.entitlement_mode !== 'free'
+    || !!ent?.unlimited
+    || (ent?.sessionsRemaining || 0) > 0
+    || !!ent?.hasEverPaid;
+}
+
+/**
+ * List the user's completed voice sessions for the history rail, newest
+ * first, at most HISTORY_LIMIT. Sessions older than the retention window are
+ * excluded, except the carve-out: when the user has no active voice plan,
+ * their most recent session row stays listed (metadata only) with
+ * reportAvailable: false.
+ *
+ * @returns {Promise<Array<{
+ *   sessionId: string, role: string|null, seniority: string|null,
+ *   createdAt: string, durationSeconds: number|null,
+ *   status: 'scoring'|'ready', overall: number|null,
+ *   fullAccess: boolean, reportAvailable: boolean
+ * }>>}
+ */
+export async function listVoiceSessions(env, userRowId, ent, nowMs = Date.now()) {
+  const db = getDb(env);
+  if (!db) return [];
+
+  // Newest 25 completed rows are always enough: expired rows sort strictly
+  // after live ones, and the carve-out row is by definition the newest row.
+  const rows = await db.prepare(
+    `SELECT id, role, seniority, status, entitlement_mode, started_at, duration_seconds, scorecard_json
+     FROM voice_sessions
+     WHERE user_id = ? AND status = 'completed'
+     ORDER BY started_at DESC LIMIT 25`
+  ).bind(userRowId).all();
+
+  const results = rows?.results || [];
+  const activePlan = hasActiveVoicePlan(ent);
+  const sessions = [];
+
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    const expired = isSessionExpired(r.started_at, nowMs);
+    // Retention: aged rows drop out of the list, except the most recent row
+    // of a user with no active voice plan (their single free-taste session).
+    if (expired && (activePlan || i !== 0)) continue;
+
+    const fullAccess = sessionFullAccess(r, ent);
+    let scorecard = null;
+    try { scorecard = r.scorecard_json ? JSON.parse(r.scorecard_json) : null; } catch (_) {}
+
+    sessions.push({
+      sessionId: r.id,
+      role: r.role,
+      seniority: r.seniority,
+      createdAt: r.started_at,
+      durationSeconds: r.duration_seconds,
+      status: scorecard ? 'ready' : 'scoring',
+      overall: fullAccess && scorecard ? (scorecard.overall ?? null) : null,
+      fullAccess,
+      reportAvailable: !expired
+    });
+    if (sessions.length >= HISTORY_LIMIT) break;
+  }
+
+  return sessions;
+}
+
+/**
+ * Owner-only delete of one session (mirrors the typed delete: ownership is
+ * enforced in the SQL, 0 changes means not found / not yours).
+ *
+ * @returns {Promise<boolean>} true when a row was deleted
+ */
+export async function deleteVoiceSession(env, userRowId, sessionId) {
+  const db = getDb(env);
+  if (!db) return false;
+  const res = await db.prepare(
+    `DELETE FROM voice_sessions WHERE id = ? AND user_id = ?`
+  ).bind(String(sessionId), userRowId).run();
+  const changes = typeof res?.meta?.changes === 'number' ? res.meta.changes : (res?.changes || 0);
+  return changes > 0;
+}
+
+/**
+ * Owner-only clear of the user's entire voice history.
+ *
+ * @returns {Promise<number>} number of rows deleted
+ */
+export async function clearVoiceSessions(env, userRowId) {
+  const db = getDb(env);
+  if (!db) return 0;
+  const res = await db.prepare(
+    `DELETE FROM voice_sessions WHERE user_id = ?`
+  ).bind(userRowId).run();
+  return typeof res?.meta?.changes === 'number' ? res.meta.changes : (res?.changes || 0);
+}

--- a/app/functions/_lib/voice-history.js
+++ b/app/functions/_lib/voice-history.js
@@ -132,7 +132,12 @@ export async function deleteVoiceSession(env, userRowId, sessionId) {
 }
 
 /**
- * Owner-only clear of the user's entire voice history.
+ * Owner-only clear of the user's voice history. In-flight sessions
+ * (created/active) are never touched: the rail is visible during a live
+ * interview, and clearing history must not destroy the session row the
+ * upcoming /complete call needs — that would lose the just-consumed
+ * interview. Abandoned rows are cleared too; they are invisible in the
+ * list and can no longer be completed.
  *
  * @returns {Promise<number>} number of rows deleted
  */
@@ -140,7 +145,7 @@ export async function clearVoiceSessions(env, userRowId) {
   const db = getDb(env);
   if (!db) return 0;
   const res = await db.prepare(
-    `DELETE FROM voice_sessions WHERE user_id = ?`
+    `DELETE FROM voice_sessions WHERE user_id = ? AND status NOT IN ('created', 'active')`
   ).bind(userRowId).run();
   return typeof res?.meta?.changes === 'number' ? res.meta.changes : (res?.changes || 0);
 }

--- a/app/functions/_lib/voice-history.js
+++ b/app/functions/_lib/voice-history.js
@@ -105,7 +105,9 @@ export async function listVoiceSessions(env, userRowId, ent, nowMs = Date.now())
       createdAt: r.started_at,
       durationSeconds: r.duration_seconds,
       status: scorecard ? 'ready' : 'scoring',
-      overall: fullAccess && scorecard ? (scorecard.overall ?? null) : null,
+      // A locked (expired) row must not leak its score through the API even
+      // while the cleaner has yet to strip the stored scorecard.
+      overall: !expired && fullAccess && scorecard ? (scorecard.overall ?? null) : null,
       fullAccess,
       reportAvailable: !expired
     });
@@ -117,7 +119,9 @@ export async function listVoiceSessions(env, userRowId, ent, nowMs = Date.now())
 
 /**
  * Owner-only delete of one session (mirrors the typed delete: ownership is
- * enforced in the SQL, 0 changes means not found / not yours).
+ * enforced in the SQL, 0 changes means not found / not yours). In-flight
+ * (created/active) sessions are refused for the same reason clear skips
+ * them: destroying the row would orphan the upcoming /complete call.
  *
  * @returns {Promise<boolean>} true when a row was deleted
  */
@@ -125,7 +129,7 @@ export async function deleteVoiceSession(env, userRowId, sessionId) {
   const db = getDb(env);
   if (!db) return false;
   const res = await db.prepare(
-    `DELETE FROM voice_sessions WHERE id = ? AND user_id = ?`
+    `DELETE FROM voice_sessions WHERE id = ? AND user_id = ? AND status NOT IN ('created', 'active')`
   ).bind(String(sessionId), userRowId).run();
   const changes = typeof res?.meta?.changes === 'number' ? res.meta.changes : (res?.changes || 0);
   return changes > 0;

--- a/app/functions/_lib/voice-scorecard.js
+++ b/app/functions/_lib/voice-scorecard.js
@@ -23,11 +23,27 @@ export const SCORECARD_SCHEMA = {
         additionalProperties: false,
         properties: {
           communication: { type: 'integer', description: 'Clarity, pace, confidence 0-100' },
-          structure: { type: 'integer', description: 'Answer organization, STAR usage 0-100' },
+          structure: { type: 'integer', description: 'Answer structure scored BY the S + A = O formula (goal: about 5% situation, 10% action, 85% outcome) 0-100' },
           contentDepth: { type: 'integer', description: 'Specificity, examples, numbers 0-100' },
           roleFit: { type: 'integer', description: 'Relevance to the target role 0-100' }
         },
         required: ['communication', 'structure', 'contentDepth', 'roleFit']
+      },
+      saoBalance: {
+        type: 'object',
+        additionalProperties: false,
+        description: 'Share of the candidate speaking time spent on each S + A = O component, integer percents summing to about 100',
+        properties: {
+          situation: { type: 'integer', description: 'Percent of candidate speaking time spent setting up the situation, 0-100' },
+          action: { type: 'integer', description: 'Percent of candidate speaking time spent describing what they did, 0-100' },
+          outcome: { type: 'integer', description: 'Percent of candidate speaking time spent on results and numbers, 0-100' }
+        },
+        required: ['situation', 'action', 'outcome']
+      },
+      saoCoaching: {
+        type: 'array',
+        description: 'Exactly 2 imperative coaching lines, each under 120 characters, telling the candidate how to rebalance toward outcomes, e.g. "Open answers with the result. Then explain how."',
+        items: { type: 'string' }
       },
       topStrength: { type: 'string', description: 'The single strongest thing the candidate did, 1-2 sentences' },
       topImprovement: { type: 'string', description: 'The single most important improvement, 1-2 sentences, actionable' },
@@ -46,7 +62,7 @@ export const SCORECARD_SCHEMA = {
       },
       summary: { type: 'string', description: '3-4 sentence overall summary written to the candidate' }
     },
-    required: ['overall', 'dimensions', 'topStrength', 'topImprovement', 'moments', 'summary']
+    required: ['overall', 'dimensions', 'saoBalance', 'saoCoaching', 'topStrength', 'topImprovement', 'moments', 'summary']
   }
 };
 
@@ -100,6 +116,10 @@ export async function generateAndStoreScorecard(env, sessionId) {
       'You are an expert interview coach scoring a voice mock interview transcript.',
       'Score honestly: a rambling or vague performance should score in the 40s-60s, a strong one in the 70s-80s, exceptional in the 90s.',
       'Base every judgment only on what the CANDIDATE actually said. Quote or closely paraphrase real moments.',
+      'JobHackAI teaches the S + A = O answer formula: Situation about 5 percent, Action about 10 percent, Outcome about 85 percent of an answer.',
+      'Compute saoBalance from the transcript: the share of the candidate speaking time spent on situation setup, actions taken, and outcomes or results, as integer percents summing to about 100.',
+      'Score the structure dimension BY the S + A = O formula, not generic answer organization: answers that spend most of their time on concrete outcomes score high; answers stuck in backstory or process score low.',
+      'Write saoCoaching as exactly two imperative tips, each under 120 characters, telling the candidate how to rebalance toward outcomes.',
       'Write feedback to the candidate directly, in second person, plain language, short sentences. Do not use em dashes.'
     ].join(' ');
 

--- a/app/functions/api/voice/session/[id].js
+++ b/app/functions/api/voice/session/[id].js
@@ -116,6 +116,7 @@ export async function onRequest(context) {
       seniority: session.seniority,
       status: session.status,
       startedAt: session.started_at,
+      createdAt: session.started_at,
       endedAt: session.ended_at,
       durationSeconds: session.duration_seconds,
       scorecardReady: !!scorecard,

--- a/app/functions/api/voice/session/[id].js
+++ b/app/functions/api/voice/session/[id].js
@@ -7,12 +7,20 @@
  * - Free-taste users get the partial scorecard only: top strength + one
  *   improvement area. The full report and transcript stay behind the paywall
  *   server-side, so no client-state tampering can reveal them.
+ * - Sessions past the 90-day retention window return a minimal expired
+ *   payload (expired: true); the client renders the locked view.
+ *
+ * DELETE /api/voice/session/:id
+ *
+ * Owner-only delete for the history rail (mirrors the typed mock interview
+ * session delete: ownership enforced, 404 when the row isn't the caller's).
  */
 
 import { getBearer, verifyFirebaseIdToken } from '../../../_lib/firebase-auth.js';
 import { getOrCreateUserByAuthId, getDb } from '../../../_lib/db.js';
 import { getVoiceEntitlement, voiceFeatureEnabled } from '../../../_lib/voice-entitlements.js';
 import { partialScorecard } from '../../../_lib/voice-scorecard.js';
+import { isSessionExpired, deleteVoiceSession } from '../../../_lib/voice-history.js';
 import { errorResponse, successResponse, generateRequestId } from '../../../_lib/error-handler.js';
 
 export async function onRequest(context) {
@@ -21,7 +29,9 @@ export async function onRequest(context) {
   const requestId = generateRequestId();
 
   if (request.method === 'OPTIONS') return successResponse({}, 200, origin, env, requestId);
-  if (request.method !== 'GET') return errorResponse('Method not allowed', 405, origin, env, requestId);
+  if (request.method !== 'GET' && request.method !== 'DELETE') {
+    return errorResponse('Method not allowed', 405, origin, env, requestId);
+  }
   if (!voiceFeatureEnabled(env)) return errorResponse('Not found', 404, origin, env, requestId);
 
   const token = getBearer(request);
@@ -49,8 +59,40 @@ export async function onRequest(context) {
       return errorResponse('Session not found', 404, origin, env, requestId);
     }
 
+    if (request.method === 'DELETE') {
+      const deleted = await deleteVoiceSession(env, d1User.id, session.id);
+      if (!deleted) return errorResponse('Session not found', 404, origin, env, requestId);
+      console.log(`[VOICE-SESSION-DELETE] Deleted session ${session.id} for uid=${uid}`);
+      return successResponse({ success: true }, 200, origin, env, requestId);
+    }
+
     let scorecard = null;
     try { scorecard = session.scorecard_json ? JSON.parse(session.scorecard_json) : null; } catch (_) {}
+
+    // Past the 90-day retention window the report is locked for everyone:
+    // the retention-cleaner will remove the payload (or, for the free-taste
+    // carve-out row, strip it while keeping the metadata). Serve a minimal
+    // expired payload either way; the client renders the locked view.
+    if (isSessionExpired(session.started_at)) {
+      return successResponse({
+        sessionId: session.id,
+        role: session.role,
+        seniority: session.seniority,
+        status: session.status,
+        startedAt: session.started_at,
+        createdAt: session.started_at,
+        endedAt: session.ended_at,
+        durationSeconds: session.duration_seconds,
+        scorecardReady: true,
+        fullAccess: false,
+        expired: true,
+        scorecard: {
+          topStrength: scorecard?.topStrength ?? null,
+          topImprovement: scorecard?.topImprovement ?? null
+        },
+        transcript: null
+      }, 200, origin, env, requestId);
+    }
 
     // Full access: the session itself was paid for, or the user is currently
     // entitled (active subscription, grandfathered legacy plan, or pack

--- a/app/functions/api/voice/sessions.js
+++ b/app/functions/api/voice/sessions.js
@@ -1,14 +1,21 @@
 /**
  * GET /api/voice/sessions
  *
- * Lists the user's voice sessions for history and progress tracking.
- * Overall scores are included only for sessions the user has full access to
- * (paid sessions, or any session once the user is currently entitled).
+ * Lists the authenticated user's completed voice sessions for the history
+ * rail, newest first, max 10. Overall scores are included only for sessions
+ * the user has full access to (paid sessions, or any session once the user
+ * has ever paid); free/partial rows return overall: null.
+ *
+ * Retention mirrors the typed mock interview (90 days, deleted by
+ * workers/retention-cleaner) with the free-taste carve-out: a user with no
+ * active voice plan keeps their most recent session row listed past 90 days
+ * with reportAvailable: false. See _lib/voice-history.js.
  */
 
 import { getBearer, verifyFirebaseIdToken } from '../../_lib/firebase-auth.js';
 import { getOrCreateUserByAuthId, getDb } from '../../_lib/db.js';
 import { getVoiceEntitlement, voiceFeatureEnabled } from '../../_lib/voice-entitlements.js';
+import { listVoiceSessions } from '../../_lib/voice-history.js';
 import { errorResponse, successResponse, generateRequestId } from '../../_lib/error-handler.js';
 
 export async function onRequest(context) {
@@ -37,30 +44,8 @@ export async function onRequest(context) {
     const d1User = await getOrCreateUserByAuthId(env, uid, null, { updateActivity: false });
     if (!d1User?.id) return successResponse({ sessions: [] }, 200, origin, env, requestId);
 
-    const rows = await db.prepare(
-      `SELECT id, role, seniority, status, entitlement_mode, started_at, duration_seconds, scorecard_json
-       FROM voice_sessions WHERE user_id = ? ORDER BY started_at DESC LIMIT 25`
-    ).bind(d1User.id).all();
-
     const ent = await getVoiceEntitlement(env, uid);
-
-    const sessions = (rows?.results || []).map((r) => {
-      const fullAccess = r.entitlement_mode !== 'free' || ent.unlimited || ent.sessionsRemaining > 0 || ent.hasEverPaid;
-      let overall = null;
-      if (fullAccess && r.scorecard_json) {
-        try { overall = JSON.parse(r.scorecard_json).overall ?? null; } catch (_) {}
-      }
-      return {
-        sessionId: r.id,
-        role: r.role,
-        seniority: r.seniority,
-        status: r.status,
-        startedAt: r.started_at,
-        durationSeconds: r.duration_seconds,
-        overall,
-        fullAccess
-      };
-    });
+    const sessions = await listVoiceSessions(env, d1User.id, ent);
 
     return successResponse({ sessions }, 200, origin, env, requestId);
   } catch (err) {

--- a/app/functions/api/voice/sessions/clear.js
+++ b/app/functions/api/voice/sessions/clear.js
@@ -1,0 +1,49 @@
+/**
+ * POST /api/voice/sessions/clear
+ *
+ * Owner-only clear-all for the voice history rail (the voice counterpart of
+ * the typed rail's clear-history flow). Deletes every voice_sessions row
+ * belonging to the authenticated user; entitlement state (credits, free-taste
+ * flag) is untouched — clearing history never refunds or re-grants sessions.
+ */
+
+import { getBearer, verifyFirebaseIdToken } from '../../../_lib/firebase-auth.js';
+import { getOrCreateUserByAuthId, getDb } from '../../../_lib/db.js';
+import { voiceFeatureEnabled } from '../../../_lib/voice-entitlements.js';
+import { clearVoiceSessions } from '../../../_lib/voice-history.js';
+import { errorResponse, successResponse, generateRequestId } from '../../../_lib/error-handler.js';
+
+export async function onRequest(context) {
+  const { request, env } = context;
+  const origin = request.headers.get('Origin') || '';
+  const requestId = generateRequestId();
+
+  if (request.method === 'OPTIONS') return successResponse({}, 200, origin, env, requestId);
+  if (request.method !== 'POST') return errorResponse('Method not allowed', 405, origin, env, requestId);
+  if (!voiceFeatureEnabled(env)) return errorResponse('Not found', 404, origin, env, requestId);
+
+  const token = getBearer(request);
+  if (!token) return errorResponse('Unauthorized', 401, origin, env, requestId);
+
+  let uid;
+  try {
+    ({ uid } = await verifyFirebaseIdToken(token, env.FIREBASE_PROJECT_ID));
+  } catch (_) {
+    return errorResponse('Unauthorized', 401, origin, env, requestId);
+  }
+
+  const db = getDb(env);
+  if (!db) return errorResponse('Storage not available. Retry later.', 503, origin, env, requestId);
+
+  try {
+    const d1User = await getOrCreateUserByAuthId(env, uid, null, { updateActivity: false });
+    if (!d1User?.id) return successResponse({ success: true, deleted: 0 }, 200, origin, env, requestId);
+
+    const deleted = await clearVoiceSessions(env, d1User.id);
+    console.log(`[VOICE-SESSIONS-CLEAR] uid=${uid} deleted=${deleted}`);
+    return successResponse({ success: true, deleted }, 200, origin, env, requestId);
+  } catch (err) {
+    console.error('[VOICE-SESSIONS-CLEAR] Error:', err?.message || err);
+    return errorResponse('Internal error', 500, origin, env, requestId);
+  }
+}

--- a/dashboard.html
+++ b/dashboard.html
@@ -2359,9 +2359,9 @@
       // Voice tile only when VOICE_INTERVIEW_ENABLED is on (via /api/plan/me)
       (async function revealVoiceTile() {
         try {
-          // Fetch /api/plan/me directly rather than via fetchSubscriptionStatus/
-          // PlanCache, which trims the response to { plan, trialEndsAt } and
-          // drops the voice entitlement block, so the tile would never unhide.
+          // Fetch /api/plan/me directly rather than via fetchSubscriptionStatus,
+          // which trims the response to { plan, trialEndsAt } and drops the
+          // voice entitlement block, so the tile would never unhide.
           const idToken = await getFirebaseIdToken();
           if (!idToken) return;
           const res = await fetch('/api/plan/me', { headers: { Authorization: `Bearer ${idToken}` } });
@@ -2369,7 +2369,24 @@
           const planData = await res.json();
           if (planData && planData.voice && planData.voice.enabled) {
             const voiceCard = root.querySelector('[data-feature-key="voice"]');
-            if (voiceCard) voiceCard.style.display = '';
+            if (voiceCard) {
+              voiceCard.style.display = '';
+              // Entitlement chip next to the tile title (plan-badge family:
+              // #E8F5E9 tint + #388E3C text). Used-up free taste: no chip,
+              // the voice page itself paywalls.
+              const voice = planData.voice;
+              const chipText = voice.unlimited ? 'Unlimited'
+                : (voice.mode === 'pack' ? `${voice.sessionsRemaining} sessions left`
+                : (voice.canStart ? '1 free session' : null));
+              const titleEl = voiceCard.querySelector('.feature-title');
+              if (chipText && titleEl && !titleEl.querySelector('.voice-entitlement-chip')) {
+                const chip = document.createElement('span');
+                chip.className = 'voice-entitlement-chip';
+                chip.textContent = chipText;
+                chip.style.cssText = 'display:inline-block;margin-left:0.5rem;padding:0.1rem 0.6rem;border-radius:9999px;background:#E8F5E9;color:#388E3C;font-size:0.75rem;font-weight:700;vertical-align:middle;white-space:nowrap;';
+                titleEl.appendChild(chip);
+              }
+            }
           }
         } catch (_) { /* flag off or fetch failed: tile stays hidden */ }
       })();

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1574,9 +1574,17 @@ function ensureVoiceNavState() {
     }
     if (_voiceNavFetching || !window.PlanCache || typeof window.PlanCache.getPlan !== 'function') return;
     _voiceNavFetching = true;
+    const requestUid = user.uid || null;
     user.getIdToken()
       .then((token) => window.PlanCache.getPlan(token))
       .then((data) => {
+        // Discard responses that outlive an account switch: the plan data
+        // belongs to whoever was signed in when the fetch started, and must
+        // not stamp their entitlement onto the next account's nav.
+        const current = (window.FirebaseAuthManager && typeof window.FirebaseAuthManager.getCurrentUser === 'function')
+          ? window.FirebaseAuthManager.getCurrentUser()
+          : null;
+        if (!current || (current.uid || null) !== requestUid) return;
         // getPlan resolves null on a failed fetch (it never rejects). That is
         // indeterminate, not authoritative: keep the last-known voice state
         // instead of tearing the nav entry out on a transient network blip.

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1522,6 +1522,89 @@ const signedInUserNav = () => ({
   ]
 });
 
+// --- Voice mock interview nav entry (flag-gated) ---
+// The Interview Prep dropdown gains 'Voice Mock Interview' (and the typed
+// item is renamed 'Typed Mock Interview' to distinguish them) ONLY when
+// /api/plan/me reports voice.enabled. With the flag off the dropdown stays
+// exactly as it is today. Voice state rides the shared PlanCache fetch —
+// no second /api/plan/me call is added.
+let _voiceNav = null;          // last-known voice block from /api/plan/me
+let _voiceNavFetching = false;
+
+function voiceNavBadgeText(voice) {
+  if (!voice || !voice.enabled) return null;
+  if (voice.unlimited) return 'Pro · Unlimited';
+  if (voice.mode === 'pack') return `${voice.sessionsRemaining} left`;
+  if (voice.canStart) return '1 free';
+  return null; // free session used: no badge, the page itself paywalls
+}
+
+function withVoiceNavItems(navItems) {
+  if (!_voiceNav || !_voiceNav.enabled || !Array.isArray(navItems)) return navItems;
+  return navItems.map((item) => {
+    if (item.isDropdown !== true || item.text !== 'Interview Prep') return item;
+    const items = item.items.map((sub) =>
+      sub.text === 'Mock Interviews' ? { ...sub, text: 'Typed Mock Interview' } : sub
+    );
+    items.push({
+      text: 'Voice Mock Interview',
+      href: APP_BASE_URL + '/voice-interview.html',
+      badge: voiceNavBadgeText(_voiceNav)
+    });
+    return { ...item, items };
+  });
+}
+
+function withVoiceNavConfig(navConfig) {
+  if (!_voiceNav || !_voiceNav.enabled || !navConfig || !Array.isArray(navConfig.navItems)) return navConfig;
+  return { ...navConfig, navItems: withVoiceNavItems(navConfig.navItems) };
+}
+
+// Reads the voice block via the shared PlanCache (30s TTL, deduplicated) and
+// schedules ONE nav rebuild when the value actually changes, so this cannot
+// loop with updateNavigation calling it on every render.
+function ensureVoiceNavState() {
+  try {
+    const user = (window.FirebaseAuthManager && typeof window.FirebaseAuthManager.getCurrentUser === 'function')
+      ? window.FirebaseAuthManager.getCurrentUser()
+      : null;
+    if (!user || typeof user.getIdToken !== 'function') {
+      _voiceNav = null;
+      return;
+    }
+    if (_voiceNavFetching || !window.PlanCache || typeof window.PlanCache.getPlan !== 'function') return;
+    _voiceNavFetching = true;
+    user.getIdToken()
+      .then((token) => window.PlanCache.getPlan(token))
+      .then((data) => {
+        const voice = (data && data.voice) || null;
+        const changed = JSON.stringify(voice) !== JSON.stringify(_voiceNav);
+        _voiceNav = voice;
+        if (changed) {
+          navLog('info', 'Voice nav state changed, refreshing navigation', { enabled: !!(voice && voice.enabled) });
+          scheduleUpdateNavigation(true);
+        }
+      })
+      .catch((err) => {
+        navLog('debug', 'Voice nav state fetch failed (non-critical)', { message: err?.message });
+      })
+      .finally(() => { _voiceNavFetching = false; });
+  } catch (err) {
+    navLog('debug', 'ensureVoiceNavState failed (non-critical)', { message: err?.message });
+  }
+}
+
+// Badge on a dropdown item (plan-badge family: #E8F5E9 tint + #388E3C text,
+// pill radius — same palette as the weekly/monthly/pack plan badges).
+function appendNavItemBadge(link, badgeText) {
+  if (!badgeText) return;
+  const badge = document.createElement('span');
+  badge.className = 'nav-dropdown-badge';
+  badge.textContent = badgeText;
+  badge.style.cssText = 'display:inline-block;margin-left:0.5rem;padding:0.1rem 0.55rem;border-radius:var(--radius-full, 9999px);background:#E8F5E9;color:#388E3C;font-size:0.75rem;font-weight:700;vertical-align:middle;';
+  link.appendChild(badge);
+}
+
 const NAVIGATION_CONFIG = {
   // Logged-out / Visitor
   visitor: {
@@ -1920,7 +2003,10 @@ function updateNavigation() {
     url: window.location.href
   });
 
-  const navConfig = NAVIGATION_CONFIG[currentPlan] || NAVIGATION_CONFIG.visitor;
+  // Voice nav entry is flag-gated: refresh the entitlement (async, rebuilds
+  // once if it changed) and fold the current known state into the config.
+  ensureVoiceNavState();
+  const navConfig = withVoiceNavConfig(NAVIGATION_CONFIG[currentPlan] || NAVIGATION_CONFIG.visitor);
   navLog('info', 'Using navigation config', {
     plan: currentPlan,
     hasConfig: !!navConfig,
@@ -2090,6 +2176,7 @@ function updateNavigation() {
           const link = document.createElement('a');
           updateLink(link, dropdownItem.href);
           link.textContent = dropdownItem.text;
+          appendNavItemBadge(link, dropdownItem.badge);
           // Only add locked handler if explicitly marked as locked
           // Dropdown items should inherit unlocked state from parent plan config
           // CRITICAL: Use strict equality to prevent issues with truthy non-boolean values
@@ -2240,6 +2327,7 @@ function updateNavigation() {
           const link = document.createElement('a');
           updateLink(link, dropdownItem.href);
           link.textContent = dropdownItem.text;
+          appendNavItemBadge(link, dropdownItem.badge);
           // Only add locked handler if explicitly marked as locked
           // CRITICAL: Use strict equality to prevent issues with truthy non-boolean values
           if (dropdownItem.locked === true) {
@@ -3096,6 +3184,7 @@ function _buildVerifiedNavItems(container, navConfig, wrapHref) {
           link.href = wrapHref(sub.href);
         }
         link.textContent = sub.text;
+        appendNavItemBadge(link, sub.badge);
         menu.appendChild(link);
       });
 
@@ -3173,7 +3262,8 @@ function _buildUserMenu(navConfig, wrapHref) {
 function renderVerifiedNav(desktop, mobile) {
   if (!desktop) return;
   const currentPlan = getEffectivePlan();
-  const navConfig = NAVIGATION_CONFIG[currentPlan] || NAVIGATION_CONFIG.free;
+  ensureVoiceNavState();
+  const navConfig = withVoiceNavConfig(NAVIGATION_CONFIG[currentPlan] || NAVIGATION_CONFIG.free);
   const planForHandoff = normalizeHandoffPlan(localStorage.getItem('user-plan') || localStorage.getItem('dev-plan') || 'free') || 'free';
 
   const wrapHref = (href) => buildAuthHandoffHref(href, true, planForHandoff);

--- a/js/navigation.js
+++ b/js/navigation.js
@@ -1577,7 +1577,11 @@ function ensureVoiceNavState() {
     user.getIdToken()
       .then((token) => window.PlanCache.getPlan(token))
       .then((data) => {
-        const voice = (data && data.voice) || null;
+        // getPlan resolves null on a failed fetch (it never rejects). That is
+        // indeterminate, not authoritative: keep the last-known voice state
+        // instead of tearing the nav entry out on a transient network blip.
+        if (!data) return;
+        const voice = data.voice || null;
         const changed = JSON.stringify(voice) !== JSON.stringify(_voiceNav);
         _voiceNav = voice;
         if (changed) {

--- a/js/plan-cache.js
+++ b/js/plan-cache.js
@@ -6,7 +6,7 @@
 (function () {
   'use strict';
 
-  var _cached = null;   // { plan, trialEndsAt }
+  var _cached = null;   // { plan, trialEndsAt, voice }
   var _cachedAt = 0;
   var _inflight = null; // Promise | null
   var _generation = 0;  // Incremented on invalidate to discard stale in-flight results
@@ -18,7 +18,13 @@
     }).then(function (res) {
       if (!res.ok) return null;
       return res.json().then(function (data) {
-        return { plan: (data && data.plan) || null, trialEndsAt: (data && data.trialEndsAt) || null };
+        return {
+          plan: (data && data.plan) || null,
+          trialEndsAt: (data && data.trialEndsAt) || null,
+          // Voice entitlement block, consumed by navigation.js, dashboard,
+          // and voice-cta.js — keeping it here saves their direct fetches.
+          voice: (data && data.voice) || null
+        };
       });
     });
   }
@@ -77,8 +83,10 @@
 
     // Manually seed the cache (e.g. after checkout redirect sets plan via
     // billing-status). Prevents a redundant /api/plan/me round-trip.
+    // Keeps any previously fetched voice block: seeding only knows the plan,
+    // and stale voice state is better than wiping it (30s TTL bounds it).
     setCachedPlan: function (plan, trialEndsAt) {
-      _cached = { plan: plan, trialEndsAt: trialEndsAt || null };
+      _cached = { plan: plan, trialEndsAt: trialEndsAt || null, voice: (_cached && _cached.voice) || null };
       _cachedAt = Date.now();
       persistToLocalStorage(_cached);
     },

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -397,6 +397,29 @@
     return div.innerHTML;
   }
 
+  // One row of the S + A = O balance block: green fill at the actual share,
+  // a dark goal tick at the 5/10/85 target, and a colored note. Over-goal is
+  // a warning, Outcome under-goal is the real error, on/near goal is success.
+  function saoBalanceRow(label, actual, goal, isOutcome) {
+    actual = Math.max(0, Math.min(100, Math.round(Number(actual) || 0)));
+    var noteClass = 'vi-sao-bal-note--ok';
+    if (isOutcome && actual < goal - 5) noteClass = 'vi-sao-bal-note--under';
+    else if (!isOutcome && actual > goal + 5) noteClass = 'vi-sao-bal-note--over';
+    return '<div class="vi-sao-bal-row"><span class="vi-sao-bal-label">' + label + '</span>' +
+      '<span class="vi-sao-bal-track"><span class="vi-sao-bal-fill" style="width:' + actual + '%"></span>' +
+      '<span class="vi-sao-bal-goal" style="left:' + goal + '%"></span></span>' +
+      '<span class="vi-sao-bal-note ' + noteClass + '">' + actual + '% · goal ≈ ' + goal + '%</span></div>';
+  }
+
+  function savedLine(data) {
+    var parts = ['Saved to history'];
+    var when = formatHistoryWhen(data.createdAt || data.startedAt);
+    if (when) parts.push(when);
+    if (data.role) parts.push(String(data.role));
+    if (data.seniority) parts.push(String(data.seniority));
+    return '<p class="vi-sc-saved">' + escapeHtml(parts.join(' · ')) + '</p>';
+  }
+
   function renderScorecard(data) {
     var wrap = $('vi-scorecard');
     var doneStatus = $('vi-done-status');
@@ -406,16 +429,34 @@
     var html = '';
 
     html += '<h2 class="vi-sc-title">Your interview report</h2>';
+    if (!data.expired) html += savedLine(data);
 
     if (data.fullAccess) {
       html += '<div class="vi-sc-overall"><div class="vi-sc-score">' + escapeHtml(sc.overall) + '</div><div class="vi-sc-overall-label">Overall</div></div>';
       if (sc.dimensions) {
         html += '<div class="vi-sc-dims">';
         html += dimensionRow('Communication', sc.dimensions.communication);
-        html += dimensionRow('Structure', sc.dimensions.structure);
+        html += dimensionRow('S + A = O structure', sc.dimensions.structure);
         html += dimensionRow('Content depth', sc.dimensions.contentDepth);
         html += dimensionRow('Role fit', sc.dimensions.roleFit);
         html += '</div>';
+      }
+      // Additive scorecard fields: old sessions have no saoBalance, so the
+      // whole balance block hides gracefully when it is absent.
+      if (sc.saoBalance) {
+        html += '<div class="vi-sc-block"><h3>How you balanced Situation, Action, and Outcome</h3>';
+        html += '<div class="vi-sao-bal">';
+        html += saoBalanceRow('Situation', sc.saoBalance.situation, 5, false);
+        html += saoBalanceRow('Action', sc.saoBalance.action, 10, false);
+        html += saoBalanceRow('Outcome', sc.saoBalance.outcome, 85, true);
+        html += '</div></div>';
+        if (sc.saoCoaching && sc.saoCoaching.length) {
+          html += '<div class="vi-sc-block vi-sc-improve"><h3>Next time, focus on</h3><ul class="vi-sc-coach">';
+          sc.saoCoaching.forEach(function (tip) {
+            html += '<li>' + escapeHtml(tip) + '</li>';
+          });
+          html += '</ul></div>';
+        }
       }
     }
 
@@ -442,7 +483,11 @@
         });
         html += '</details>';
       }
-      html += '<div class="vi-sc-actions"><a class="vi-btn-secondary" href="voice-interview.html">Run another interview</a></div>';
+      html += '<div class="vi-sc-actions">' +
+        '<a class="vi-btn-primary" href="voice-interview.html">Run another interview</a>' +
+        '<a class="vi-btn-secondary" href="mock-interview.html">Practice typed questions</a>' +
+        '<a class="vi-sc-actions-link" href="dashboard.html">Back to Dashboard</a>' +
+        '</div>';
     } else {
       // Free taste: partial scorecard, blurred full report, one upgrade CTA.
       // Expired sessions (past the 90-day retention window) share the same

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -83,6 +83,8 @@
       var voice = res.data && res.data.voice;
       if (!voice || !voice.enabled) { show('vi-disabled-view'); return; }
 
+      initHistory(voice);
+
       var banner = $('vi-entitlement');
       var startBtn = $('vi-start-btn');
       if (!banner || !startBtn) return;
@@ -281,6 +283,7 @@
       show('vi-live-view');
       setStatus('Connecting...', 'vi-connecting');
       track('voice_session_start', { mode: res.data.mode });
+      historyLiveStart(role, seniority);
 
       await connectRealtime(res.data.clientSecret, state.model);
       startTimer(state.maxMinutes);
@@ -340,6 +343,7 @@
     show('vi-done-view');
     var doneStatus = $('vi-done-status');
     if (doneStatus) doneStatus.textContent = 'Interview finished. Preparing your report...';
+    historyLiveScoring();
 
     try {
       await api('/api/voice/session/' + encodeURIComponent(state.sessionId) + '/complete', {
@@ -371,6 +375,7 @@
         var res = await api('/api/voice/session/' + encodeURIComponent(state.sessionId), { method: 'GET' });
         if (res.ok && res.data && res.data.scorecardReady) {
           renderScorecard(res.data);
+          historyOnScorecardReady();
           return;
         }
       } catch (_) {}
@@ -414,8 +419,10 @@
       }
     }
 
-    html += '<div class="vi-sc-block vi-sc-strength"><h3>Top strength</h3><p>' + escapeHtml(sc.topStrength) + '</p></div>';
-    html += '<div class="vi-sc-block vi-sc-improve"><h3>Improve this first</h3><p>' + escapeHtml(sc.topImprovement) + '</p></div>';
+    if (!data.expired) {
+      html += '<div class="vi-sc-block vi-sc-strength"><h3>Top strength</h3><p>' + escapeHtml(sc.topStrength) + '</p></div>';
+      html += '<div class="vi-sc-block vi-sc-improve"><h3>Improve this first</h3><p>' + escapeHtml(sc.topImprovement) + '</p></div>';
+    }
 
     if (data.fullAccess) {
       if (sc.moments && sc.moments.length) {
@@ -437,20 +444,415 @@
       }
       html += '<div class="vi-sc-actions"><a class="vi-btn-secondary" href="voice-interview.html">Run another interview</a></div>';
     } else {
-      // Free taste: partial scorecard, blurred full report, one upgrade CTA
+      // Free taste: partial scorecard, blurred full report, one upgrade CTA.
+      // Expired sessions (past the 90-day retention window) share the same
+      // locked view with retention-specific copy.
       track('paywall_view', { surface: 'voice_scorecard' });
+      var unlockHeading = data.expired ? 'This report has expired.' : 'Your full report is ready.';
+      var unlockBody = data.expired
+        ? 'Upgrade to keep every report, transcript, and your progress across sessions.'
+        : 'Unlock every score, the moment by moment feedback, and your transcript. Then keep practicing until the answers are automatic.';
       html += '<div class="vi-sc-locked">';
       html += '<div class="vi-sc-blur" aria-hidden="true">';
       html += '<div class="vi-sc-overall"><div class="vi-sc-score">??</div><div class="vi-sc-overall-label">Overall</div></div>';
       html += '<div class="vi-sc-dims">' + dimensionRow('Communication', 70) + dimensionRow('Structure', 55) + dimensionRow('Content depth', 62) + dimensionRow('Role fit', 75) + '</div>';
       html += '<p>The full report includes your scores, specific moments from your answers, a summary, and the complete transcript.</p>';
       html += '</div>';
-      html += '<div class="vi-sc-unlock"><h3>Your full report is ready.</h3><p>Unlock every score, the moment by moment feedback, and your transcript. Then keep practicing until the answers are automatic.</p><a class="vi-btn-primary" href="/pricing" data-cta="voice-scorecard-unlock">See plans</a></div>';
+      html += '<div class="vi-sc-unlock"><h3>' + unlockHeading + '</h3><p>' + unlockBody + '</p><a class="vi-btn-primary" href="/pricing" data-cta="voice-scorecard-unlock">See plans</a></div>';
       html += '</div>';
     }
 
     wrap.innerHTML = html;
     wrap.style.display = '';
+  }
+
+  // ---------- history rail ----------
+  // Mirrors the typed mock interview's history rail (mock-interview.html):
+  // same fetch/render/manage/delete/clear flow with vi- prefixed elements.
+  // The rail is gated on the same voice.enabled signal as the rest of the
+  // page: with the flag off none of this runs and the markup stays hidden.
+
+  var historyState = {
+    voice: null,               // voice entitlement payload from /api/plan/me
+    items: [],                 // rows from GET /api/voice/sessions
+    liveRow: null,             // { role, seniority, phase: 'live'|'scoring' }
+    manageMode: false,
+    selectedIds: {},           // id -> true
+    pendingDeleteIds: [],
+    pendingClearAll: false,
+    bound: false
+  };
+
+  function historySelectedCount() {
+    return Object.keys(historyState.selectedIds).length;
+  }
+
+  function initHistory(voice) {
+    historyState.voice = voice || null;
+    if (!voice || !voice.enabled) return;
+    var panel = $('vi-history-panel');
+    if (!panel) return;
+    var wrap = document.querySelector('.vi-wrap');
+    if (wrap) wrap.classList.add('vi-has-rail');
+    panel.style.display = '';
+    bindHistoryEvents();
+    fetchHistory();
+  }
+
+  function showHistoryError(message) {
+    var errEl = $('vi-history-error');
+    if (!errEl) return;
+    var span = errEl.querySelector('[data-default-message]');
+    if (span) span.textContent = (message || span.getAttribute('data-default-message')) + ' ';
+    errEl.hidden = false;
+  }
+
+  async function fetchHistory() {
+    var loading = $('vi-history-loading');
+    var errEl = $('vi-history-error');
+    if (errEl) errEl.hidden = true;
+    if (loading && !historyState.items.length) loading.classList.add('is-visible');
+    try {
+      var res = await api('/api/voice/sessions', { method: 'GET' });
+      if (!res.ok || !res.data || !Array.isArray(res.data.sessions)) throw new Error('history_failed');
+      historyState.items = res.data.sessions;
+    } catch (err) {
+      console.warn('[VOICE] history load failed:', err && err.message);
+      showHistoryError(null);
+    }
+    if (loading) loading.classList.remove('is-visible');
+    renderHistory();
+    renderProgressStrip();
+  }
+
+  function formatHistoryWhen(createdAt) {
+    if (!createdAt) return '';
+    var s = String(createdAt);
+    if (s.indexOf('T') === -1) s = s.replace(' ', 'T');
+    if (!/Z|[+-]\d\d:?\d\d$/.test(s)) s += 'Z';
+    var d = new Date(s);
+    if (isNaN(d.getTime())) return '';
+    var now = new Date();
+    var startOfDay = function (x) { return new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime(); };
+    var dayDiff = Math.round((startOfDay(now) - startOfDay(d)) / 86400000);
+    if (dayDiff <= 0) return 'Today';
+    if (dayDiff === 1) return 'Yesterday';
+    var months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+    return months[d.getMonth()] + ' ' + d.getDate();
+  }
+
+  function historyMetaLine(item) {
+    var parts = [];
+    var when = formatHistoryWhen(item.createdAt);
+    if (when) parts.push(when);
+    if (item.durationSeconds != null && isFinite(Number(item.durationSeconds))) {
+      parts.push(Math.max(1, Math.round(Number(item.durationSeconds) / 60)) + ' min');
+    }
+    return parts.join(' · ');
+  }
+
+  var HISTORY_LOCK_SVG = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="11" width="18" height="8" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>';
+
+  function historyChip(item) {
+    if (!item.reportAvailable || !item.fullAccess) {
+      return '<span class="vi-history-chip vi-history-chip--partial">' + HISTORY_LOCK_SVG + 'Partial</span>';
+    }
+    if (item.status === 'scoring') {
+      return '<span class="vi-history-chip vi-history-chip--scoring">Scoring…</span>';
+    }
+    if (item.overall != null && isFinite(Number(item.overall))) {
+      return '<span class="vi-history-chip vi-history-chip--score">' + Math.round(Number(item.overall)) + '</span>';
+    }
+    return '<span class="vi-history-chip vi-history-chip--scoring">Scoring…</span>';
+  }
+
+  function historyRowLine1(role, seniority) {
+    var text = String(role || 'Untitled role');
+    if (seniority) text += ' · ' + seniority;
+    return escapeHtml(text);
+  }
+
+  function renderHistory() {
+    var listEl = $('vi-history-list');
+    var emptyEl = $('vi-history-empty');
+    if (!listEl) return;
+
+    var html = '';
+    if (historyState.liveRow) {
+      var live = historyState.liveRow;
+      var liveChip = live.phase === 'scoring'
+        ? '<span class="vi-history-chip vi-history-chip--scoring">Scoring…</span>'
+        : '<span class="vi-history-chip vi-history-chip--live">Live</span>';
+      html += '<div class="vi-history-item vi-history-item--live">' +
+        '<div class="vi-history-text">' +
+        '<div class="vi-history-line1">' + historyRowLine1(live.role, live.seniority) + '</div>' +
+        '<div class="vi-history-line2">' + (live.phase === 'scoring' ? 'Scoring your report…' : 'Live now') + '</div>' +
+        '</div>' + liveChip + '</div>';
+    }
+
+    html += historyState.items.map(function (item) {
+      var id = String(item.sessionId || '');
+      var isSelected = !!historyState.selectedIds[id];
+      return '<div class="vi-history-item' + (isSelected ? ' is-selected' : '') + '" data-id="' + escapeHtml(id) + '" tabindex="0" data-history-row>' +
+        '<span class="vi-history-checkbox-wrap" aria-hidden="' + (historyState.manageMode ? 'false' : 'true') + '">' +
+        '<input class="vi-history-checkbox" type="checkbox" data-action="toggle-select" data-id="' + escapeHtml(id) + '" aria-label="Select ' + historyRowLine1(item.role, item.seniority) + '"' + (isSelected ? ' checked' : '') + '/>' +
+        '</span>' +
+        '<div class="vi-history-text">' +
+        '<div class="vi-history-line1">' + historyRowLine1(item.role, item.seniority) + '</div>' +
+        '<div class="vi-history-line2">' + escapeHtml(historyMetaLine(item)) + '</div>' +
+        '</div>' +
+        historyChip(item) +
+        '</div>';
+    }).join('');
+
+    listEl.innerHTML = html;
+    if (emptyEl) emptyEl.hidden = !!(html || historyState.liveRow);
+  }
+
+  function renderProgressStrip() {
+    var strip = $('vi-history-progress');
+    var locked = $('vi-history-progress-locked');
+    if (!strip || !locked) return;
+    strip.hidden = true;
+    locked.hidden = true;
+
+    var voice = historyState.voice || {};
+    var paid = !!(voice.unlimited || (voice.mode === 'pack' && voice.sessionsRemaining > 0));
+
+    // Chronological order (list is newest first), last 3 scored sessions
+    var scored = historyState.items.filter(function (item) {
+      return item.overall != null && isFinite(Number(item.overall));
+    }).slice(0, 3).reverse();
+
+    if (paid && scored.length >= 2) {
+      var values = scored.map(function (item) { return Math.round(Number(item.overall)); });
+      var delta = values[values.length - 1] - values[0];
+      var valueEl = $('vi-history-progress-value');
+      var deltaEl = $('vi-history-progress-delta');
+      if (valueEl) valueEl.textContent = values.join(' → ');
+      if (deltaEl) {
+        // A downward trend is muted, not error-red: practice is never punished
+        deltaEl.textContent = (delta >= 0 ? '▲ +' : '▼ −') + Math.abs(delta) + ' overall';
+        deltaEl.className = 'vi-history-progress-delta' + (delta >= 0 ? '' : ' vi-history-progress-delta--down');
+      }
+      strip.hidden = false;
+    } else if (!paid && historyState.items.length >= 1) {
+      locked.hidden = false;
+    }
+  }
+
+  function setHistoryManageMode(next) {
+    var panel = $('vi-history-panel');
+    var titleEl = $('vi-history-header-title');
+    historyState.manageMode = !!next;
+    if (panel) panel.classList.toggle('vi-history-panel--manage', historyState.manageMode);
+    if (titleEl) titleEl.textContent = historyState.manageMode ? 'Select items' : 'History';
+    if (!historyState.manageMode) historyState.selectedIds = {};
+    syncBulkDeleteState();
+    renderHistory();
+  }
+
+  function syncBulkDeleteState() {
+    var btn = $('vi-history-delete-selected');
+    if (btn) btn.disabled = historySelectedCount() < 1;
+  }
+
+  function openDeleteModalFor(ids, clearAll) {
+    historyState.pendingDeleteIds = ids.slice();
+    historyState.pendingClearAll = !!clearAll;
+    var backdrop = $('vi-history-modal-backdrop');
+    var modal = $('vi-history-delete-modal');
+    if (backdrop) backdrop.hidden = false;
+    if (modal) {
+      modal.hidden = false;
+      var confirmBtn = $('vi-history-delete-confirm');
+      if (confirmBtn) confirmBtn.focus();
+    }
+  }
+
+  function closeDeleteModal() {
+    historyState.pendingDeleteIds = [];
+    historyState.pendingClearAll = false;
+    var backdrop = $('vi-history-modal-backdrop');
+    var modal = $('vi-history-delete-modal');
+    if (backdrop) backdrop.hidden = true;
+    if (modal) modal.hidden = true;
+  }
+
+  async function handleDeleteConfirm() {
+    var ids = historyState.pendingDeleteIds.slice();
+    var clearAll = historyState.pendingClearAll;
+    closeDeleteModal();
+    if (!ids.length) return;
+
+    var failed = 0;
+    try {
+      if (clearAll) {
+        var res = await api('/api/voice/sessions/clear', { method: 'POST' });
+        if (!res.ok) failed = ids.length;
+        else track('voice_history_clear', { count: ids.length });
+      } else {
+        var results = await Promise.allSettled(ids.map(function (id) {
+          return api('/api/voice/session/' + encodeURIComponent(id), { method: 'DELETE' });
+        }));
+        failed = results.filter(function (r) { return r.status !== 'fulfilled' || !r.value.ok; }).length;
+        if (failed < ids.length) track('voice_history_delete', { count: ids.length - failed });
+      }
+    } catch (err) {
+      console.warn('[VOICE] history delete failed:', err && err.message);
+      failed = ids.length;
+    }
+    if (failed > 0) {
+      showHistoryError('Some selected entries could not be deleted. History refreshed to reflect the current state.');
+    }
+    setHistoryManageMode(false);
+    fetchHistory();
+  }
+
+  function bindHistoryEvents() {
+    if (historyState.bound) return;
+    historyState.bound = true;
+
+    var refreshBtn = $('vi-history-refresh');
+    if (refreshBtn) refreshBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      if (historyState.manageMode) return;
+      fetchHistory();
+    });
+
+    var manageBtn = $('vi-history-manage');
+    if (manageBtn) manageBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      setHistoryManageMode(true);
+    });
+
+    var cancelBtn = $('vi-history-cancel-manage');
+    if (cancelBtn) cancelBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      setHistoryManageMode(false);
+    });
+
+    var deleteSelectedBtn = $('vi-history-delete-selected');
+    if (deleteSelectedBtn) deleteSelectedBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      var ids = Object.keys(historyState.selectedIds);
+      if (!ids.length) return;
+      openDeleteModalFor(ids, false);
+    });
+
+    var clearBtn = $('vi-history-clear');
+    if (clearBtn) clearBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      var ids = historyState.items.map(function (item) { return String(item.sessionId || ''); }).filter(Boolean);
+      if (!ids.length) return;
+      if (!historyState.manageMode) setHistoryManageMode(true);
+      historyState.selectedIds = {};
+      ids.forEach(function (id) { historyState.selectedIds[id] = true; });
+      syncBulkDeleteState();
+      renderHistory();
+      openDeleteModalFor(ids, true);
+    });
+
+    var retryBtn = $('vi-history-retry');
+    if (retryBtn) retryBtn.addEventListener('click', function (e) {
+      e.preventDefault();
+      fetchHistory();
+    });
+
+    var listEl = $('vi-history-list');
+    if (listEl) listEl.addEventListener('click', function (e) {
+      var checkbox = e.target.closest ? e.target.closest('[data-action="toggle-select"]') : null;
+      var row = e.target.closest ? e.target.closest('[data-history-row]') : null;
+      if (!row) return;
+      var id = row.getAttribute('data-id');
+      if (!id) return;
+      if (historyState.manageMode) {
+        if (historyState.selectedIds[id]) delete historyState.selectedIds[id];
+        else historyState.selectedIds[id] = true;
+        if (!checkbox) renderHistory();
+        else row.classList.toggle('is-selected', !!historyState.selectedIds[id]);
+        syncBulkDeleteState();
+        return;
+      }
+      track('voice_history_open', { session: id });
+      window.location = 'voice-interview.html?session=' + encodeURIComponent(id);
+    });
+    if (listEl) listEl.addEventListener('keydown', function (e) {
+      if (e.key !== 'Enter' && e.key !== ' ') return;
+      var row = e.target.closest ? e.target.closest('[data-history-row]') : null;
+      if (!row) return;
+      e.preventDefault();
+      row.click();
+    });
+
+    var backdrop = $('vi-history-modal-backdrop');
+    if (backdrop) backdrop.addEventListener('click', closeDeleteModal);
+    var deleteCancel = $('vi-history-delete-cancel');
+    if (deleteCancel) deleteCancel.addEventListener('click', closeDeleteModal);
+    var deleteConfirm = $('vi-history-delete-confirm');
+    if (deleteConfirm) deleteConfirm.addEventListener('click', handleDeleteConfirm);
+
+    // Focus trap + ESC close for the confirm modal (typed precedent)
+    var modal = $('vi-history-delete-modal');
+    if (modal && !modal.dataset.bound) {
+      modal.dataset.bound = '1';
+      modal.addEventListener('keydown', function (e) {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          closeDeleteModal();
+          return;
+        }
+        if (e.key !== 'Tab') return;
+        var focusables = modal.querySelectorAll('button,[href],input,select,textarea,[tabindex]:not([tabindex="-1"])');
+        var list = Array.prototype.filter.call(focusables, function (el) { return !el.disabled && el.offsetParent !== null; });
+        if (!list.length) return;
+        var first = list[0];
+        var last = list[list.length - 1];
+        var active = document.activeElement;
+        if (e.shiftKey && active === first) {
+          e.preventDefault();
+          last.focus();
+        } else if (!e.shiftKey && active === last) {
+          e.preventDefault();
+          first.focus();
+        }
+      });
+    }
+    document.addEventListener('keydown', function (e) {
+      if (e.key === 'Escape') {
+        var backdropEl = $('vi-history-modal-backdrop');
+        if (backdropEl && !backdropEl.hidden) closeDeleteModal();
+      }
+    });
+  }
+
+  function historyLiveStart(role, seniority) {
+    if (!historyState.voice || !historyState.voice.enabled) return;
+    historyState.liveRow = { role: role, seniority: seniority, phase: 'live' };
+    renderHistory();
+  }
+
+  function historyLiveScoring() {
+    if (!historyState.liveRow) return;
+    historyState.liveRow.phase = 'scoring';
+    renderHistory();
+  }
+
+  function historyOnScorecardReady() {
+    if (!historyState.voice || !historyState.voice.enabled) return;
+    historyState.liveRow = null;
+    fetchHistory();
+  }
+
+  // Deep-link path (?session=...): loadEntitlement() never runs, so fetch the
+  // same plan payload once here purely to gate + fill the rail.
+  async function initHistoryFromPlan() {
+    try {
+      var res = await api('/api/plan/me', { method: 'GET' });
+      initHistory(res.data && res.data.voice);
+    } catch (err) {
+      console.warn('[VOICE] history plan load failed:', err && err.message);
+    }
   }
 
   // ---------- view a past session (?session=...) ----------
@@ -501,6 +903,8 @@
     if (!shown) {
       show('vi-setup-view');
       loadEntitlement();
+    } else {
+      initHistoryFromPlan();
     }
   });
 })();

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -291,6 +291,7 @@
       console.error('[VOICE] start failed:', err);
       alert('Could not connect the voice session. Check your connection and try again.');
       teardownConnection();
+      historyLiveClear(false);
       show('vi-setup-view');
       if (startBtn) { startBtn.disabled = false; startBtn.textContent = 'Start the interview'; }
     }
@@ -361,6 +362,7 @@
     } catch (err) {
       console.error('[VOICE] complete failed:', err);
       if (doneStatus) doneStatus.textContent = 'The session ended but saving failed. Your session is recorded; check back shortly.';
+      historyLiveClear(false);
     }
   }
 
@@ -368,6 +370,9 @@
     if (attempt > 20) {
       var doneStatus = $('vi-done-status');
       if (doneStatus) doneStatus.textContent = 'Your report is taking longer than usual. Refresh this page in a minute.';
+      // The session IS completed server-side; swap the local Scoring… row
+      // for the server's own scoring row so the rail stays truthful.
+      historyLiveClear(true);
       return;
     }
     setTimeout(async function () {
@@ -888,6 +893,17 @@
     if (!historyState.liveRow) return;
     historyState.liveRow.phase = 'scoring';
     renderHistory();
+  }
+
+  // Failure paths: drop the live row so the rail never shows Live/Scoring…
+  // for a session that is no longer going anywhere. Pass refresh=true when
+  // the session was completed server-side (poll timeout): the refetch swaps
+  // the local row for the server's real 'scoring' row instead.
+  function historyLiveClear(refresh) {
+    if (!historyState.liveRow) return;
+    historyState.liveRow = null;
+    if (refresh && historyState.voice && historyState.voice.enabled) fetchHistory();
+    else renderHistory();
   }
 
   function historyOnScorecardReady() {

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -599,11 +599,18 @@
   var HISTORY_LOCK_SVG = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><rect x="3" y="11" width="18" height="8" rx="2"/><path d="M7 11V7a5 5 0 0110 0v4"/></svg>';
 
   function historyChip(item) {
-    if (!item.reportAvailable || !item.fullAccess) {
+    // Expired rows are locked whatever their status says: the stripped
+    // carve-out row reports 'scoring' (no stored scorecard) forever.
+    if (!item.reportAvailable) {
       return '<span class="vi-history-chip vi-history-chip--partial">' + HISTORY_LOCK_SVG + 'Partial</span>';
     }
+    // A report still being scored is 'Scoring…' even without full access —
+    // the Partial lock only applies once there is a report to lock.
     if (item.status === 'scoring') {
       return '<span class="vi-history-chip vi-history-chip--scoring">Scoring…</span>';
+    }
+    if (!item.fullAccess) {
+      return '<span class="vi-history-chip vi-history-chip--partial">' + HISTORY_LOCK_SVG + 'Partial</span>';
     }
     if (item.overall != null && isFinite(Number(item.overall))) {
       return '<span class="vi-history-chip vi-history-chip--score">' + Math.round(Number(item.overall)) + '</span>';

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -342,7 +342,7 @@
 
     show('vi-done-view');
     var doneStatus = $('vi-done-status');
-    if (doneStatus) doneStatus.textContent = 'Interview finished. Preparing your report...';
+    if (doneStatus) doneStatus.textContent = 'We\'re reviewing your conversation using our S + A = O formula and interview rubric. This usually takes a few seconds.';
     historyLiveScoring();
 
     try {

--- a/voice-interview.html
+++ b/voice-interview.html
@@ -256,11 +256,12 @@
         <label for="vi-seniority">Seniority</label>
         <select id="vi-seniority">
           <option value="">Any level</option>
-          <option>Entry level</option>
-          <option>Mid level</option>
+          <option>Intern</option>
+          <option>Junior</option>
+          <option>Mid</option>
           <option>Senior</option>
-          <option>Lead or Manager</option>
-          <option>Director or above</option>
+          <option>Lead</option>
+          <option>Director+</option>
         </select>
       </div>
       <div class="vi-field">

--- a/voice-interview.html
+++ b/voice-interview.html
@@ -31,6 +31,21 @@
     .vi-field input:focus-visible, .vi-field select:focus-visible, .vi-field textarea:focus-visible { outline: 2px solid var(--color-accent-blue); outline-offset: 1px; }
     .vi-field textarea { min-height: 110px; resize: vertical; }
     .vi-hint { font-size: 0.85rem; color: var(--color-text-muted); margin-top: 0.3rem; }
+    /* "What to expect" checklist (typed .mi-checklist pattern, retokenized) */
+    .vi-checklist { background: var(--color-bg-light); border-radius: var(--radius-md); padding: 1rem 1.25rem; margin-bottom: 1rem; }
+    .vi-checklist-title { font-weight: var(--font-weight-semibold); color: var(--color-text-main); margin-bottom: 0.75rem; font-size: 0.9rem; }
+    .vi-checklist-item { display: flex; align-items: flex-start; gap: 0.5rem; font-size: 0.9rem; color: var(--color-text-secondary); margin-bottom: 0.5rem; line-height: 1.4; }
+    .vi-checklist-item:last-child { margin-bottom: 0; }
+    .vi-checklist-item svg { flex-shrink: 0; margin-top: 2px; color: var(--color-cta-green); }
+    /* Live answer cue (typed .mi-sao-strip visual, retokenized). Static on
+       purpose: it must not compete with listening. */
+    .vi-sao-cue { border: 1px dashed var(--color-divider); border-radius: var(--radius-md); padding: 0.8rem 1rem; margin: 0 0 1.2rem; }
+    .vi-sao-cue-label { color: var(--color-text-muted); font-size: 12px; font-weight: var(--font-weight-semibold); letter-spacing: 0.04em; margin-bottom: 0.6rem; }
+    .vi-sao-strip { display: flex; justify-content: space-between; gap: 0.6rem; font-size: 0.85rem; }
+    .vi-sao-item { flex: 1; text-align: center; color: var(--color-text-secondary); background: var(--color-bg-light); border: 1px solid var(--color-divider); border-radius: var(--radius-md); padding: 0.5rem 0.6rem; }
+    .vi-sao-label { font-weight: var(--font-weight-semibold); color: var(--color-accent-blue); }
+    .vi-sao-item--outcome { background: #E8F5E9; border-color: var(--color-cta-green); color: var(--color-cta-green); }
+    .vi-sao-item--outcome .vi-sao-label { color: var(--color-cta-green); }
     .vi-banner { border-radius: 8px; padding: 0.7rem 1rem; font-size: 0.95rem; margin-bottom: 1.1rem; }
     .vi-banner-ok { background: #E8F5E9; color: var(--color-cta-green); }
     .vi-banner-paywall { background: #FFF7E6; color: #92400E; }
@@ -236,8 +251,23 @@
       <div class="vi-field">
         <label for="vi-jd">Job description (optional)</label>
         <textarea id="vi-jd" maxlength="2000" placeholder="Paste the job description so the interviewer can target it."></textarea>
-        <p class="vi-hint">Find a quiet room and use headphones if you can. The interviewer hears everything your microphone hears.</p>
       </div>
+      <div class="vi-checklist">
+        <div class="vi-checklist-title">What to expect</div>
+        <div class="vi-checklist-item">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20,6 9,17 4,12"/></svg>
+          <span>Up to 20 minutes, live voice, natural follow-up questions.</span>
+        </div>
+        <div class="vi-checklist-item">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20,6 9,17 4,12"/></svg>
+          <span>Use Situation → Action → Outcome — spend most of your answer on the Outcome (≈85%).</span>
+        </div>
+        <div class="vi-checklist-item">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="20,6 9,17 4,12"/></svg>
+          <span>We'll score you out of 100 and save this session to your history.</span>
+        </div>
+      </div>
+      <p class="vi-hint">Find a quiet room and use headphones if you can. The interviewer hears everything your microphone hears.</p>
       <button id="vi-start-btn" class="vi-btn-primary" disabled>Start the interview</button>
     </div>
 
@@ -247,6 +277,14 @@
       <div class="vi-timer" id="vi-timer">20:00</div>
       <p><span id="vi-speaking" class="vi-speaking"></span>Interviewer</p>
       <p id="vi-caption" class="vi-caption">The interviewer will start in a moment. Speak naturally and take your time.</p>
+      <div class="vi-sao-cue">
+        <div class="vi-sao-cue-label">ANSWER CUE — S + A = O</div>
+        <div class="vi-sao-strip">
+          <div class="vi-sao-item"><span class="vi-sao-label">Situation</span><br>≈ 5% — one line</div>
+          <div class="vi-sao-item"><span class="vi-sao-label">Action</span><br>≈ 10% — what you did</div>
+          <div class="vi-sao-item vi-sao-item--outcome"><span class="vi-sao-label">Outcome</span><br>≈ 85% — results, numbers</div>
+        </div>
+      </div>
       <div class="vi-live-actions">
         <button id="vi-mute-btn" class="vi-btn-secondary">Mute</button>
         <button id="vi-reconnect-btn" class="vi-btn-secondary" style="display:none">Reconnect</button>

--- a/voice-interview.html
+++ b/voice-interview.html
@@ -78,6 +78,96 @@
     .vi-sc-unlock { position: absolute; top: 18%; left: 50%; transform: translateX(-50%); width: min(92%, 420px); background: #fff; border: 1px solid var(--color-divider); border-radius: var(--radius-xl); box-shadow: var(--shadow-xl); padding: 1.4rem 1.4rem 1.5rem; text-align: center; }
     .vi-sc-unlock h3 { margin: 0 0 0.5rem; color: var(--color-text-main); }
     .vi-sc-unlock p { color: var(--color-text-secondary); font-size: 0.95rem; margin: 0 0 1rem; }
+
+    /* Two-column layout with the history rail (mirrors mock-interview's
+       .mi-layout grid, retokenized). The page stays single-column at the
+       production width until JS confirms voice.enabled and adds .vi-has-rail,
+       so with the flag off nothing changes visually. */
+    .vi-wrap.vi-has-rail { max-width: 1100px; }
+    .vi-layout { display: grid; grid-template-columns: 1fr; gap: 1.5rem; align-items: start; }
+    .vi-has-rail .vi-layout { grid-template-columns: 1fr 380px; }
+    @media (max-width: 900px) { .vi-has-rail .vi-layout { grid-template-columns: 1fr; } }
+
+    /* History rail (mirrors mock-interview's mi-history-* rail, retokenized) */
+    .vi-history { position: sticky; top: 1rem; }
+    .vi-history-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; }
+    .vi-history-title-wrap { display: flex; align-items: center; gap: 10px; min-width: 0; color: var(--color-text-main); }
+    .vi-history-title-text { font-weight: 800; color: var(--color-text-main); font-size: 1.05rem; line-height: 1.2; }
+    .vi-history-header-actions { display: flex; align-items: center; gap: 10px; flex-shrink: 0; }
+    .vi-history-icon-btn { width: 40px; height: 40px; display: inline-flex; align-items: center; justify-content: center; border: 1px solid var(--color-divider); border-radius: var(--radius-md); background: transparent; color: var(--color-text-secondary); cursor: pointer; transition: background 0.18s ease, border-color 0.18s ease; }
+    .vi-history-icon-btn:hover { background: var(--color-bg-light); }
+    .vi-history-manage-btn { text-decoration: none; color: var(--color-text-secondary); font-weight: 700; border: 1px solid var(--color-divider); border-radius: var(--radius-md); padding: 0.5rem 1rem; background: transparent; transition: background 0.18s ease, border-color 0.18s ease; cursor: pointer; }
+    .vi-history-manage-btn:hover { color: var(--color-text-main); background: var(--color-bg-light); }
+    .vi-history-panel--manage .vi-history-header-actions { display: none; }
+    .vi-history-manage-actions { display: none; flex-shrink: 0; gap: 10px; }
+    .vi-history-panel--manage .vi-history-manage-actions { display: flex; justify-content: flex-end; align-items: center; }
+    .vi-history-danger-btn { background: rgba(220, 38, 38, 0.10); border: 1px solid rgba(220, 38, 38, 0.25); color: var(--color-error); font-weight: 800; border-radius: var(--radius-md); padding: 0.7rem 1rem; cursor: pointer; transition: background 0.18s ease, border-color 0.18s ease, opacity 0.18s ease; }
+    .vi-history-danger-btn:disabled { opacity: 0.55; cursor: not-allowed; }
+    .vi-history-danger-btn:hover:not(:disabled) { background: rgba(220, 38, 38, 0.14); border-color: rgba(220, 38, 38, 0.35); }
+    .vi-history-neutral-btn { background: #fff; border: 1px solid var(--color-divider); color: var(--color-text-main); font-weight: 700; border-radius: var(--radius-md); padding: 0.7rem 1rem; cursor: pointer; transition: background 0.18s ease, border-color 0.18s ease; }
+    .vi-history-neutral-btn:hover { background: var(--color-bg-light); }
+    @media (max-width: 520px) {
+      .vi-history-panel--manage .vi-history-manage-actions { flex-direction: column; align-items: stretch; }
+      #vi-history-delete-selected, #vi-history-cancel-manage { width: 100%; }
+    }
+    .vi-history-subtitle { margin-top: 10px; font-size: 0.875rem; color: var(--color-text-muted); }
+    .vi-history-progress { margin-top: 12px; background: var(--color-bg-light); border: 1px solid var(--color-divider); border-radius: var(--radius-md); padding: 0.7rem 0.9rem; }
+    .vi-history-progress[hidden] { display: none !important; }
+    .vi-history-progress-label { color: var(--color-text-muted); font-size: 12px; font-weight: var(--font-weight-semibold); letter-spacing: 0.04em; }
+    .vi-history-progress-value { margin-top: 2px; font-weight: 800; color: var(--color-text-main); font-size: 1.05rem; font-variant-numeric: tabular-nums; }
+    .vi-history-progress-delta { margin-top: 2px; font-weight: 700; font-size: 0.85rem; color: var(--color-success); }
+    .vi-history-progress-delta--down { color: var(--color-text-muted); }
+    .vi-history-progress--locked { display: flex; align-items: center; gap: 8px; color: var(--color-text-muted); font-weight: var(--font-weight-semibold); font-size: 0.9rem; }
+    .vi-history-progress--locked svg { flex-shrink: 0; }
+    .vi-history-progress--locked a { color: var(--color-accent-blue); font-weight: 700; margin-left: auto; }
+    .vi-history-body { margin-top: 16px; }
+    .vi-history-loading { display: none; }
+    .vi-history-loading.is-visible { display: flex; flex-direction: column; gap: 12px; }
+    .vi-history-skeleton-row { display: flex; align-items: center; gap: 12px; padding: 0.875rem 1rem; border-radius: var(--radius-md); border: 1px solid var(--color-divider); background: #fff; min-height: 56px; }
+    .vi-skeleton { background: linear-gradient(90deg, var(--color-bg-light) 25%, var(--color-divider) 50%, var(--color-bg-light) 75%); background-size: 200% 100%; animation: vi-shimmer 1.5s infinite; border-radius: var(--radius-lg); }
+    @keyframes vi-shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+    .vi-history-skeleton-pill { height: 16px; border-radius: var(--radius-md); width: 60%; }
+    .vi-history-skeleton-pill.sm { width: 40%; }
+    .vi-history-skeleton-score { width: 44px; height: 24px; border-radius: var(--radius-full); }
+    .vi-history-error { padding: 10px 12px; border: 1px solid rgba(220, 38, 38, 0.22); background: rgba(220, 38, 38, 0.06); border-radius: var(--radius-lg); color: var(--color-text-main); font-size: 0.95rem; margin-bottom: 12px; }
+    .vi-history-link-btn { color: var(--color-accent-blue); text-decoration: underline; background: transparent; border: none; padding: 0; cursor: pointer; font-size: inherit; }
+    .vi-history-list { display: flex; flex-direction: column; gap: 12px; }
+    .vi-history-item { position: relative; display: flex; align-items: center; gap: 12px; padding: 0.875rem 1rem; background: #fff; border-radius: var(--radius-md); border: 1px solid var(--color-divider); transition: background 0.18s ease, border-color 0.18s ease, outline 0.18s ease; cursor: pointer; min-height: 56px; }
+    .vi-history-item:hover { background: var(--color-bg-light); }
+    .vi-history-item.is-selected { outline: 2px solid var(--color-accent-blue); outline-offset: 0; border-color: var(--color-divider); background: #fff; }
+    .vi-history-item--live { border-style: dashed; border-color: var(--color-warning); cursor: default; }
+    .vi-history-item--live:hover { background: #fff; }
+    .vi-history-checkbox-wrap { display: none; align-items: center; justify-content: center; flex-shrink: 0; }
+    .vi-history-checkbox { width: 18px; height: 18px; accent-color: var(--color-accent-blue); cursor: pointer; }
+    .vi-history-panel--manage .vi-history-checkbox-wrap { display: inline-flex; }
+    .vi-history-text { flex: 1; min-width: 0; }
+    .vi-history-line1 { font-weight: var(--font-weight-semibold); color: var(--color-text-main); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; font-size: 0.95rem; line-height: 1.25; }
+    .vi-history-line2 { margin-top: 2px; font-size: 0.85rem; color: var(--color-text-muted); white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+    .vi-history-chip { flex-shrink: 0; display: inline-flex; align-items: center; gap: 5px; font-weight: 800; font-size: 0.85rem; line-height: 1; padding: 0.3rem 0.7rem; border-radius: var(--radius-full); }
+    .vi-history-chip svg { flex-shrink: 0; }
+    .vi-history-chip--score { background: #E8F5E9; color: var(--color-cta-green); }
+    .vi-history-chip--scoring { background: rgba(217, 119, 6, 0.10); color: var(--color-warning); }
+    .vi-history-chip--partial { background: var(--color-bg-light); color: var(--color-text-muted); border: 1px solid var(--color-divider); font-weight: 700; }
+    .vi-history-chip--live { background: rgba(217, 119, 6, 0.10); color: var(--color-warning); }
+    .vi-history-empty { text-align: center; padding: 20px 12px; color: var(--color-text-muted); border: 1px dashed var(--color-divider); border-radius: var(--radius-lg); }
+    .vi-history-footer { margin-top: 16px; font-size: 0.875rem; color: var(--color-text-muted); line-height: 1.45; }
+    .vi-history-footer a, .vi-history-footer button { font-size: inherit; }
+    .vi-history-footer-links { display: inline-flex; gap: 6px; align-items: center; margin-left: 4px; }
+    .vi-history-footer-link { color: var(--color-accent-blue); text-decoration: underline; background: transparent; border: none; padding: 0; cursor: pointer; }
+    .vi-history-footer-separator { color: var(--color-text-muted); font-weight: 600; }
+    .vi-history-footer-link--danger { color: var(--color-error); font-weight: 600; }
+    .vi-history-footer-link--danger:hover { text-decoration: underline; }
+    .vi-history-modal-backdrop { position: fixed; inset: 0; background: rgba(17, 24, 39, 0.45); z-index: var(--z-modal-backdrop); }
+    .vi-history-delete-modal { position: fixed; top: 50%; left: 50%; transform: translate(-50%, -50%); width: min(520px, calc(100vw - 32px)); background: #fff; border: 1px solid var(--color-divider); border-radius: var(--radius-xl); box-shadow: var(--shadow-xl); padding: 20px; z-index: var(--z-modal); }
+    .vi-history-delete-modal[hidden] { display: none !important; }
+    .vi-history-delete-modal-content { display: flex; flex-direction: column; }
+    .vi-history-delete-modal-title { font-size: 1.15rem; font-weight: 800; margin: 0 0 8px 0; color: var(--color-text-main); }
+    .vi-history-delete-modal-body { margin: 6px 0; color: var(--color-text-secondary); line-height: 1.5; }
+    .vi-history-delete-modal-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 16px; flex-wrap: wrap; }
+    .vi-history-delete-modal-actions button { min-height: 44px; }
+    @media (max-width: 520px) {
+      .vi-history-delete-modal-actions { flex-direction: column; align-items: stretch; }
+    }
   </style>
 </head>
 <body>
@@ -115,6 +205,9 @@
     <h1>Voice Mock Interview</h1>
     <p class="vi-sub">A realistic spoken interview for your target role. Up to 20 minutes, then a scored report.</p>
 
+    <div class="vi-layout">
+      <!-- Left Column: Main Content Area -->
+      <div>
     <!-- Feature disabled -->
     <div id="vi-disabled-view" class="vi-card" style="display:none">
       <h2>Voice interviews are not available yet</h2>
@@ -166,6 +259,116 @@
     <div id="vi-done-view" class="vi-card" style="display:none">
       <p id="vi-done-status">Interview finished. Preparing your report...</p>
       <div id="vi-scorecard" style="display:none"></div>
+    </div>
+      </div>
+
+      <!-- Right Column: Session History (shown by JS only when voice.enabled) -->
+      <aside class="vi-card vi-history" id="vi-history-panel" style="display:none">
+        <div class="vi-history-header">
+          <div class="vi-history-title-wrap">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <circle cx="12" cy="12" r="10"/>
+              <polyline points="12 6 12 12 16 14"/>
+            </svg>
+            <span class="vi-history-title-text" id="vi-history-header-title">History</span>
+          </div>
+
+          <div class="vi-history-header-actions">
+            <button id="vi-history-refresh" class="vi-history-icon-btn" title="Refresh history" aria-label="Refresh history" type="button">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+                <path d="M23 4v6h-6"/>
+                <path d="M1 20v-6h6"/>
+                <path d="M3.51 9a9 9 0 0114.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0020.49 15"/>
+              </svg>
+            </button>
+            <button id="vi-history-manage" class="vi-history-manage-btn" type="button">Manage</button>
+          </div>
+
+          <div class="vi-history-manage-actions" id="vi-history-manage-actions">
+            <button id="vi-history-delete-selected" class="vi-history-danger-btn" type="button" disabled>Delete selected</button>
+            <button id="vi-history-cancel-manage" class="vi-history-neutral-btn" type="button">Cancel</button>
+          </div>
+        </div>
+
+        <div class="vi-history-subtitle">Last 10 sessions • Auto-saved</div>
+
+        <!-- Progress strip: scored variant (paid, 2+ scored sessions) -->
+        <div class="vi-history-progress" id="vi-history-progress" hidden>
+          <div class="vi-history-progress-label">PROGRESS · LAST 3 SESSIONS</div>
+          <div class="vi-history-progress-value" id="vi-history-progress-value"></div>
+          <div class="vi-history-progress-delta" id="vi-history-progress-delta"></div>
+        </div>
+        <!-- Progress strip: locked variant (free users with history) -->
+        <div class="vi-history-progress vi-history-progress--locked" id="vi-history-progress-locked" hidden>
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+            <rect x="3" y="11" width="18" height="8" rx="2"/>
+            <path d="M7 11V7a5 5 0 0110 0v4"/>
+          </svg>
+          <span>Progress tracking</span>
+          <a href="/pricing" data-cta="voice-history-progress-locked">See plans</a>
+        </div>
+
+        <div class="vi-history-body">
+          <div class="vi-history-loading" id="vi-history-loading">
+            <div class="vi-history-skeleton-row">
+              <div style="flex:1;min-width:0;">
+                <div class="vi-skeleton vi-history-skeleton-pill"></div>
+                <div class="vi-skeleton vi-history-skeleton-pill sm" style="margin-top:8px;"></div>
+              </div>
+              <div class="vi-skeleton vi-history-skeleton-score"></div>
+            </div>
+            <div class="vi-history-skeleton-row">
+              <div style="flex:1;min-width:0;">
+                <div class="vi-skeleton vi-history-skeleton-pill"></div>
+                <div class="vi-skeleton vi-history-skeleton-pill sm" style="margin-top:8px;"></div>
+              </div>
+              <div class="vi-skeleton vi-history-skeleton-score"></div>
+            </div>
+            <div class="vi-history-skeleton-row">
+              <div style="flex:1;min-width:0;">
+                <div class="vi-skeleton vi-history-skeleton-pill"></div>
+                <div class="vi-skeleton vi-history-skeleton-pill sm" style="margin-top:8px;"></div>
+              </div>
+              <div class="vi-skeleton vi-history-skeleton-score"></div>
+            </div>
+          </div>
+
+          <div class="vi-history-error" id="vi-history-error" hidden>
+            <span data-default-message="Couldn't load history.">Couldn't load history. </span>
+            <button id="vi-history-retry" class="vi-history-link-btn" type="button">Retry.</button>
+          </div>
+
+          <div class="vi-history-list" id="vi-history-list"></div>
+
+          <div class="vi-history-empty" id="vi-history-empty" hidden>
+            <div style="font-weight:800;margin-bottom:0.25rem;color:var(--color-text-main);">No history yet</div>
+            <div>Your last 10 voice interview sessions will appear here automatically.</div>
+          </div>
+        </div>
+
+        <div class="vi-history-footer">
+          <span>Data retention: your last 10 voice sessions are kept for 90 days.</span>
+          <div class="vi-history-footer-links">
+            <a class="vi-history-footer-link" href="privacy.html">Learn more</a>
+            <span class="vi-history-footer-separator" aria-hidden="true">·</span>
+            <button id="vi-history-clear" class="vi-history-footer-link vi-history-footer-link--danger" type="button">Clear history</button>
+          </div>
+        </div>
+      </aside>
+
+      <!-- Delete confirmation modal -->
+      <div class="vi-history-modal-backdrop" id="vi-history-modal-backdrop" hidden></div>
+      <div class="vi-history-delete-modal" id="vi-history-delete-modal" role="dialog" aria-labelledby="vi-history-delete-modal-title" aria-modal="true" hidden>
+        <div class="vi-history-delete-modal-content">
+          <h3 class="vi-history-delete-modal-title" id="vi-history-delete-modal-title">Permanently delete history?</h3>
+          <p class="vi-history-delete-modal-body">This will remove the selected items from your account.</p>
+          <p class="vi-history-delete-modal-body">This cannot be undone.</p>
+          <div class="vi-history-delete-modal-actions">
+            <button id="vi-history-delete-cancel" class="vi-history-neutral-btn" type="button">Cancel</button>
+            <button id="vi-history-delete-confirm" class="vi-history-danger-btn" type="button">Delete permanently</button>
+          </div>
+        </div>
+      </div>
     </div>
   </main>
 

--- a/voice-interview.html
+++ b/voice-interview.html
@@ -403,6 +403,6 @@
   <script src="js/universal-logout.js?v=20260208-1" defer></script>
   <script src="js/analytics.js" type="module"></script>
   <script src="js/main.js" type="module"></script>
-  <script src="js/voice-interview.js?v=20260613-1" defer></script>
+  <script src="js/voice-interview.js?v=20260704-1" defer></script>
 </body>
 </html>

--- a/voice-interview.html
+++ b/voice-interview.html
@@ -87,7 +87,22 @@
     .vi-sc-transcript { margin: 1.2rem 0; }
     .vi-sc-transcript summary { font-weight: 600; cursor: pointer; color: var(--color-text-main); }
     .vi-sc-transcript p { font-size: 0.92rem; color: var(--color-text-secondary); }
-    .vi-sc-actions { margin-top: 1.4rem; }
+    .vi-sc-saved { color: var(--color-text-muted); font-size: 12.5px; margin: -0.9rem 0 1.2rem; }
+    .vi-sao-bal-row { display: flex; align-items: center; gap: 0.7rem; margin-bottom: 0.55rem; }
+    .vi-sao-bal-label { flex: 0 0 5.5rem; font-size: 0.9rem; color: var(--color-text-secondary); }
+    .vi-sao-bal-track { position: relative; flex: 1; height: 9px; background: var(--color-divider); border-radius: var(--radius-full); }
+    .vi-sao-bal-fill { position: absolute; left: 0; top: 0; bottom: 0; background: var(--color-cta-green); border-radius: var(--radius-full); }
+    .vi-sao-bal-goal { position: absolute; top: -3px; bottom: -3px; width: 2.5px; background: var(--color-text-main); border-radius: 1px; }
+    .vi-sao-bal-note { flex: 0 0 8.5rem; text-align: right; font-size: 0.85rem; font-weight: var(--font-weight-semibold); font-variant-numeric: tabular-nums; }
+    .vi-sao-bal-note--ok { color: var(--color-success); }
+    .vi-sao-bal-note--over { color: var(--color-warning); }
+    .vi-sao-bal-note--under { color: var(--color-error); }
+    .vi-sc-coach { margin: 0; padding-left: 1.1rem; color: var(--color-text-secondary); }
+    .vi-sc-coach li { margin-bottom: 0.3rem; }
+    .vi-sc-coach li:last-child { margin-bottom: 0; }
+    .vi-sc-actions { margin-top: 1.4rem; display: flex; align-items: center; gap: 0.7rem; flex-wrap: wrap; }
+    .vi-sc-actions-link { margin-left: auto; color: var(--color-accent-blue); font-weight: var(--font-weight-semibold); text-decoration: none; }
+    .vi-sc-actions-link:hover { text-decoration: underline; }
     .vi-sc-locked { position: relative; }
     .vi-sc-blur { filter: blur(7px); pointer-events: none; user-select: none; opacity: 0.7; }
     .vi-sc-unlock { position: absolute; top: 18%; left: 50%; transform: translateX(-50%); width: min(92%, 420px); background: #fff; border: 1px solid var(--color-divider); border-radius: var(--radius-xl); box-shadow: var(--shadow-xl); padding: 1.4rem 1.4rem 1.5rem; text-align: center; }

--- a/workers/retention-cleaner/src/index.js
+++ b/workers/retention-cleaner/src/index.js
@@ -117,6 +117,48 @@ async function runCleanup(env) {
     cutoff
   );
 
+  // 9. Voice sessions — same 90-day rule as mock interviews, with the
+  // free-taste carve-out: a user with no active voice plan (no live
+  // subscription, no usable pack credits) keeps their most recent session
+  // row as metadata so it stays visible in history, but its transcript and
+  // scorecard are stripped (the report is locked once past retention).
+  // Entitled users' aged sessions are deleted exactly like typed sessions.
+  const hasVoiceSessions = await checkColumnExists(db, 'voice_sessions', 'id');
+  if (hasVoiceSessions) {
+    // Mirrors getVoiceEntitlement (app/functions/_lib/voice-entitlements.js):
+    // active subscription = unlimited plan label + live Stripe status + period
+    // not lapsed beyond the 3-day grace; usable pack = credits > 0, not expired.
+    const activeVoicePlan = `(
+        (u.plan IN ('weekly','monthly','trial','essential','pro','premium')
+         AND u.subscription_status IN ('active','trialing','past_due')
+         AND (u.current_period_end IS NULL OR datetime(u.current_period_end) > datetime('now','-3 days')))
+        OR (u.voice_sessions_remaining > 0
+         AND (u.pack_expires_at IS NULL OR datetime(u.pack_expires_at) > datetime('now')))
+      )`;
+    const carveOutIds = `SELECT vs.id FROM voice_sessions vs
+        JOIN users u ON u.id = vs.user_id
+        WHERE vs.started_at < ?
+          AND NOT ${activeVoicePlan}
+          AND vs.id = (
+            SELECT v2.id FROM voice_sessions v2
+            WHERE v2.user_id = vs.user_id
+            ORDER BY v2.started_at DESC, v2.id DESC LIMIT 1
+          )`;
+    results.voice_sessions_stripped = await deleteRows(
+      db,
+      `UPDATE voice_sessions SET transcript_json = NULL, scorecard_json = NULL, updated_at = datetime('now')
+       WHERE id IN (${carveOutIds})
+         AND (transcript_json IS NOT NULL OR scorecard_json IS NOT NULL)`,
+      cutoff
+    );
+    results.voice_sessions = await deleteRows(
+      db,
+      `DELETE FROM voice_sessions WHERE started_at < ? AND id NOT IN (${carveOutIds})`,
+      cutoff,
+      cutoff
+    );
+  }
+
   console.log('[retention-cleaner] cleanup complete', results);
 }
 

--- a/workers/retention-cleaner/src/index.js
+++ b/workers/retention-cleaner/src/index.js
@@ -135,13 +135,16 @@ async function runCleanup(env) {
         OR (u.voice_sessions_remaining > 0
          AND (u.pack_expires_at IS NULL OR datetime(u.pack_expires_at) > datetime('now')))
       )`;
+    // Newest COMPLETED row only: the history list ignores created/active/
+    // abandoned rows, so a newer incomplete session must not steal the
+    // carve-out from the completed session the list actually keeps.
     const carveOutIds = `SELECT vs.id FROM voice_sessions vs
         JOIN users u ON u.id = vs.user_id
         WHERE vs.started_at < ?
           AND NOT ${activeVoicePlan}
           AND vs.id = (
             SELECT v2.id FROM voice_sessions v2
-            WHERE v2.user_id = vs.user_id
+            WHERE v2.user_id = vs.user_id AND v2.status = 'completed'
             ORDER BY v2.started_at DESC, v2.id DESC LIMIT 1
           )`;
     results.voice_sessions_stripped = await deleteRows(


### PR DESCRIPTION
# Voice parity: nav entry, history rail, S + A = O

Executes the pre-approved voice-parity plan (UX review 2026-07-03). UI + one additive API surface + one additive scorecard field; no Stripe/checkout, entitlement-logic, `_headers`, or `voice-cta.js` gating changes.

## Per-commit summary

1. **feat(api): voice session history endpoints** — `GET /api/voice/sessions` now returns the history-rail shape (max 10 newest completed sessions: `sessionId, role, seniority, createdAt, durationSeconds, status ('scoring'|'ready'), overall, fullAccess, reportAvailable`), with `overall` only for full-access rows. Adds owner-only `DELETE /api/voice/session/:id` and `POST /api/voice/sessions/clear` mirroring the typed history's auth/ownership semantics (Firebase token verify + ownership in SQL). `GET /api/voice/session/:id` serves a minimal `expired: true` payload past 90 days. Query/shaping logic lives in `_lib/voice-history.js` with a 12-case standalone test suite (fake D1, same style as `voice-entitlements.test.mjs`).
2. **feat(voice): two-column layout and history rail markup** — typed's `.mi-layout` grid (1fr / 380px, stacks under 900px) mirrored as `vi-` classes; full `vi-history-*` rail (header with typed's clock/refresh SVGs, Manage flow, caption `Last 10 sessions • Auto-saved`, progress strip + locked variant, loading/error/empty states, retention footnote, delete-confirm modal with typed's exact copy). All styles retokenized to `css/tokens.css`.
3. **feat(voice): history wiring, deep links, live row** — rail fetch/render on both the setup and `?session=` paths; row click deep-links to the report (`voice_history_open`); manage/delete/clear with the shared confirm modal (per-id `DELETE` for selections, `POST clear` for Clear history; `voice_history_delete` / `voice_history_clear`); progress strip from the last 3 scored sessions (`71 → 74 → 78`, `▲ +7 overall`; downward deltas muted, not error-red) with the locked variant for free users; dashed **Live** row on start → **Scoring…** on end → score chip when the scorecard lands; expired reports render the locked view: *"This report has expired."*
4. **feat(voice): S + A = O touchpoints** — setup "What to expect" checklist (typed's green-check pattern) between the JD field and mic tip; static dashed answer-cue card in the live view (`ANSWER CUE — S + A = O`, Outcome cell highlighted); post-interview status now reads *"We're reviewing your conversation using our S + A = O formula and interview rubric. This usually takes a few seconds."* (failure/slow-path strings unchanged).
5. **feat(voice): scorecard S + A = O structure, balance block, saved line, actions parity** — see schema note below; report gains the saved-to-history line, the `S + A = O structure` dimension label (key `structure` unchanged), the balance block (green fill, dark goal ticks at 5/10/85, colored notes: over-goal warning, Outcome under-goal error), the "Next time, focus on" coaching list, and the actions row: primary **Run another interview**, secondary **Practice typed questions**, right-aligned **Back to Dashboard**.
6. **feat(nav): Voice Mock Interview in Interview Prep dropdown** — when `voice.enabled`: `Interview Questions / Typed Mock Interview (renamed) / Voice Mock Interview` with a plan-badge-family chip (`Pro · Unlimited` / `{n} left` / `1 free` / none when the free taste is used). Voice state rides the shared PlanCache fetch (plan-cache.js now retains the `voice` block instead of dropping it) — no second `/api/plan/me` call. Visitor nav untouched.
7. **feat(dashboard): entitlement chip on the voice tile** — `Unlimited` / `{n} sessions left` / `1 free session` / none, rendered by the tile's existing visibility gate from the same plan payload.
8. **fix(voice): unify seniority vocabulary with typed** — `Any level` (default) / `Intern` / `Junior` / `Mid` / `Senior` / `Lead` / `Director+`; `/api/voice/session` passes the string through unchanged (no enum validation exists).
9. **feat(typed): cross-link to voice — SKIPPED** — `js/voice-cta.js` `PAGE_CONFIG` already injects a voice CTA on `mock-interview.html` for entitled users once results render (*"You practiced in writing. Now say it out loud."* → voice-interview.html), so per the handoff this commit was skipped.

## Retention carve-out (decided)

Typed retention is enforced by the `workers/retention-cleaner` daily cron; the voice path mirrors that mechanism and adds the voice-only carve-out:

- **Free user (no active voice plan — `unlimited` false and no usable pack credits):** their most recent session row **survives** the 90-day lapse. The list endpoint always returns it with `reportAvailable: false` once aged; the cleaner strips `transcript_json`/`scorecard_json` but keeps the row metadata (role, seniority, date, duration). Opening it shows the expired/locked paywall view.
- **Paid/entitled users:** sessions follow the typed rule exactly — excluded from the list past 90 days and deleted by the cleaner.

## Additive scorecard schema

`saoBalance: { situation, action, outcome }` (integer percent of candidate speaking time, sums ≈100) and `saoCoaching: [string, string]` (imperative, ≤120 chars) are **added** to the scorecard JSON blob in `voice_sessions.scorecard_json` — nothing renamed, **no migration** (scorecards are JSON blobs). The scoring prompt now computes the balance from the transcript and scores the `structure` dimension by the S + A = O formula (goals 5/10/85). **Backward compatibility:** every new render path null-checks — old sessions without `saoBalance` hide the entire balance/coaching block and render exactly as before.

## Flag-off safety

With `VOICE_INTERVIEW_ENABLED` off (`/api/plan/me` → `voice.enabled` false or absent) every change is invisible, verified against a local serve with stubbed plan state:

- Nav: Interview Prep dropdown is byte-identical to today (`Interview Questions / Mock Interviews`, no rename, no voice item); visitor nav untouched.
- Dashboard: voice tile stays `display:none`, no chip.
- Voice page: single-column 760px layout exactly as production (the grid activates only via a `vi-has-rail` class that JS adds only when `voice.enabled`); rail markup stays hidden; no `/api/voice/sessions` request is made.
- Typed page: `mock-interview.html` is not touched by this PR at all.

## Verification

- `node --check` on all 9 changed JS files: pass.
- Tests: `voice-history.test.mjs` (new, 12) + `voice-entitlements.test.mjs` (20) + `stripe-webhook-pack.test.mjs` (2) — all pass.
- Hex sweeps: `00E676|00897B|00695C|E0F2F1|C62828` → 0 hits across the diff; new hex literals limited to `#E8F5E9`, `#388E3C`, `#fff`.
- Screenshot set captured against a local serve with stubbed fetch (all states verified visually and via DOM assertions): setup with rail + expect block; live with answer cue; report with balance block + goal ticks (plus an old payload without `saoBalance` proving graceful hiding, and the free partial view); history states (empty, populated with score/Scoring…/Partial/Live chips, manage mode + confirm modal, error + retry, locked progress variant, expired deep-link); nav dropdown per entitlement state (logged-out, flag-off, unlimited, pack, 1-free, used); dashboard chip per state with no layout shift when absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LY4Rh54bnSyVvS3NkiiNnk

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authenticated delete/clear APIs, retention SQL, and entitlement-gated score exposure; large client surface but guarded by `voice.enabled` and covered by new `voice-history` tests.
> 
> **Overview**
> Adds **voice session history** end-to-end: shared logic in `voice-history.js` powers `GET /api/voice/sessions` (max 10 completed, entitlement-aware scores, 90-day list rules + free-taste carve-out), **owner-only** `DELETE /api/voice/session/:id` and `POST /api/voice/sessions/clear` (skips in-flight `created`/`active` rows), and **expired** minimal payloads on session GET past retention. The **retention-cleaner** now strips or deletes aged `voice_sessions` using the same carve-out for users without an active voice plan.
> 
> The **voice interview page** gains a typed-style **history rail** (live/scoring row, manage/delete/clear, progress strip, deep links) plus **S + A = O** UX (setup checklist, live cue, richer report with `saoBalance` / coaching). **Scorecard generation** requires new `saoBalance` and `saoCoaching` fields and scores **structure** by the formula.
> 
> **Navigation** and **dashboard** show voice when `voice.enabled`, using the **`voice` block** now cached in `PlanCache` (Interview Prep rename + badges; dashboard entitlement chip). Seniority options align with typed mock interview.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e7689477e6907f5ec41ce5eaaaa9a8b058de37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->