### PR TITLE
Add voice mock interview feature with OpenAI Realtime integration

### DIFF
--- a/app/functions/api/cover-letter/generate.js
+++ b/app/functions/api/cover-letter/generate.js
@@ -8,6 +8,7 @@
 
 import { getBearer, verifyFirebaseIdToken } from '../../_lib/firebase-auth.js';
 import { callOpenAI } from '../../_lib/openai-client.js';
+import { isSignedInPlan } from '../../_lib/plan-access.js';
 
 const DB_BINDING_NAMES = ['JOBHACKAI_DB', 'INTERVIEW_QUESTIONS_DB', 'IQ_D1', 'DB'];
 
@@ -163,7 +164,7 @@ export async function onRequest(context) {
   }
 
   const plan = await getUserPlan(env, uid);
-  if (!['free', 'trial', 'essential', 'pro', 'premium', 'weekly', 'monthly', 'pack'].includes(plan)) { // repositioning: free with signup
+  if (!isSignedInPlan(plan)) { // repositioning: free with signup (central gate, plan-access.js)
     return json(origin, { error: 'not_authorized' }, 403);
   }
 

--- a/app/functions/api/stripe-webhook.js
+++ b/app/functions/api/stripe-webhook.js
@@ -222,10 +222,14 @@ export async function onRequest(context) {
         (priceId === env.STRIPE_PRICE_PACK || originalPlan === 'pack');
       if (isOneTimePayment) {
         if (!isPackPurchase) {
-          // Unrecognized one-time product: we cannot know what to grant. Do not
-          // mis-map it to a subscription plan; log loudly for manual review.
-          console.error(`❌ [WEBHOOK] Unrecognized one-time payment (price=${priceId}, plan=${originalPlan}, session=${sessionId}); not granting any plan`);
-          return new Response('[ok]', { status: 200, headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': origin, 'Vary': 'Origin' } });
+          // Unrecognized one-time product: we cannot know what to grant, and no
+          // follow-up event will heal a one-time charge. Do not 200 this away
+          // (Stripe would never retry and a misconfigured pack price would be
+          // charged without credits); release the marker and 5xx so Stripe
+          // retries and the failure surfaces for manual review.
+          console.error(`❌ [WEBHOOK] Unrecognized one-time payment (price=${priceId}, plan=${originalPlan}, session=${sessionId}); returning 500 for Stripe retry`);
+          await releaseEventForRetry();
+          return new Response('unrecognized one-time payment', { status: 500, headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': origin, 'Vary': 'Origin' } });
         }
         if (!uid) {
           // No follow-up event will ever heal a one-time pack, so do NOT 200
@@ -236,18 +240,30 @@ export async function onRequest(context) {
           await releaseEventForRetry();
           return new Response('pack uid unresolved', { status: 500, headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': origin, 'Vary': 'Origin' } });
         }
-        const db = getDb(env);
-        const existingUser = db ? await db.prepare('SELECT id FROM users WHERE auth_id = ?').bind(uid).first() : null;
-        if (!existingUser) {
-          const d1Tombstone = await isDeletedUser(env, uid);
-          const kvTombstone = await env.JOBHACKAI_KV?.get(`deleted:${uid}`);
-          if (d1Tombstone || kvTombstone) {
-            console.log(`⏭️ [WEBHOOK] Skipping pack grant: user ${uid} was deleted (tombstone found)`);
-            return new Response('[ok]', { status: 200, headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': origin, 'Vary': 'Origin' } });
+        // Everything from user resolution through the grant must not fall
+        // through to the outer catch: it logs and returns 200 with the evt
+        // idempotency marker still set, so a throw here (e.g. D1 down while
+        // creating a first-time buyer's user row) would permanently eat the
+        // paid pack. Release the marker and 5xx so Stripe retries instead.
+        let granted, duplicate;
+        try {
+          const db = getDb(env);
+          const existingUser = db ? await db.prepare('SELECT id FROM users WHERE auth_id = ?').bind(uid).first() : null;
+          if (!existingUser) {
+            const d1Tombstone = await isDeletedUser(env, uid);
+            const kvTombstone = await env.JOBHACKAI_KV?.get(`deleted:${uid}`);
+            if (d1Tombstone || kvTombstone) {
+              console.log(`⏭️ [WEBHOOK] Skipping pack grant: user ${uid} was deleted (tombstone found)`);
+              return new Response('[ok]', { status: 200, headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': origin, 'Vary': 'Origin' } });
+            }
+            await getOrCreateUserByAuthId(env, uid, customerEmail, { updateActivity: false });
           }
-          await getOrCreateUserByAuthId(env, uid, customerEmail, { updateActivity: false });
+          ({ granted, duplicate } = await grantPackCredits(env, uid, event.id));
+        } catch (packErr) {
+          console.error(`❌ [WEBHOOK] Pack handling failed before grant completion (uid=${uid}, session=${sessionId}); returning 500 for Stripe retry:`, packErr?.message || packErr);
+          await releaseEventForRetry();
+          return new Response('pack handling failed', { status: 500, headers: { 'Cache-Control': 'no-store', 'Access-Control-Allow-Origin': origin, 'Vary': 'Origin' } });
         }
-        const { granted, duplicate } = await grantPackCredits(env, uid, event.id);
         console.log(`✅ [WEBHOOK] Pack grant for ${uid}: granted=${granted}, duplicate=${duplicate}`);
         if (!granted && !duplicate) {
           // Grant failed unexpectedly (e.g. the user row could not be resolved).

--- a/app/functions/api/upgrade-plan.js
+++ b/app/functions/api/upgrade-plan.js
@@ -37,7 +37,11 @@ export async function onRequest(context) {
     const requestedReturnUrl = body?.returnUrl || request.headers.get('Referer') || '';
 
     const targetPlan = normalizePlan(targetPlanRaw);
-    if (!targetPlan || !['essential', 'pro', 'premium'].includes(targetPlan)) {
+    // Voice subscription plans (weekly/monthly) are valid upgrade targets so
+    // existing subscribers can switch plans from /pricing without hitting
+    // INVALID_PLAN. The pack stays excluded: it is a one-time payment product
+    // handled by stripe-checkout (mode=payment), not a subscription change.
+    if (!targetPlan || !['essential', 'pro', 'premium', 'weekly', 'monthly'].includes(targetPlan)) {
       return json({ ok: false, code: 'INVALID_PLAN' }, 400, origin, env);
     }
 

--- a/app/functions/api/voice/session.js
+++ b/app/functions/api/voice/session.js
@@ -32,6 +32,13 @@ const RESUME_WINDOW_MS = (MAX_SESSION_MINUTES + 10) * 60 * 1000;
 const DEFAULT_VOICE_MODEL = 'gpt-realtime-mini';
 const DEFAULT_VOICE = 'marin';
 
+// Revised per the 6-persona conversational audit (transcript-evidenced
+// findings: verbatim stock acknowledgments, re-asking answered questions,
+// never probing standout answers, conceding challenged premises, no
+// long-answer redirect, no pause recovery, JD leakage, template close).
+// Preserved behaviors: one-sentence open, one question at a time, short
+// turns, vague-answer follow-up trigger, paywall-safe feedback deflection,
+// structured close.
 function interviewerInstructions({ role, seniority, jd }) {
   const roleLine = seniority ? `${seniority} ${role}` : role;
   return [
@@ -39,11 +46,19 @@ function interviewerInstructions({ role, seniority, jd }) {
     jd ? `The job description, for context: ${jd}` : '',
     'Rules:',
     `- Conduct a focused interview of up to ${MAX_SESSION_MINUTES} minutes. Open with a one-sentence welcome and your first question. Do not give a long preamble.`,
-    '- Ask one question at a time. Mix behavioral questions with role-specific ones. Ask natural follow-ups when an answer is vague, lacks a concrete example, or skips the outcome.',
-    '- Stay in character as the interviewer. Do not coach, do not give feedback mid-interview, and do not answer the questions yourself.',
-    '- If the candidate asks for help or feedback, say feedback comes in the written report afterward, then continue.',
+    '- Ask one question at a time, pacing for roughly 6 to 9 questions total. Mix behavioral questions with role-specific ones. You own the clock and the question arc.',
     '- Keep your own speaking turns short. The candidate should do most of the talking.',
-    '- Pace for roughly 6 to 9 questions total. When time is nearly up or the question arc is complete, ask if they have anything to add, then close by thanking them and saying their feedback report is being prepared.',
+    '- Listen before you ask. Never ask something the candidate already answered: skip it or go one level deeper into what they said.',
+    '- Follow up when an answer is vague, buzzword-heavy, lacks a concrete example, or skips the outcome: ask for one specific example with a number. Push at most twice on the same answer, then move on.',
+    '- Also follow up on standout material: a big number, an admitted mistake, a controversial decision, or a thread the candidate opened and dropped. Pull one such thread deeper before changing topics.',
+    '- Vary your acknowledgments and keep them neutral, never "great", "excellent", or "that makes sense". Instead, briefly name one specific detail from their answer, then ask your next question.',
+    '- If answers keep running long, politely ask for the headline or the short version first.',
+    '- If the candidate\'s last words trail off mid-sentence or end on a hanging word like "because" or "so", they are still thinking: invite them to finish ("...because?") or say "take your time". If you cut them off, apologize in a few words and hand the turn back.',
+    '- Brief rapport is not feedback: you may steady a nervous candidate with one short, calm sentence, confirm when they ask whether they answered the question, and apologize if you talked over them. Never evaluate their performance.',
+    '- Stay in character as the interviewer. Do not coach, do not give feedback mid-interview, and do not answer the questions yourself. If the candidate asks how they are doing or for help, say feedback comes in the written report afterward, then continue.',
+    '- If the candidate challenges or refuses a question, say in one sentence what it is meant to reveal and ask them to take a shot at it, or adapt once to a more realistic variant, using theirs if they offer one. Do not drop the question, and never describe what a good answer would contain.',
+    `- Use the job description as background, not a script: mention only details relevant to a ${roleLine} candidate, and keep hypotheticals realistic for the level they have shown.`,
+    '- When time is nearly up, if a valuable unexplored thread remains and time allows, ask about it. Then ask if they have anything to add. Close by thanking them, referencing one specific thing they said without judging it, confirming any request they made for the report, and saying their feedback report is being prepared.',
     '- Speak only in English unless the candidate clearly prefers another language.'
   ].filter(Boolean).join('\n');
 }


### PR DESCRIPTION
## Summary

This PR implements a complete voice mock interview feature for JobHackAI, enabling users to practice interviews out loud with an AI interviewer powered by OpenAI's Realtime API. The feature includes entitlement management (free tier, interview packs, and subscription-based access), session persistence, scoring, and marketing integration.

## Key Changes

### Core Voice Interview Feature
- **Voice interview client** (`js/voice-interview.js`): Full WebRTC implementation connecting directly to OpenAI Realtime API using server-minted ephemeral tokens. Handles session lifecycle, transcript collection, timer, and UI state management.
- **Voice interview UI** (`voice-interview.html`): Authenticated page with setup, live interview, and completion views. Includes entitlement banner, session history rail, and scorecard display.
- **Session API** (`app/functions/api/voice/session.js`): Creates/resumes voice sessions with atomic entitlement consumption. Mints OpenAI ephemeral client secrets; audio streams directly between browser and OpenAI (no Workers intermediary).
- **Session completion** (`app/functions/api/voice/session/[id]/complete.js`): Persists transcript, duration, token usage, and computes per-session model costs.
- **Session retrieval** (`app/functions/api/voice/session/[id].js`): Returns session with scorecard, gated by entitlement level (full report for paid users, partial for free-taste users).
- **Session history** (`app/functions/api/voice/sessions.js`, `app/functions/api/voice/sessions/clear.js`): Lists and manages completed sessions with ownership enforcement.

### Entitlements & Billing
- **Voice entitlements module** (`app/functions/_lib/voice-entitlements.js`): Server-side gate for session consumption with three-tier precedence: active subscriptions (unlimited, fair-use capped), interview packs (5 credits, 90-day expiry), and free taste (1 lifetime session). Atomic consumption prevents double-charging on reconnects.
- **Voice history module** (`app/functions/_lib/voice-history.js`): Query/shaping logic for history rail with retention rules (90 days, with carve-out for free users' aged sessions).
- **Voice scorecard module** (`app/functions/_lib/voice-scorecard.js`): Generates structured scorecards via chat completions API from session transcripts.
- **Plan access constants** (`app/functions/_lib/plan-access.js`): Shared plan definitions for repositioned business model.
- **Database migration** (`app/db/migrations/020_add_voice_entitlements.sql`): Adds voice entitlement fields to users table and creates voice_sessions table for lifecycle/cost tracking.

### Stripe Integration
- **Stripe webhook updates** (`app/functions/api/stripe-webhook.js`): Handles pack purchases (one-time payment, 5 credits, 90-day expiry) and subscription plan mapping with idempotency safeguards.
- **Stripe checkout** (`app/functions/api/stripe-checkout.js`): Supports Interview Pack as a one-time payment product alongside subscriptions.
- **Billing utilities** (`app/functions/_lib/billing-utils.js`): Maps new pack plan to pricing.

### Marketing & SEO
- **Pricing page** (`pricing.html`, `app/functions/pricing.js`): New unified pricing page with voice interview offerings (free tier, weekly pass $17, monthly $34, 5-session pack $39).
- **Role-based interview questions** (`marketing/scripts/build-role-pages.mjs`): Programmatic generator for role-specific question pages (12 roles: PM, SDE, UX Designer, Data Analyst, etc.). Generates static HTML for SEO and updates sitemap.
- **Interview questions hub** (`marketing/interview-questions/index.html`): Central listing of all role-specific question pages.
- **Structured data**: Added SoftwareApplication schema with offers to marketing homepage and pricing page for rich snippets.
- **Robots.txt updates**: Added voice interview and role pages to crawl directives.

### Client-Side Integration
- **Voice

https://claude.ai/code/session_01F4Y7LiUGpJLReN7sLBPL3t

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Webhook changes affect paid pack fulfillment and Stripe retry behavior; voice prompt changes alter live interview UX but not entitlement or payment paths.
> 
> **Overview**
> This diff tightens **billing reliability** and **plan routing**, and revises **voice interviewer behavior** (not the full voice feature scaffold).
> 
> **Stripe webhook (`checkout.session.completed`, one-time / pack):** Unrecognized `mode=payment` charges now return **500** after `releaseEventForRetry()` instead of **200**, so Stripe retries and misconfigured prices do not silently grant nothing while keeping the event deduped. Pack user creation + `grantPackCredits` run inside a **try/catch** that also releases the idempotency marker and returns **500** on failure—avoiding the outer handler’s **200** path that would permanently mark the event processed when D1 or grant logic throws.
> 
> **Plan access:** Cover letter generation swaps a hard-coded plan allowlist for **`isSignedInPlan`** from `plan-access.js`. **`/api/upgrade-plan`** now accepts **`weekly`** and **`monthly`** as subscription upgrade/switch targets (pack still excluded).
> 
> **Voice session:** `interviewerInstructions` in `session.js` is expanded from a short rule set to audit-driven guidance: listen-before-ask, capped vague follow-ups, probing standout answers, neutral acknowledgments, long-answer redirects, pause/trailing-off recovery, limited rapport without mid-interview feedback, handling challenged questions, tighter JD usage, and a more specific close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6608fef377069784bdfb82e7050b1f07607a607b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->