### PR TITLE
feat(voice): personalization — session continuity, JD-aware scoring, role typeahead

### DIFF
--- a/app/functions/_lib/voice-history.js
+++ b/app/functions/_lib/voice-history.js
@@ -108,6 +108,10 @@ export async function listVoiceSessions(env, userRowId, ent, nowMs = Date.now())
       // A locked (expired) row must not leak its score through the API even
       // while the cleaner has yet to strip the stored scorecard.
       overall: !expired && fullAccess && scorecard ? (scorecard.overall ?? null) : null,
+      // Continuity for the setup view ("Last time we said: ..."); same
+      // gating as overall, and the fixed too-short line is not a real focus.
+      topImprovement: !expired && fullAccess && scorecard && !scorecard.tooShort
+        ? (scorecard.topImprovement ?? null) : null,
       fullAccess,
       reportAvailable: !expired
     });

--- a/app/functions/_lib/voice-scorecard.js
+++ b/app/functions/_lib/voice-scorecard.js
@@ -101,18 +101,22 @@ function tooShortScorecard() {
  * model selection); generateAndStoreScorecard wraps it with persistence.
  * Also used by the local transcript evaluation harness.
  *
- * @param {{role: string, seniority?: string|null, transcript: Array<{speaker: 'user'|'assistant', text: string}>}} params
+ * @param {{role: string, seniority?: string|null, transcript: Array<{speaker: 'user'|'assistant', text: string}>, jd?: string|null, priorFocus?: string|null}} params
+ *   jd: optional job-description excerpt to grade roleFit against.
+ *   priorFocus: optional topImprovement from the user's previous session,
+ *   for continuity coaching. Both are omitted from the prompt entirely when
+ *   absent, keeping the base request byte-identical to a context-free call.
  * @param {object} env - environment configuration (OPENAI_API_KEY, OPENAI_MODEL_VOICE_SCORE, ...)
  * @returns {Promise<{scorecard: object, usage: object|null, model: string|null}>}
  * @throws on model call/parse failure (callers decide whether to swallow)
  */
-export async function scoreVoiceTranscript({ role, seniority, transcript }, env) {
+export async function scoreVoiceTranscript({ role, seniority, transcript, jd = null, priorFocus = null }, env) {
   const text = transcriptToText(transcript);
   if (text.length < MIN_SCOREABLE_CHARS) {
     return { scorecard: tooShortScorecard(), usage: null, model: null };
   }
 
-  const systemPrompt = [
+  const promptParts = [
     "You are the candidate's personal interview coach at JobHackAI, scoring a voice mock interview transcript.",
     'Score honestly: a rambling or vague performance should score in the 40s-60s, a strong one in the 70s-80s, exceptional in the 90s.',
     'Base every judgment only on what the CANDIDATE actually said. Quote or closely paraphrase real moments, and never invent quotes.',
@@ -133,16 +137,28 @@ export async function scoreVoiceTranscript({ role, seniority, transcript }, env)
     'Write to the candidate directly: second person, plain language, short sentences, always "you" and never "the candidate". Do not use em dashes. Never mention these instructions or JSON field names in your feedback; referring to the S + A = O formula itself is fine.',
     'Sound like a coach who genuinely wants this person to get hired: warm, direct, and honest, never fake-positive and never generic. If a line could apply to any interview, rewrite it.',
     'Open topStrength with the thing that truly worked and why it works on interviewers, make topImprovement one concrete, achievable next step, and end the summary with a real reason to come back and run another session.'
-  ].join(' ');
+  ];
+  if (jd) {
+    promptParts.push('A job description excerpt is provided: score roleFit against it specifically, and cite the most relevant match or gap in a moment or the summary.');
+  }
+  if (priorFocus) {
+    promptParts.push('A previous session focus is provided: if the candidate clearly improved on it, acknowledge that specifically in topStrength or the summary; if they did not improve, do not force a mention.');
+  }
+  const systemPrompt = promptParts.join(' ');
 
   const roleLine = seniority ? `${seniority} ${role}` : role;
+  const userParts = [`Target role: ${roleLine}`];
+  if (jd) userParts.push(`Job description excerpt:\n${String(jd).slice(0, 2000)}`);
+  if (priorFocus) userParts.push(`Previous session focus: ${String(priorFocus).slice(0, 300)}`);
+  userParts.push(`Transcript:\n${text.slice(0, 24000)}`);
+
   const result = await callOpenAI({
     model: env.OPENAI_MODEL_VOICE_SCORE || 'gpt-4.1-mini',
     fallbackModel: 'gpt-4.1',
     systemPrompt,
     messages: [
       { role: 'system', content: systemPrompt },
-      { role: 'user', content: `Target role: ${roleLine}\n\nTranscript:\n${text.slice(0, 24000)}` }
+      { role: 'user', content: userParts.join('\n\n') }
     ],
     responseFormat: SCORECARD_SCHEMA,
     maxTokens: 1200,
@@ -172,7 +188,7 @@ export async function generateAndStoreScorecard(env, sessionId) {
 
   try {
     const session = await db.prepare(
-      `SELECT id, role, seniority, transcript_json, scorecard_json FROM voice_sessions WHERE id = ?`
+      `SELECT id, user_id, role, seniority, jd_excerpt, transcript_json, scorecard_json FROM voice_sessions WHERE id = ?`
     ).bind(sessionId).first();
     if (!session) return null;
     if (session.scorecard_json) {
@@ -182,8 +198,32 @@ export async function generateAndStoreScorecard(env, sessionId) {
     let transcript = [];
     try { transcript = JSON.parse(session.transcript_json || '[]'); } catch (_) {}
 
+    // Continuity: the previous session's topImprovement lets the coach say
+    // "last time you worked on X". Strictly optional — any failure here
+    // must never block scoring.
+    let priorFocus = null;
+    try {
+      const prior = await db.prepare(
+        `SELECT scorecard_json FROM voice_sessions
+         WHERE user_id = ? AND id != ? AND scorecard_json IS NOT NULL
+         ORDER BY started_at DESC LIMIT 1`
+      ).bind(session.user_id, sessionId).first();
+      if (prior && prior.scorecard_json) {
+        const priorCard = JSON.parse(prior.scorecard_json);
+        if (priorCard && !priorCard.tooShort && priorCard.topImprovement) {
+          priorFocus = String(priorCard.topImprovement);
+        }
+      }
+    } catch (_) { /* continuity is best-effort */ }
+
     const { scorecard } = await scoreVoiceTranscript(
-      { role: session.role, seniority: session.seniority, transcript },
+      {
+        role: session.role,
+        seniority: session.seniority,
+        transcript,
+        jd: session.jd_excerpt || null,
+        priorFocus
+      },
       env
     );
 

--- a/app/tests/voice-transcripts/unit.test.mjs
+++ b/app/tests/voice-transcripts/unit.test.mjs
@@ -65,6 +65,50 @@ export async function testScoreVoiceTranscriptTooShortPath() {
   assert.ok(MIN_SCOREABLE_CHARS === 200);
 }
 
+export async function testScoreVoiceTranscriptContextBlocks() {
+  const transcript = [
+    { speaker: 'assistant', text: 'Tell me about a time you had to deliver a project under a very tight deadline for the team.' },
+    { speaker: 'user', text: 'Two weeks before our holiday sale, load testing showed our checkout service timing out at peak traffic. I profiled it, fixed an N+1 query, and P95 dropped from 2.1 seconds to 180 milliseconds.' }
+  ];
+  const env = { OPENAI_API_KEY: 'sk-test' };
+  let captured;
+  const origFetch = globalThis.fetch;
+  globalThis.fetch = async (url, opts) => {
+    captured = JSON.parse(opts.body);
+    return {
+      ok: true, status: 200, headers: { get: () => null },
+      json: async () => ({ model: captured.model, choices: [{ message: { content: '{"overall":70}' }, finish_reason: 'stop' }], usage: {} })
+    };
+  };
+  try {
+    // Without context: message is byte-identical to the classic shape
+    await scoreVoiceTranscript({ role: 'Software Engineer', seniority: 'Senior', transcript }, env);
+    const baseMsg = captured.messages[1].content;
+    const baseSys = captured.messages[0].content;
+    assert.ok(baseMsg.startsWith('Target role: Senior Software Engineer\n\nTranscript:\n'));
+    assert.ok(!baseMsg.includes('Job description excerpt'));
+    assert.ok(!baseMsg.includes('Previous session focus'));
+
+    // With context: blocks appear between the role line and the transcript,
+    // and the base system prompt is extended, never altered
+    await scoreVoiceTranscript({
+      role: 'Software Engineer', seniority: 'Senior', transcript,
+      jd: 'Must have Kubernetes and on-call experience.',
+      priorFocus: 'Lead with the results you achieved.'
+    }, env);
+    const ctxMsg = captured.messages[1].content;
+    assert.ok(ctxMsg.includes('Job description excerpt:\nMust have Kubernetes and on-call experience.'));
+    assert.ok(ctxMsg.includes('Previous session focus: Lead with the results you achieved.'));
+    assert.ok(ctxMsg.indexOf('Job description excerpt') < ctxMsg.indexOf('Previous session focus'));
+    assert.ok(ctxMsg.indexOf('Previous session focus') < ctxMsg.indexOf('Transcript:'));
+    assert.ok(captured.messages[0].content.startsWith(baseSys));
+    assert.ok(captured.messages[0].content.includes('A job description excerpt is provided'));
+    assert.ok(captured.messages[0].content.includes('A previous session focus is provided'));
+  } finally {
+    globalThis.fetch = origFetch;
+  }
+}
+
 export function testToVoiceTranscript() {
   assert.deepStrictEqual(
     toVoiceTranscript([
@@ -423,6 +467,7 @@ export function testAggregateResults() {
 const TESTS = [
   testTranscriptToText,
   testScoreVoiceTranscriptTooShortPath,
+  testScoreVoiceTranscriptContextBlocks,
   testToVoiceTranscript,
   testConceptMatching,
   testFeedbackTextExtraction,

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -391,9 +391,22 @@
   // ---------- scorecard rendering ----------
 
   function dimensionRow(label, value) {
+    // Band colors make honest scores legible at a glance: red <40, amber 40-69, green >=70
+    var band = value >= 70 ? '' : value >= 40 ? ' vi-dim-fill--mid' : ' vi-dim-fill--low';
     return '<div class="vi-dim"><span class="vi-dim-label">' + label + '</span>' +
-      '<span class="vi-dim-bar"><span class="vi-dim-fill" style="width:' + Math.max(2, Math.min(100, value)) + '%"></span></span>' +
+      '<span class="vi-dim-bar"><span class="vi-dim-fill' + band + '" style="width:' + Math.max(2, Math.min(100, value)) + '%"></span></span>' +
       '<span class="vi-dim-num">' + value + '</span></div>';
+  }
+
+  // Most recent OTHER scored session, for the "vs your last session" delta.
+  function previousOverall(currentSessionId) {
+    for (var i = 0; i < historyState.items.length; i++) {
+      var item = historyState.items[i];
+      if (item.sessionId === currentSessionId) continue;
+      var v = Number(item.overall);
+      if (item.overall != null && isFinite(v)) return Math.round(v);
+    }
+    return null;
   }
 
   function escapeHtml(s) {
@@ -438,6 +451,14 @@
 
     if (data.fullAccess) {
       html += '<div class="vi-sc-overall"><div class="vi-sc-score">' + escapeHtml(sc.overall) + '</div><div class="vi-sc-overall-label">Overall</div></div>';
+      // Session-over-session delta; downward trends are muted, not error-red —
+      // practice is never punished (same rule as the history progress strip).
+      var prevOverall = previousOverall(data.sessionId);
+      if (prevOverall != null && sc.overall != null && isFinite(Number(sc.overall))) {
+        var scDelta = Math.round(Number(sc.overall)) - prevOverall;
+        html += '<p class="vi-sc-delta' + (scDelta < 0 ? ' vi-sc-delta--down' : '') + '">' +
+          (scDelta >= 0 ? '▲ +' : '▼ −') + Math.abs(scDelta) + ' vs your last session</p>';
+      }
       if (sc.dimensions) {
         html += '<div class="vi-sc-dims">';
         html += dimensionRow('Communication', sc.dimensions.communication);
@@ -573,6 +594,22 @@
     if (loading) loading.classList.remove('is-visible');
     renderHistory();
     renderProgressStrip();
+    renderLastFocus();
+  }
+
+  // "Last time we said: ..." on the setup view for returning users — pairs
+  // with the scorer's continuity coaching so the loop feels closed.
+  function renderLastFocus() {
+    var el = $('vi-last-focus');
+    if (!el) return;
+    var focus = null;
+    for (var i = 0; i < historyState.items.length; i++) {
+      if (historyState.items[i].topImprovement) { focus = historyState.items[i].topImprovement; break; }
+    }
+    if (!focus) { el.hidden = true; return; }
+    el.innerHTML = '<strong>Last time we said:</strong> ';
+    el.appendChild(document.createTextNode('“' + String(focus) + '”'));
+    el.hidden = false;
   }
 
   function formatHistoryWhen(createdAt) {
@@ -950,11 +987,35 @@
 
   // ---------- init ----------
 
+  // Same canonical role typeahead as mock-interview/resume-feedback/cover-letter
+  // pages (js/role-selector.js, backed by /api/roles). Free-typed roles keep
+  // working (showCustomOption), and the submit path is unchanged — the
+  // component writes the chosen string into #vi-role's value.
+  function initRoleSelector() {
+    var input = $('vi-role');
+    if (!input) return;
+    if (window.RoleSelector && !input.dataset.roleSelectorInitialized) {
+      try {
+        new window.RoleSelector(input, {
+          minChars: 2,
+          maxResults: 8,
+          showCustomOption: true
+        });
+        input.dataset.roleSelectorInitialized = 'true';
+      } catch (e) {
+        console.warn('[VOICE] RoleSelector init failed:', e);
+      }
+    } else if (!input.dataset.roleSelectorInitialized) {
+      setTimeout(initRoleSelector, 200); // module script may not have loaded yet
+    }
+  }
+
   document.addEventListener('DOMContentLoaded', async function () {
     var startBtn = $('vi-start-btn');
     var endBtn = $('vi-end-btn');
     var muteBtn = $('vi-mute-btn');
     var reconnectBtn = $('vi-reconnect-btn');
+    initRoleSelector();
     if (startBtn) startBtn.addEventListener('click', startInterview);
     if (endBtn) endBtn.addEventListener('click', function () { endInterview('user_ended'); });
     if (muteBtn) muteBtn.addEventListener('click', toggleMute);

--- a/voice-interview.html
+++ b/voice-interview.html
@@ -76,6 +76,12 @@
     .vi-dim-label { flex: 0 0 8.5rem; font-size: 0.9rem; color: var(--color-text-secondary); }
     .vi-dim-bar { flex: 1; height: 9px; background: var(--color-divider); border-radius: 999px; overflow: hidden; }
     .vi-dim-fill { display: block; height: 100%; background: var(--color-cta-green); border-radius: 999px; }
+    .vi-dim-fill--mid { background: var(--color-warning); }
+    .vi-dim-fill--low { background: var(--color-error); }
+    .vi-sc-delta { font-size: 0.9rem; font-weight: 600; color: var(--color-cta-green); text-align: center; margin: -0.6rem 0 1rem; }
+    .vi-sc-delta--down { color: var(--color-text-secondary); }
+    .vi-last-focus { font-size: 0.92rem; color: var(--color-text-secondary); margin: 0.6rem 0 0.9rem; }
+    .vi-last-focus strong { color: var(--color-text-main); font-weight: 600; }
     .vi-dim-num { flex: 0 0 2.2rem; text-align: right; font-weight: 700; color: var(--color-text-main); font-size: 0.9rem; }
     .vi-sc-block { margin-bottom: 1.2rem; }
     .vi-sc-block h3 { font-size: 1.02rem; color: var(--color-text-main); margin: 0 0 0.4rem; }
@@ -248,9 +254,10 @@
     <!-- Setup -->
     <div id="vi-setup-view" class="vi-card" style="display:none">
       <div id="vi-entitlement" class="vi-banner vi-banner-ok">Checking your access...</div>
+      <p id="vi-last-focus" class="vi-last-focus" hidden></p>
       <div class="vi-field">
         <label for="vi-role">Role you are interviewing for</label>
-        <input id="vi-role" type="text" placeholder="e.g. Product Manager" maxlength="120" autocomplete="off">
+        <input id="vi-role" type="text" placeholder="e.g. Product Manager" maxlength="120" autocomplete="off" role="combobox" aria-autocomplete="list" aria-expanded="false">
       </div>
       <div class="vi-field">
         <label for="vi-seniority">Seniority</label>
@@ -266,7 +273,7 @@
       </div>
       <div class="vi-field">
         <label for="vi-jd">Job description (optional)</label>
-        <textarea id="vi-jd" maxlength="2000" placeholder="Paste the job description so the interviewer can target it."></textarea>
+        <textarea id="vi-jd" maxlength="2000" placeholder="Paste the job description. The interviewer will target it, and your report will grade you against it."></textarea>
       </div>
       <div class="vi-checklist">
         <div class="vi-checklist-title">What to expect</div>
@@ -457,6 +464,7 @@
   <script src="js/universal-logout.js?v=20260208-1" defer></script>
   <script src="js/analytics.js" type="module"></script>
   <script src="js/main.js" type="module"></script>
-  <script src="js/voice-interview.js?v=20260704-1" defer></script>
+  <script src="js/role-selector.js" type="module"></script>
+  <script src="js/voice-interview.js?v=20260720-1" defer></script>
 </body>
 </html>


### PR DESCRIPTION
# Voice personalization — the "this site knows me" layer

Builds on the merged #839 (harness) + #840 (v2.5 scorecard). Zero new form fields, zero schema changes.

## What the candidate feels

1. **"Last time we said: …"** on the setup screen for returning users — their previous report's `topImprovement`, straight from data already stored.
2. **Continuity in the coaching**: the scorer receives the prior session's focus and is instructed to acknowledge clear improvement on it specifically ("last time you worked on leading with outcomes — you did it in two of three answers") — and *never* to force the mention when there's no improvement.
3. **JD-aware role fit**: the job description they already paste (stored as `jd_excerpt`, previously used only by the interviewer) now reaches the scorer — roleFit is graded against the actual posting, with a cited match or gap.
4. **"+N vs your last session"** under the overall score (downward trends muted, never red — same "practice is never punished" rule as the history strip).
5. **Role typeahead**: the voice page's free-text role input becomes the site's canonical `RoleSelector` autocomplete (same component as mock-interview, resume-feedback, cover-letter, LinkedIn, interview-questions). Free-typed roles still work; the submit path is unchanged.
6. **Honesty bands on dimension bars**: red <40 / amber 40–69 / green ≥70, so the newly-honest structure and roleFit numbers are legible at a glance.

## Files

- `app/functions/_lib/voice-scorecard.js` — `scoreVoiceTranscript` gains optional `jd`/`priorFocus`; `generateAndStoreScorecard` fetches `jd_excerpt` + prior scorecard (one indexed query, best-effort — failures never block scoring). **Both context blocks are strictly additive: with no context, the prompt and user message are byte-identical to v2.5** (unit-tested via captured requests).
- `app/functions/_lib/voice-history.js` — list rows expose `topImprovement`, gated identically to `overall` (never on expired/locked rows, never the too-short template line).
- `voice-interview.html` / `js/voice-interview.js` — typeahead init (retry-guarded, copied from the mock-interview pattern), delta line, last-focus line, band colors, JD helper copy.

## Testing

- Unit suite now 15/15 (new: context-block message assembly — presence, ordering, byte-identical absence).
- `voice-history` 14/14 and `voice-entitlements` 20/20 still green.
- **Not executable in this environment (no API key):** a real-model check that continuity coaching reads naturally. Validation plan: owner runs two consecutive dev sessions (second one should reference the first's focus if improved), plus one `npm run test:voice:transcripts:full` (floor 94 — the harness calls `scoreVoiceTranscript` without context, which is byte-identical to v2.5, so no scoring drift is possible from this PR).

## Risk

Scoring-path risk is confined to the two additive parameters; the no-context path is proven byte-identical. The prior-focus DB query is wrapped and best-effort. Frontend changes are additive rendering. Rollback: single revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PRjXnEuZdGXs9DgSxGJae

---
_Generated by [Claude Code](https://claude.ai/code/session_019PRjXnEuZdGXs9DgSxGJae)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scoring behavior can shift when JD or prior-focus context is present; the no-context path is guarded by tests. The prior-session DB lookup is best-effort and wrapped so failures should not block scoring.
> 
> **Overview**
> Adds a **personalization layer** to voice mock interviews so returning users see continuity from prior sessions and richer scoring context, without new form fields or schema changes.
> 
> **Backend:** `scoreVoiceTranscript` accepts optional `jd` and `priorFocus`; when omitted, prompts stay byte-identical to the prior scorer (unit-tested). `generateAndStoreScorecard` loads `jd_excerpt` from the session and best-effort fetches the user’s latest prior `topImprovement` for continuity coaching. Session history list rows now expose `topImprovement` with the same gating as `overall` (not on expired/locked or too-short sessions).
> 
> **Frontend:** Setup shows **“Last time we said: …”** from history; reports show **±N vs your last session** (down deltas muted, not red). Dimension bars use red/amber/green bands; role input uses shared `RoleSelector` typeahead; JD helper copy notes report grading against the posting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fab45b5493d93f72c65ee30d4f8e304cf3e0423c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->