### PR TITLE
fix(voice): interviewer truthfulness, meta-question deflections, reconnect continuity

### DIFF
--- a/app/functions/_lib/__tests__/voice-interviewer.test.mjs
+++ b/app/functions/_lib/__tests__/voice-interviewer.test.mjs
@@ -1,0 +1,102 @@
+// Voice interviewer instructions test suite (standalone, no framework)
+// Run: node app/functions/_lib/__tests__/voice-interviewer.test.mjs
+//
+// Covers the real-session transcript findings:
+// - the model invented a "few days" report timeline (report is immediate)
+// - meta-questions (salary, name, "when will I hear back") got mismatched answers
+// - after a reconnect the interviewer restarted and re-asked covered questions
+
+import assert from 'node:assert/strict';
+import {
+  interviewerInstructions,
+  buildResumeContext,
+  RESUME_CONTEXT_MAX_CHARS
+} from '../voice-interviewer.js';
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log(`  ✓ ${name}`); }
+  catch (err) { failed++; console.error(`  ✗ ${name}\n    ${err.message}`); }
+}
+
+const BASE = { role: 'Software Engineer', seniority: 'Senior', jd: null, maxMinutes: 20 };
+
+test('base instructions include role, minutes, and preserved audit rules', () => {
+  const out = interviewerInstructions(BASE);
+  assert.ok(out.includes('Senior Software Engineer position'));
+  assert.ok(out.includes('up to 20 minutes'));
+  assert.ok(out.includes('one question at a time'));
+  assert.ok(out.includes('Never ask something the candidate already answered'));
+  assert.ok(out.includes('Stay in character as the interviewer'));
+});
+
+test('report timing is stated as immediate and timelines are banned', () => {
+  const out = interviewerInstructions(BASE);
+  assert.ok(out.includes('ready on this page moments after the session ends'));
+  assert.ok(out.includes('Never invent a timeline such as "a few days"'));
+  // The close references the report appearing on this page, not a future delivery
+  assert.ok(out.includes('will appear on this page'));
+});
+
+test('meta-question deflections cover salary, name, and hearing back', () => {
+  const out = interviewerInstructions(BASE);
+  assert.ok(out.includes('salary or compensation is outside a mock interview'));
+  assert.ok(out.includes('your own name or personal life stays out of it'));
+  assert.ok(out.includes('when will I hear back'));
+});
+
+test('jd is included only when provided', () => {
+  const without = interviewerInstructions(BASE);
+  assert.ok(!without.includes('job description, for context'));
+  const withJd = interviewerInstructions({ ...BASE, jd: 'Must have Kubernetes.' });
+  assert.ok(withJd.includes('The job description, for context: Must have Kubernetes.'));
+});
+
+test('resume context appends the continuity block; absence changes nothing', () => {
+  const fresh = interviewerInstructions(BASE);
+  assert.ok(!fresh.includes('RESUMING'));
+
+  const resumed = interviewerInstructions({
+    ...BASE,
+    resumeContext: 'Interviewer: Tell me about a project.\nCandidate: I led the checkout rebuild.'
+  });
+  assert.ok(resumed.includes('RESUMING an interview already in progress'));
+  assert.ok(resumed.includes('do not re-ask anything already covered'));
+  assert.ok(resumed.includes('Candidate: I led the checkout rebuild.'));
+  // Continuity block comes last so it reads as the freshest state
+  assert.ok(resumed.indexOf('RESUMING') > resumed.indexOf('Speak only in English'));
+  // The base rules are unchanged, just extended
+  assert.ok(resumed.startsWith(fresh));
+});
+
+test('buildResumeContext formats speakers and keeps the newest turns', () => {
+  const ctx = buildResumeContext([
+    { speaker: 'assistant', text: 'Tell me about a tight deadline.' },
+    { speaker: 'user', text: 'I shipped the checkout fix before the sale.' }
+  ]);
+  assert.equal(
+    ctx,
+    'Interviewer: Tell me about a tight deadline.\nCandidate: I shipped the checkout fix before the sale.'
+  );
+});
+
+test('buildResumeContext caps total size, dropping the OLDEST turns first', () => {
+  const turns = [];
+  for (let i = 0; i < 50; i++) {
+    turns.push({ speaker: i % 2 ? 'user' : 'assistant', text: `Turn number ${i} ` + 'x'.repeat(120) });
+  }
+  const ctx = buildResumeContext(turns);
+  assert.ok(ctx.length <= RESUME_CONTEXT_MAX_CHARS);
+  assert.ok(ctx.includes('Turn number 49'), 'newest turn kept');
+  assert.ok(!ctx.includes('Turn number 0 '), 'oldest turn dropped');
+});
+
+test('buildResumeContext ignores junk and returns null when empty', () => {
+  assert.equal(buildResumeContext(null), null);
+  assert.equal(buildResumeContext([]), null);
+  assert.equal(buildResumeContext([{ speaker: 'system', text: 'nope' }, { speaker: 'user', text: '   ' }]), null);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/app/functions/_lib/voice-interviewer.js
+++ b/app/functions/_lib/voice-interviewer.js
@@ -1,0 +1,65 @@
+/**
+ * Realtime interviewer instructions for voice mock interviews.
+ *
+ * Extracted from api/voice/session.js so the prompt is unit-testable
+ * (session.js pulls in auth deps that need installed packages). Revised
+ * per the 6-persona conversational audit, plus real-session transcript
+ * findings: the model invented a "few days" report timeline, answered
+ * meta-questions with mismatched deflections, and restarted the interview
+ * from scratch after a reconnect.
+ */
+
+// Most recent conversation kept when building the resume context.
+export const RESUME_CONTEXT_MAX_CHARS = 1500;
+const RESUME_TURN_MAX_CHARS = 220;
+
+/**
+ * Condense a sanitized transcript ({speaker: 'user'|'assistant', text})
+ * into a compact "conversation so far" block for reconnects. Keeps the
+ * most recent turns, newest-complete, within RESUME_CONTEXT_MAX_CHARS.
+ * Returns null when there is nothing usable.
+ */
+export function buildResumeContext(transcript) {
+  if (!Array.isArray(transcript)) return null;
+  const lines = [];
+  let total = 0;
+  for (let i = transcript.length - 1; i >= 0; i--) {
+    const t = transcript[i];
+    if (!t || typeof t.text !== 'string' || !t.text.trim()) continue;
+    if (t.speaker !== 'user' && t.speaker !== 'assistant') continue;
+    const line = `${t.speaker === 'assistant' ? 'Interviewer' : 'Candidate'}: ${t.text.trim().slice(0, RESUME_TURN_MAX_CHARS)}`;
+    if (total + line.length + 1 > RESUME_CONTEXT_MAX_CHARS) break;
+    lines.unshift(line);
+    total += line.length + 1;
+  }
+  return lines.length > 0 ? lines.join('\n') : null;
+}
+
+export function interviewerInstructions({ role, seniority, jd, maxMinutes = 20, resumeContext = null }) {
+  const roleLine = seniority ? `${seniority} ${role}` : role;
+  return [
+    `You are a professional job interviewer running a realistic spoken mock interview for a ${roleLine} position.`,
+    jd ? `The job description, for context: ${jd}` : '',
+    'Rules:',
+    `- Conduct a focused interview of up to ${maxMinutes} minutes. Open with a one-sentence welcome and your first question. Do not give a long preamble.`,
+    '- Ask one question at a time, pacing for roughly 6 to 9 questions total. Mix behavioral questions with role-specific ones. You own the clock and the question arc.',
+    '- Keep your own speaking turns short. The candidate should do most of the talking.',
+    '- Listen before you ask. Never ask something the candidate already answered: skip it or go one level deeper into what they said.',
+    '- Follow up when an answer is vague, buzzword-heavy, lacks a concrete example, or skips the outcome: ask for one specific example with a number. Push at most twice on the same answer, then move on.',
+    '- Also follow up on standout material: a big number, an admitted mistake, a controversial decision, or a thread the candidate opened and dropped. Pull one such thread deeper before changing topics.',
+    '- Vary your acknowledgments and keep them neutral, never "great", "excellent", or "that makes sense". Instead, briefly name one specific detail from their answer, then ask your next question.',
+    '- If answers keep running long, politely ask for the headline or the short version first.',
+    '- If the candidate\'s last words trail off mid-sentence or end on a hanging word like "because" or "so", they are still thinking: invite them to finish ("...because?") or say "take your time". If you cut them off, apologize in a few words and hand the turn back.',
+    '- Brief rapport is not feedback: you may steady a nervous candidate with one short, calm sentence, confirm when they ask whether they answered the question, and apologize if you talked over them. Never evaluate their performance.',
+    '- Stay in character as the interviewer. Do not coach, do not give feedback mid-interview, and do not answer the questions yourself. If the candidate asks how they are doing or for help, say feedback comes in the written report afterward, then continue.',
+    '- The written feedback report is generated automatically and is ready on this page moments after the session ends. If the candidate asks about feedback, results, or when they will hear back, say exactly that. Never invent a timeline such as "a few days".',
+    '- Answer the meta-question they actually asked with one short deflection, then ask your next question: salary or compensation is outside a mock interview; your own name or personal life stays out of it, keep the spotlight on them; process questions like "when will I hear back" mean their report, which is ready right after the session ends.',
+    '- If the candidate challenges or refuses a question, say in one sentence what it is meant to reveal and ask them to take a shot at it, or adapt once to a more realistic variant, using theirs if they offer one. Do not drop the question, and never describe what a good answer would contain.',
+    `- Use the job description as background, not a script: mention only details relevant to a ${roleLine} candidate, and keep hypotheticals realistic for the level they have shown.`,
+    '- When time is nearly up, if a valuable unexplored thread remains and time allows, ask about it. Then ask if they have anything to add. Close by thanking them, referencing one specific thing they said without judging it, confirming any request they made for the report, and saying their feedback report is being prepared and will appear on this page.',
+    '- Speak only in English unless the candidate clearly prefers another language.',
+    resumeContext
+      ? 'IMPORTANT: You are RESUMING an interview already in progress after a connection drop. Do not restart the interview, do not greet the candidate as if meeting them, and do not re-ask anything already covered below. Acknowledge the reconnect in a few words, then continue naturally from where the conversation left off.\nConversation so far (condensed):\n' + resumeContext
+      : ''
+  ].filter(Boolean).join('\n');
+}

--- a/app/functions/api/voice/session.js
+++ b/app/functions/api/voice/session.js
@@ -24,6 +24,7 @@ import {
   voiceFeatureEnabled
 } from '../../_lib/voice-entitlements.js';
 import { errorResponse, successResponse, generateRequestId } from '../../_lib/error-handler.js';
+import { interviewerInstructions, buildResumeContext } from '../../_lib/voice-interviewer.js';
 
 const MAX_SESSION_MINUTES = 20;
 // Reconnects allowed while the session could still plausibly be live.
@@ -31,37 +32,6 @@ const RESUME_WINDOW_MS = (MAX_SESSION_MINUTES + 10) * 60 * 1000;
 
 const DEFAULT_VOICE_MODEL = 'gpt-realtime-mini';
 const DEFAULT_VOICE = 'marin';
-
-// Revised per the 6-persona conversational audit (transcript-evidenced
-// findings: verbatim stock acknowledgments, re-asking answered questions,
-// never probing standout answers, conceding challenged premises, no
-// long-answer redirect, no pause recovery, JD leakage, template close).
-// Preserved behaviors: one-sentence open, one question at a time, short
-// turns, vague-answer follow-up trigger, paywall-safe feedback deflection,
-// structured close.
-function interviewerInstructions({ role, seniority, jd }) {
-  const roleLine = seniority ? `${seniority} ${role}` : role;
-  return [
-    `You are a professional job interviewer running a realistic spoken mock interview for a ${roleLine} position.`,
-    jd ? `The job description, for context: ${jd}` : '',
-    'Rules:',
-    `- Conduct a focused interview of up to ${MAX_SESSION_MINUTES} minutes. Open with a one-sentence welcome and your first question. Do not give a long preamble.`,
-    '- Ask one question at a time, pacing for roughly 6 to 9 questions total. Mix behavioral questions with role-specific ones. You own the clock and the question arc.',
-    '- Keep your own speaking turns short. The candidate should do most of the talking.',
-    '- Listen before you ask. Never ask something the candidate already answered: skip it or go one level deeper into what they said.',
-    '- Follow up when an answer is vague, buzzword-heavy, lacks a concrete example, or skips the outcome: ask for one specific example with a number. Push at most twice on the same answer, then move on.',
-    '- Also follow up on standout material: a big number, an admitted mistake, a controversial decision, or a thread the candidate opened and dropped. Pull one such thread deeper before changing topics.',
-    '- Vary your acknowledgments and keep them neutral, never "great", "excellent", or "that makes sense". Instead, briefly name one specific detail from their answer, then ask your next question.',
-    '- If answers keep running long, politely ask for the headline or the short version first.',
-    '- If the candidate\'s last words trail off mid-sentence or end on a hanging word like "because" or "so", they are still thinking: invite them to finish ("...because?") or say "take your time". If you cut them off, apologize in a few words and hand the turn back.',
-    '- Brief rapport is not feedback: you may steady a nervous candidate with one short, calm sentence, confirm when they ask whether they answered the question, and apologize if you talked over them. Never evaluate their performance.',
-    '- Stay in character as the interviewer. Do not coach, do not give feedback mid-interview, and do not answer the questions yourself. If the candidate asks how they are doing or for help, say feedback comes in the written report afterward, then continue.',
-    '- If the candidate challenges or refuses a question, say in one sentence what it is meant to reveal and ask them to take a shot at it, or adapt once to a more realistic variant, using theirs if they offer one. Do not drop the question, and never describe what a good answer would contain.',
-    `- Use the job description as background, not a script: mention only details relevant to a ${roleLine} candidate, and keep hypotheticals realistic for the level they have shown.`,
-    '- When time is nearly up, if a valuable unexplored thread remains and time allows, ask about it. Then ask if they have anything to add. Close by thanking them, referencing one specific thing they said without judging it, confirming any request they made for the report, and saying their feedback report is being prepared.',
-    '- Speak only in English unless the candidate clearly prefers another language.'
-  ].filter(Boolean).join('\n');
-}
 
 async function mintClientSecret(env, { model, instructions }) {
   const res = await fetch('https://api.openai.com/v1/realtime/client_secrets', {
@@ -192,9 +162,27 @@ export async function onRequest(context) {
         return errorResponse('Session expired', 409, origin, env, requestId);
       }
 
+      // The fresh realtime session has no memory of the dropped one, so the
+      // client sends its local transcript tail; without it the interviewer
+      // restarts from scratch and re-asks covered questions.
+      let resumeContext = null;
+      if (Array.isArray(body.transcript)) {
+        const tail = body.transcript
+          .filter((t) => t && typeof t.text === 'string' && (t.speaker === 'user' || t.speaker === 'assistant'))
+          .slice(-20)
+          .map((t) => ({ speaker: t.speaker, text: t.text.slice(0, 500) }));
+        resumeContext = buildResumeContext(tail);
+      }
+
       const minted = await mintClientSecret(env, {
         model,
-        instructions: interviewerInstructions({ role: session.role, seniority: session.seniority, jd: session.jd_excerpt })
+        instructions: interviewerInstructions({
+          role: session.role,
+          seniority: session.seniority,
+          jd: session.jd_excerpt,
+          maxMinutes: MAX_SESSION_MINUTES,
+          resumeContext
+        })
       });
       if (!minted) return errorResponse('Could not start the voice session. Please try again.', 502, origin, env, requestId);
 
@@ -279,7 +267,7 @@ export async function onRequest(context) {
 
         const minted = await mintClientSecret(env, {
           model,
-          instructions: interviewerInstructions({ role, seniority, jd })
+          instructions: interviewerInstructions({ role, seniority, jd, maxMinutes: MAX_SESSION_MINUTES })
         });
         if (!minted) {
           return errorResponse('Could not start the voice session. Please try again.', 502, origin, env, requestId);

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -307,9 +307,14 @@
     if (btn) { btn.disabled = true; btn.textContent = 'Reconnecting...'; }
     try {
       teardownConnection();
+      // Send the local transcript tail so the fresh realtime session resumes
+      // the conversation instead of restarting the interview from scratch.
       var res = await api('/api/voice/session', {
         method: 'POST',
-        body: JSON.stringify({ resumeSessionId: state.sessionId })
+        body: JSON.stringify({
+          resumeSessionId: state.sessionId,
+          transcript: state.transcript.slice(-20)
+        })
       });
       if (!res.ok) throw new Error((res.data && res.data.error) || 'resume_failed');
       setStatus('Reconnecting...', 'vi-connecting');


### PR DESCRIPTION
# Interviewer conversation fixes — from a real dev session transcript

**Stacked on #841** (base is `claude/voice-personalization-pr3` so the diff shows only these changes). Merge #841 first, then retarget this to `dev0`.

## The three defects (all observed verbatim in the owner's real session)

1. **False product promise** — "you'll receive the feedback report within a few days." The report is ready on the page moments after the session. The prompt previously never stated timing, so the model invented one. Now stated explicitly, with invented timelines banned, and the interview close references the report appearing *on this page*.
2. **Meta-question mismatch** — candidate asked "when will I hear back?", got a salary deflection. The prompt now has one explicit, short deflection each for: salary/compensation, the interviewer's name/personal life, and process questions — answer the question actually asked, then continue.
3. **Reconnect amnesia** — after a connection drop, the resumed realtime session had no conversational memory: "This is a new session, let's reset," followed by the same opening question three times. The client now sends its local transcript tail with the resume request; the server condenses it (newest-first, 1,500-char cap, sanitized like the complete endpoint) and appends a continuity block: *resuming, don't restart, don't re-ask, continue from here*. Absent transcript = exact current behavior.

## Files

- `app/functions/_lib/voice-interviewer.js` (new) — `interviewerInstructions` extracted from session.js so the prompt is unit-testable (session.js pulls auth deps). Every audited rule from PR #838 preserved verbatim; the three fixes are additions/one-line edits. Plus `buildResumeContext` (the condenser).
- `app/functions/api/voice/session.js` — imports the extracted module; resume path accepts optional `transcript` and builds the continuity block; both call sites pass `maxMinutes` explicitly.
- `js/voice-interview.js` — `reconnect()` sends `state.transcript.slice(-20)`.

## Testing

- New standalone suite `voice-interviewer.test.mjs`: **8/8** — report-timing truth, deflections, jd conditionality, continuity block presence/absence/ordering (base rules unchanged, only extended), condenser size caps + newest-first retention + junk rejection.
- All affected suites green: harness unit 15/15, voice-entitlements 20/20, voice-history 14/14.
- **Not executable here:** live realtime behavior. Validation: run a dev session, refresh mid-interview, hit Reconnect — the interviewer should acknowledge the drop and continue (not re-ask the opening question); ask "when will I hear back?" — the answer should reference the immediate on-page report.

## Risk

Prompt-only for the interviewer plus one optional request field. New-session behavior differs only by the three added/edited rule lines; resume without transcript is byte-identical to today. Rollback: single revert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PRjXnEuZdGXs9DgSxGJae

---
_Generated by [Claude Code](https://claude.ai/code/session_019PRjXnEuZdGXs9DgSxGJae)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly prompt text plus an optional resume `transcript` field; new sessions differ only by added rules, and resume without transcript is unchanged. No auth, billing, or entitlement logic changes.
> 
> **Overview**
> Fixes three voice mock-interview issues seen in real sessions: **false report timing**, **wrong meta-question deflections**, and **reconnect amnesia**.
> 
> **Prompt changes** move `interviewerInstructions` into testable `voice-interviewer.js` and add rules that the feedback report is ready on the page right after the session (no invented timelines), explicit short deflections for salary, personal questions, and “when will I hear back,” and an updated close that mentions the report appearing on this page.
> 
> **Reconnect continuity** sends the client’s last ~20 transcript turns on resume; the server condenses them with `buildResumeContext` and appends a “RESUMING” block so the model continues instead of restarting. Resume without a transcript keeps prior behavior.
> 
> Adds an 8-test standalone suite for prompt wording and resume-context condensing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f622c1b0bf3ec5b12774b8e242c131c97e908701. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->