### PR TITLE
fix(voice): store the transcript in conversation order, not arrival order

### DIFF
--- a/.github/workflows/test-ats-scoring.yml
+++ b/.github/workflows/test-ats-scoring.yml
@@ -6,11 +6,19 @@ on:
     paths:
       - 'app/functions/_lib/**'
       - 'app/functions/dictionaries/**'
+      # The voice transcript assembler is a browser module, but its suite lives
+      # in _lib/__tests__ — without these the module could break untested.
+      - 'js/voice-transcript-order.js'
+      - 'js/package.json'
   pull_request:
     branches: [main, dev0]
     paths:
       - 'app/functions/_lib/**'
       - 'app/functions/dictionaries/**'
+      # The voice transcript assembler is a browser module, but its suite lives
+      # in _lib/__tests__ — without these the module could break untested.
+      - 'js/voice-transcript-order.js'
+      - 'js/package.json'
 
 jobs:
   test:
@@ -46,5 +54,24 @@ jobs:
       - name: Run ATS scoring tests
         working-directory: app/functions/_lib/__tests__
         run: node ats-scoring-engine.test.mjs
+
+      # Deterministic voice suites — no API key, no cost. These prove the
+      # transcript assembler and the prompt's own text, NOT that the live model
+      # obeys the prompt; that stays a manual dev-session check.
+      - name: Run voice transcript ordering tests
+        working-directory: app/functions/_lib/__tests__
+        run: node voice-transcript-order.test.mjs
+
+      - name: Run voice interviewer prompt tests
+        working-directory: app/functions/_lib/__tests__
+        run: node voice-interviewer.test.mjs
+
+      - name: Run voice entitlement tests
+        working-directory: app/functions/_lib/__tests__
+        run: node voice-entitlements.test.mjs
+
+      - name: Run voice history tests
+        working-directory: app/functions/_lib/__tests__
+        run: node voice-history.test.mjs
 
 

--- a/app/functions/_lib/__tests__/voice-transcript-order.test.mjs
+++ b/app/functions/_lib/__tests__/voice-transcript-order.test.mjs
@@ -16,6 +16,14 @@ function test(name, fn) {
   catch (err) { failed++; console.error(`  ✗ ${name}\n    ${err.message}`); }
 }
 
+const asyncTests = [];
+function asyncTest(name, fn) {
+  asyncTests.push(async () => {
+    try { await fn(); passed++; console.log(`  ✓ ${name}`); }
+    catch (err) { failed++; console.error(`  ✗ ${name}\n    ${err.message}`); }
+  });
+}
+
 test('out-of-order transcripts land in conversation order', () => {
   const o = createTranscriptOrder();
   // Items are announced in true order...
@@ -121,6 +129,116 @@ test('list() returns a fresh array each call (no shared mutation)', () => {
   a.push({ speaker: 'user', text: 'injected' });
   assert.equal(o.list().length, 1);
 });
+
+// ---------- previous_item_id ordering ----------
+
+test('previous_item_id inserts an out-of-band item after its anchor, not at the end', () => {
+  const o = createTranscriptOrder();
+  o.noteItem('a');
+  o.noteItem('b', 'a');
+  o.noteItem('c', 'b');
+  // An item announced late but belonging right after 'a'
+  o.noteItem('a2', 'a');
+  o.setText('a', 'user', 'one');
+  o.setText('a2', 'user', 'one-and-a-half');
+  o.setText('b', 'assistant', 'two');
+  o.setText('c', 'user', 'three');
+  assert.deepEqual(o.list().map((t) => t.text), ['one', 'one-and-a-half', 'two', 'three']);
+});
+
+test('in-order previous_item_id chains behave exactly like appending', () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1', null);
+  o.noteItem('a1', 'u1');
+  o.noteItem('u2', 'a1');
+  o.setText('a1', 'assistant', 'mid');
+  o.setText('u2', 'user', 'last');
+  o.setText('u1', 'user', 'first');
+  assert.deepEqual(o.list().map((t) => t.text), ['first', 'mid', 'last']);
+});
+
+test('an unknown previous_item_id appends rather than dropping the turn', () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.noteItem('u2', 'never_seen');
+  o.setText('u1', 'user', 'first');
+  o.setText('u2', 'user', 'second');
+  assert.deepEqual(o.list().map((t) => t.text), ['first', 'second']);
+});
+
+test('a repeat noteItem never moves an already-reserved slot', () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.noteItem('a1', 'u1');
+  o.noteItem('u1', 'a1');        // contradictory replay: must not reorder
+  o.setText('u1', 'user', 'first');
+  o.setText('a1', 'assistant', 'second');
+  assert.deepEqual(o.list().map((t) => t.text), ['first', 'second']);
+});
+
+// ---------- pending / flush ----------
+
+test('pendingCount counts only announced slots still awaiting a transcript', () => {
+  const o = createTranscriptOrder();
+  assert.equal(o.pendingCount(), 0);
+  o.noteItem('u1');
+  o.noteItem('a1');
+  assert.equal(o.pendingCount(), 2);
+  o.setText('u1', 'user', 'filled');
+  assert.equal(o.pendingCount(), 1);
+  o.append('assistant', 'appended directly');   // id-less, never pending
+  assert.equal(o.pendingCount(), 1);
+  o.setText('a1', 'assistant', 'filled too');
+  assert.equal(o.pendingCount(), 0);
+});
+
+asyncTest('flushTranscript resolves immediately when nothing is in flight', async () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.setText('u1', 'user', 'done');
+  assert.equal(await o.flushTranscript({ timeoutMs: 50 }), true);
+});
+
+asyncTest('flushTranscript resolves as soon as the late transcript lands', async () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.noteItem('a1');
+  o.setText('a1', 'assistant', 'arrived first');
+  // The user's whisper transcript is still in flight when the session ends
+  const flushed = o.flushTranscript({ timeoutMs: 5000 });
+  setTimeout(() => o.setText('u1', 'user', 'the line that ended the session'), 10);
+  assert.equal(await flushed, true);
+  // ...and the recovered turn is in the right place, not appended at the end
+  assert.deepEqual(o.list().map((t) => t.text), [
+    'the line that ended the session',
+    'arrived first'
+  ]);
+});
+
+asyncTest('flushTranscript gives up on timeout and keeps what already arrived', async () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.noteItem('a1');            // never arrives
+  o.setText('u1', 'user', 'kept');
+  assert.equal(await o.flushTranscript({ timeoutMs: 20 }), false);
+  assert.deepEqual(o.list().map((t) => t.text), ['kept']);
+});
+
+asyncTest('a zero timeout does not wait', async () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  assert.equal(await o.flushTranscript({ timeoutMs: 0 }), false);
+});
+
+asyncTest('reset releases an in-progress flush instead of hanging it', async () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  const flushed = o.flushTranscript({ timeoutMs: 5000 });
+  o.reset();
+  assert.equal(await flushed, false);
+});
+
+for (const run of asyncTests) await run();
 
 console.log(`\n${passed} passed, ${failed} failed`);
 if (failed > 0) process.exit(1);

--- a/app/functions/_lib/__tests__/voice-transcript-order.test.mjs
+++ b/app/functions/_lib/__tests__/voice-transcript-order.test.mjs
@@ -1,0 +1,126 @@
+// Ordered transcript assembly test suite (standalone, no framework)
+// Run: node app/functions/_lib/__tests__/voice-transcript-order.test.mjs
+//
+// Covers the real-session bug: the Realtime API delivers a user turn's
+// whisper transcript AFTER the assistant transcript for the turn it
+// preceded, so arrival-order appending scrambled the conversation that gets
+// stored, shown to the candidate, and fed to the scorecard model.
+
+import assert from 'node:assert/strict';
+import { createTranscriptOrder } from '../../../../js/voice-transcript-order.js';
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log(`  ✓ ${name}`); }
+  catch (err) { failed++; console.error(`  ✗ ${name}\n    ${err.message}`); }
+}
+
+test('out-of-order transcripts land in conversation order', () => {
+  const o = createTranscriptOrder();
+  // Items are announced in true order...
+  o.noteItem('item_user_1');
+  o.noteItem('item_asst_1');
+  o.noteItem('item_user_2');
+  // ...but transcripts arrive scrambled (assistant first, user late)
+  o.setText('item_asst_1', 'assistant', 'So 45 customers served?');
+  o.setText('item_user_2', 'user', 'Yes, about 45.');
+  o.setText('item_user_1', 'user', 'It was Christmas Eve.');
+
+  assert.deepEqual(o.list(), [
+    { speaker: 'user', text: 'It was Christmas Eve.' },
+    { speaker: 'assistant', text: 'So 45 customers served?' },
+    { speaker: 'user', text: 'Yes, about 45.' }
+  ]);
+});
+
+test('the reported symptom is fixed: interviewer never precedes the candidate', () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.noteItem('a1');
+  // Assistant transcript arrives before the user transcript it responded to
+  o.setText('a1', 'assistant', 'Take your time - so the employee quit.');
+  o.setText('u1', 'user', 'He quit.');
+  const list = o.list();
+  assert.equal(list[0].text, 'He quit.');
+  assert.equal(list[1].text, 'Take your time - so the employee quit.');
+});
+
+test('unannounced item ids append in arrival order (graceful degradation)', () => {
+  const o = createTranscriptOrder();
+  o.setText('never_announced_1', 'user', 'first');
+  o.setText('never_announced_2', 'assistant', 'second');
+  assert.deepEqual(o.list(), [
+    { speaker: 'user', text: 'first' },
+    { speaker: 'assistant', text: 'second' }
+  ]);
+});
+
+test('missing item id falls back to append, never drops the turn', () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.setText('u1', 'user', 'kept');
+  o.setText(null, 'assistant', 'also kept');
+  o.append('user', 'appended directly');
+  assert.deepEqual(o.list().map((t) => t.text), ['kept', 'also kept', 'appended directly']);
+});
+
+test('unfilled slots never leak as placeholders', () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.noteItem('a1');            // announced but transcript never arrived
+  o.noteItem('u2');
+  o.setText('u1', 'user', 'one');
+  o.setText('u2', 'user', 'two');
+  assert.deepEqual(o.list(), [
+    { speaker: 'user', text: 'one' },
+    { speaker: 'user', text: 'two' }
+  ]);
+});
+
+test('identical consecutive same-speaker lines are deduped (event replays)', () => {
+  const o = createTranscriptOrder();
+  o.append('assistant', 'Tell me about a deadline.');
+  o.append('assistant', 'Tell me about a deadline.');
+  o.append('user', 'Tell me about a deadline.');   // different speaker: kept
+  o.append('assistant', 'Tell me about a deadline.');
+  assert.equal(o.list().length, 3);
+});
+
+test('re-filling the same item id updates in place, no duplicate slot', () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.setText('u1', 'user', 'partial');
+  o.setText('u1', 'user', 'partial but corrected');
+  assert.deepEqual(o.list(), [{ speaker: 'user', text: 'partial but corrected' }]);
+});
+
+test('duplicate noteItem for one id does not reserve twice', () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.noteItem('u1');
+  o.setText('u1', 'user', 'once');
+  assert.equal(o.list().length, 1);
+});
+
+test('reset clears everything for a fresh session', () => {
+  const o = createTranscriptOrder();
+  o.noteItem('u1');
+  o.setText('u1', 'user', 'old session');
+  o.reset();
+  assert.deepEqual(o.list(), []);
+  o.noteItem('u2');
+  o.setText('u2', 'user', 'new session');
+  assert.deepEqual(o.list(), [{ speaker: 'user', text: 'new session' }]);
+});
+
+test('list() returns a fresh array each call (no shared mutation)', () => {
+  const o = createTranscriptOrder();
+  o.append('user', 'x');
+  const a = o.list();
+  a.push({ speaker: 'user', text: 'injected' });
+  assert.equal(o.list().length, 1);
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/app/functions/api/voice/session/[id]/complete.js
+++ b/app/functions/api/voice/session/[id]/complete.js
@@ -69,7 +69,10 @@ export async function onRequest(context) {
     transcript = transcript
       .filter((t) => t && typeof t.text === 'string' && (t.speaker === 'user' || t.speaker === 'assistant'))
       .map((t) => ({ speaker: t.speaker, text: t.text.slice(0, 4000) }))
-      .slice(0, 400);
+      // Keep the most recent turns, matching the byte-overflow branch below:
+      // in a long interview the closing questions and stated outcomes carry
+      // the most scoring signal, so the tail must survive, not the opening.
+      .slice(-400);
     let transcriptJson = JSON.stringify(transcript);
     if (transcriptJson.length > MAX_TRANSCRIPT_BYTES) {
       transcript = transcript.slice(-200);

--- a/app/package.json
+++ b/app/package.json
@@ -27,7 +27,9 @@
     "test:voice:transcripts:smoke": "node tests/voice-transcripts/run-evals.mjs --mode smoke",
     "test:voice:transcripts:full": "node tests/voice-transcripts/run-evals.mjs --mode full",
     "test:voice:transcripts:stability": "node tests/voice-transcripts/run-evals.mjs --mode stability",
-    "test:voice:transcripts:unit": "node tests/voice-transcripts/unit.test.mjs"
+    "test:voice:transcripts:unit": "node tests/voice-transcripts/unit.test.mjs",
+    "test:voice:interviewer": "node functions/_lib/__tests__/voice-interviewer.test.mjs",
+    "test:voice:transcript-order": "node functions/_lib/__tests__/voice-transcript-order.test.mjs"
   },
   "dependencies": {
     "firebase": "^10.7.0",

--- a/js/package.json
+++ b/js/package.json
@@ -1,0 +1,4 @@
+{
+  "//": "Scope marker only — not a package. Declares /js as ESM so Node test suites can import these browser modules directly (same mechanism as app/functions/_lib/package.json). Browsers ignore package.json entirely, so this changes nothing at runtime. free-account-manager.js and stripe-integration.js assign module.exports behind a `typeof module !== 'undefined'` guard and are never loaded by Node, so they are unaffected.",
+  "type": "module"
+}

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -17,7 +17,7 @@
     startedAtMs: null,
     timerInterval: null,
     maxMinutes: 20,
-    transcript: [],            // [{speaker:'user'|'assistant', text}]
+    order: null,               // ordered transcript assembler (voice-transcript-order.js)
     usage: { input: 0, output: 0 },
     ending: false,
     connected: false
@@ -113,12 +113,35 @@
 
   // ---------- realtime event handling ----------
 
-  function appendTranscript(speaker, text) {
+  // js/voice-transcript-order.js is an ES module, so on the vanishing chance
+  // it has not executed yet we degrade to plain arrival-order collection
+  // rather than losing turns.
+  function newTranscriptOrder() {
+    if (typeof window.createTranscriptOrder === 'function') {
+      return window.createTranscriptOrder();
+    }
+    var arr = [];
+    return {
+      noteItem: function () {},
+      setText: function (id, speaker, text) { arr.push({ speaker: speaker, text: text }); },
+      append: function (speaker, text) { arr.push({ speaker: speaker, text: text }); },
+      list: function () { return arr.slice(); },
+      reset: function () { arr = []; }
+    };
+  }
+
+  // The conversation in true order, for /complete and the resume tail.
+  function getTranscript() {
+    return state.order ? state.order.list() : [];
+  }
+
+  // Realtime transcripts arrive out of order; itemId places each turn in the
+  // slot its conversation item reserved (see voice-transcript-order.js).
+  function recordTurn(speaker, text, itemId) {
     text = String(text || '').trim();
     if (!text) return;
-    var last = state.transcript[state.transcript.length - 1];
-    if (last && last.speaker === speaker && last.text === text) return; // dedupe replays
-    state.transcript.push({ speaker: speaker, text: text });
+    if (!state.order) state.order = newTranscriptOrder();
+    state.order.setText(itemId || null, speaker, text);
     var caption = $('vi-caption');
     if (caption) {
       caption.textContent = (speaker === 'assistant' ? 'Interviewer: ' : 'You: ') + text;
@@ -128,13 +151,21 @@
   function handleRealtimeEvent(evt) {
     var type = evt.type || '';
 
+    // Items are announced in true conversation order and carry the id that
+    // the (later, out-of-order) transcript events reference.
+    if (type === 'conversation.item.created' || type === 'conversation.item.added') {
+      if (!state.order) state.order = newTranscriptOrder();
+      state.order.noteItem(evt.item && evt.item.id);
+      return;
+    }
+
     if (type === 'conversation.item.input_audio_transcription.completed') {
-      appendTranscript('user', evt.transcript);
+      recordTurn('user', evt.transcript, evt.item_id);
       return;
     }
     // GA + beta event names for assistant transcript
     if (type === 'response.output_audio_transcript.done' || type === 'response.audio_transcript.done') {
-      appendTranscript('assistant', evt.transcript);
+      recordTurn('assistant', evt.transcript, evt.item_id);
       return;
     }
     if (type === 'response.done' && evt.response && evt.response.usage) {
@@ -276,7 +307,7 @@
       state.sessionId = res.data.sessionId;
       state.model = res.data.model;
       state.maxMinutes = res.data.maxMinutes || 20;
-      state.transcript = [];
+      state.order = newTranscriptOrder();
       state.usage = { input: 0, output: 0 };
       state.ending = false;
 
@@ -313,7 +344,7 @@
         method: 'POST',
         body: JSON.stringify({
           resumeSessionId: state.sessionId,
-          transcript: state.transcript.slice(-20)
+          transcript: getTranscript().slice(-20)
         })
       });
       if (!res.ok) throw new Error((res.data && res.data.error) || 'resume_failed');
@@ -355,7 +386,7 @@
       await api('/api/voice/session/' + encodeURIComponent(state.sessionId) + '/complete', {
         method: 'POST',
         body: JSON.stringify({
-          transcript: state.transcript,
+          transcript: getTranscript(),
           durationSeconds: durationSeconds,
           inputTokens: state.usage.input,
           outputTokens: state.usage.output,

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -7,6 +7,11 @@
 
   var REALTIME_CALLS_URL = 'https://api.openai.com/v1/realtime/calls';
 
+  // How long ending the interview waits for transcripts already in flight.
+  // Long enough for a trailing whisper result, short enough that nobody is
+  // left staring at a spinner if an event never arrives.
+  var TRANSCRIPT_FLUSH_MS = 1500;
+
   var state = {
     sessionId: null,
     model: null,
@@ -126,6 +131,10 @@
       setText: function (id, speaker, text) { arr.push({ speaker: speaker, text: text }); },
       append: function (speaker, text) { arr.push({ speaker: speaker, text: text }); },
       list: function () { return arr.slice(); },
+      // Arrival-order collection reserves nothing, so there is never anything
+      // in flight to wait for.
+      pendingCount: function () { return 0; },
+      flushTranscript: function () { return Promise.resolve(true); },
       reset: function () { arr = []; }
     };
   }
@@ -155,7 +164,9 @@
     // the (later, out-of-order) transcript events reference.
     if (type === 'conversation.item.created' || type === 'conversation.item.added') {
       if (!state.order) state.order = newTranscriptOrder();
-      state.order.noteItem(evt.item && evt.item.id);
+      // previous_item_id says which item this one follows, so an item inserted
+      // out of band lands in the right place instead of at the end.
+      state.order.noteItem(evt.item && evt.item.id, evt.previous_item_id);
       return;
     }
 
@@ -237,13 +248,32 @@
     await pc.setRemoteDescription({ type: 'answer', sdp: answerSdp });
   }
 
-  function teardownConnection() {
-    try { if (state.dc) state.dc.close(); } catch (_) {}
-    try { if (state.pc) state.pc.close(); } catch (_) {}
+  // The mic is released on its own so the interview can stop listening the
+  // instant it ends, while the data channel stays open long enough for
+  // in-flight transcripts to land. Mic audio is outbound only, so this never
+  // cuts the interviewer off mid-sentence.
+  function stopMicrophone() {
     try {
       if (state.micStream) state.micStream.getTracks().forEach(function (t) { t.stop(); });
     } catch (_) {}
-    state.pc = null; state.dc = null; state.micStream = null; state.connected = false;
+    state.micStream = null;
+  }
+
+  function teardownConnection() {
+    try { if (state.dc) state.dc.close(); } catch (_) {}
+    try { if (state.pc) state.pc.close(); } catch (_) {}
+    stopMicrophone();
+    state.pc = null; state.dc = null; state.connected = false;
+  }
+
+  // Whisper transcripts for the last turn routinely arrive after the turn is
+  // over. Closing the data channel first threw them away, which is how the
+  // utterance that ended a session went missing from its own report.
+  function flushPendingTranscript() {
+    if (!state.order || typeof state.order.flushTranscript !== 'function') {
+      return Promise.resolve(false);
+    }
+    return state.order.flushTranscript({ timeoutMs: TRANSCRIPT_FLUSH_MS });
   }
 
   // ---------- timer ----------
@@ -375,12 +405,17 @@
     if (state.timerInterval) { clearInterval(state.timerInterval); state.timerInterval = null; }
 
     var durationSeconds = state.startedAtMs ? Math.round((Date.now() - state.startedAtMs) / 1000) : 0;
-    teardownConnection();
+    stopMicrophone();
 
     show('vi-done-view');
     var doneStatus = $('vi-done-status');
     if (doneStatus) doneStatus.textContent = 'We\'re reviewing your conversation using our S + A = O formula and interview rubric. This usually takes a few seconds.';
     historyLiveScoring();
+
+    // Let any transcript still in flight land before the channel closes; the
+    // wait is bounded and a timeout just means we store what we already have.
+    await flushPendingTranscript();
+    teardownConnection();
 
     try {
       await api('/api/voice/session/' + encodeURIComponent(state.sessionId) + '/complete', {

--- a/js/voice-transcript-order.js
+++ b/js/voice-transcript-order.js
@@ -18,16 +18,26 @@
  * mis-ordered turn is cosmetic; a missing turn corrupts the score.
  */
 
+var DEFAULT_FLUSH_MS = 1500;
+
 export function createTranscriptOrder() {
   var slots = [];
   var byId = Object.create(null);
+  var waiters = [];
 
-  function reserve(id) {
+  // Realtime item events carry `previous_item_id` — the item this one follows.
+  // Honoring it places out-of-band items (anything inserted rather than
+  // appended, e.g. a resumed turn) correctly instead of at the end. An unknown
+  // or absent anchor appends, which is the ordinary in-order case.
+  function reserve(id, previousItemId) {
     if (!id) return null;
     if (byId[id]) return byId[id];
     var slot = { id: id, speaker: '', text: '' };
     byId[id] = slot;
-    slots.push(slot);
+    var anchor = previousItemId ? byId[previousItemId] : null;
+    var at = anchor ? slots.indexOf(anchor) : -1;
+    if (at >= 0) slots.splice(at + 1, 0, slot);
+    else slots.push(slot);
     return slot;
   }
 
@@ -36,8 +46,51 @@ export function createTranscriptOrder() {
   }
 
   // conversation.item.created / conversation.item.added — reserves order
-  function noteItem(id) {
-    reserve(id);
+  function noteItem(id, previousItemId) {
+    reserve(id, previousItemId);
+  }
+
+  // Reserved slots still waiting on a transcript. These are the turns that
+  // `list()` would silently drop, so this is what a flush waits on.
+  function pendingCount() {
+    var n = 0;
+    for (var i = 0; i < slots.length; i++) {
+      var s = slots[i];
+      if (s.id && (!s.speaker || !s.text)) n++;
+    }
+    return n;
+  }
+
+  function settleWaiters() {
+    if (waiters.length === 0 || pendingCount() !== 0) return;
+    var ready = waiters;
+    waiters = [];
+    for (var i = 0; i < ready.length; i++) ready[i](true);
+  }
+
+  // Resolves true once every announced slot has its transcript, false on
+  // timeout. Callers tearing the connection down await this so a whisper
+  // transcript still in flight — often the final turn, the one that ended the
+  // session — is not lost with the data channel.
+  function flushTranscript(opts) {
+    var timeoutMs = opts && opts.timeoutMs != null ? Number(opts.timeoutMs) : DEFAULT_FLUSH_MS;
+    if (pendingCount() === 0) return Promise.resolve(true);
+    if (!(timeoutMs > 0)) return Promise.resolve(false);
+    return new Promise(function (resolve) {
+      var settled = false;
+      var timer = null;
+      function finish(filled) {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        var at = waiters.indexOf(onFilled);
+        if (at >= 0) waiters.splice(at, 1);
+        resolve(filled);
+      }
+      function onFilled(filled) { finish(filled !== false); }
+      waiters.push(onFilled);
+      timer = setTimeout(function () { finish(false); }, timeoutMs);
+    });
   }
 
   // A transcript arrived. Fills its reserved slot, or appends when the id is
@@ -46,10 +99,12 @@ export function createTranscriptOrder() {
     var slot = reserve(id);
     if (!slot) {
       append(speaker, text);
+      settleWaiters();
       return;
     }
     slot.speaker = speaker;
     slot.text = text;
+    settleWaiters();
   }
 
   // Ordered, placeholder-free, with identical consecutive same-speaker
@@ -69,6 +124,10 @@ export function createTranscriptOrder() {
   function reset() {
     slots = [];
     byId = Object.create(null);
+    // Release anyone mid-flush so a reset can never leave a pending await.
+    var ready = waiters;
+    waiters = [];
+    for (var i = 0; i < ready.length; i++) ready[i](false);
   }
 
   return {
@@ -76,6 +135,8 @@ export function createTranscriptOrder() {
     setText: setText,
     append: append,
     list: list,
+    pendingCount: pendingCount,
+    flushTranscript: flushTranscript,
     reset: reset
   };
 }

--- a/js/voice-transcript-order.js
+++ b/js/voice-transcript-order.js
@@ -1,0 +1,85 @@
+/**
+ * Ordered transcript assembly for the voice mock interview.
+ *
+ * The Realtime API does not deliver transcripts in conversational order. A
+ * user turn's `conversation.item.input_audio_transcription.completed`
+ * (whisper, computed asynchronously) routinely lands AFTER the assistant
+ * transcript for the turn it preceded, so appending in arrival order
+ * scrambles the conversation. That scrambled array is what gets stored,
+ * shown back to the candidate, and fed to the scorecard model — where it
+ * corrupts speaker attribution, the S + A = O balance, and quoted moments.
+ *
+ * Fix: `conversation.item.created` / `conversation.item.added` arrive in true
+ * conversation order and carry the item id, so they reserve an ordered slot
+ * that the later transcript events fill by `item_id`.
+ *
+ * Defensive by design: a transcript with no usable id, or an id that was
+ * never announced, is appended at the end rather than dropped. A
+ * mis-ordered turn is cosmetic; a missing turn corrupts the score.
+ */
+
+export function createTranscriptOrder() {
+  var slots = [];
+  var byId = Object.create(null);
+
+  function reserve(id) {
+    if (!id) return null;
+    if (byId[id]) return byId[id];
+    var slot = { id: id, speaker: '', text: '' };
+    byId[id] = slot;
+    slots.push(slot);
+    return slot;
+  }
+
+  function append(speaker, text) {
+    slots.push({ id: null, speaker: speaker, text: text });
+  }
+
+  // conversation.item.created / conversation.item.added — reserves order
+  function noteItem(id) {
+    reserve(id);
+  }
+
+  // A transcript arrived. Fills its reserved slot, or appends when the id is
+  // unknown/absent (graceful degradation to arrival order).
+  function setText(id, speaker, text) {
+    var slot = reserve(id);
+    if (!slot) {
+      append(speaker, text);
+      return;
+    }
+    slot.speaker = speaker;
+    slot.text = text;
+  }
+
+  // Ordered, placeholder-free, with identical consecutive same-speaker
+  // lines collapsed (dedupes realtime event replays).
+  function list() {
+    var out = [];
+    for (var i = 0; i < slots.length; i++) {
+      var s = slots[i];
+      if (!s.speaker || !s.text) continue;
+      var prev = out[out.length - 1];
+      if (prev && prev.speaker === s.speaker && prev.text === s.text) continue;
+      out.push({ speaker: s.speaker, text: s.text });
+    }
+    return out;
+  }
+
+  function reset() {
+    slots = [];
+    byId = Object.create(null);
+  }
+
+  return {
+    noteItem: noteItem,
+    setText: setText,
+    append: append,
+    list: list,
+    reset: reset
+  };
+}
+
+if (typeof window !== 'undefined') {
+  window.createTranscriptOrder = createTranscriptOrder;
+}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "test:voice:transcripts:smoke": "node app/tests/voice-transcripts/run-evals.mjs --mode smoke",
     "test:voice:transcripts:full": "node app/tests/voice-transcripts/run-evals.mjs --mode full",
     "test:voice:transcripts:stability": "node app/tests/voice-transcripts/run-evals.mjs --mode stability",
-    "test:voice:transcripts:unit": "node app/tests/voice-transcripts/unit.test.mjs"
+    "test:voice:transcripts:unit": "node app/tests/voice-transcripts/unit.test.mjs",
+    "test:voice:interviewer": "node app/functions/_lib/__tests__/voice-interviewer.test.mjs",
+    "test:voice:transcript-order": "node app/functions/_lib/__tests__/voice-transcript-order.test.mjs"
   }
 }

--- a/voice-interview.html
+++ b/voice-interview.html
@@ -465,6 +465,7 @@
   <script src="js/analytics.js" type="module"></script>
   <script src="js/main.js" type="module"></script>
   <script src="js/role-selector.js" type="module"></script>
-  <script src="js/voice-interview.js?v=20260720-1" defer></script>
+  <script src="js/voice-transcript-order.js" type="module"></script>
+  <script src="js/voice-interview.js?v=20260723-1" defer></script>
 </body>
 </html>


### PR DESCRIPTION
# Transcript ordering — a silent bug degrading every scorecard

Found while reading a real adversarial dev session. This is the highest-impact fix in the voice series so far because it affects **every session**, not just adversarial ones.

## The bug

`appendTranscript` pushed turns in **event-arrival order**. The Realtime API computes user speech transcripts asynchronously (whisper), so a user turn's `conversation.item.input_audio_transcription.completed` routinely lands *after* the assistant's `response.output_audio_transcript.done` for the turn it preceded.

Evidence from the owner's session — the interviewer appears to reference facts before the candidate states them:

| Stored order | Reality |
|---|---|
| "Got it—so 45 customers served and an expected $10,000 more" … then "I guess the 10,000…" | candidate said it first |
| "You noticed signs of stress—what exactly did you say to reassure them?" … then the stress line | candidate said it first |
| "Take your time—so the employee quit." … then "He quit." | candidate said it first |

The "three consecutive interviewer greetings" at the start of that session were the same artifact — the candidate's interjections were displaced, not actually absent.

## Why it matters twice

1. **Scoring**: this exact array is POSTed to `/complete`, stored in `transcript_json`, and fed verbatim to the scorecard model via `transcriptToText`. Every scorecard has been grading a scrambled conversation — worst for speaker attribution, `saoBalance` (which depends on knowing which words were the candidate's), and quoted `moments`.
2. **Trust**: users expand "Full transcript" in their own report and read something incoherent.

## The fix

`conversation.item.created` / `conversation.item.added` arrive in true conversation order and carry the item id, so they reserve an ordered slot that later transcript events fill by `item_id`.

- New `js/voice-transcript-order.js` — pure logic, ESM export + `window` global (same dual pattern as the existing `js/role-selector.js`), so it is unit-testable outside a browser.
- `js/voice-interview.js` — `recordTurn(speaker, text, itemId)` replaces `appendTranscript`; `getTranscript()` returns the ordered array; both consumers switched (`/complete` POST and the resume tail).
- **Defensive throughout**: an event with no usable `item_id`, or an id never announced, appends at the end exactly as today. A mis-ordered turn is cosmetic; a dropped turn corrupts the score. The client also carries a local fallback assembler in case the module hasn't executed yet.

**Same-area fix**: `/complete` truncated with `.slice(0, 400)` — keeping the *first* 400 turns and discarding the end of a long interview — while the byte-overflow branch keeps the last 200. Both now keep the most recent turns; in a 20-minute interview the closing questions and stated outcomes carry the most scoring signal.

## Testing

- New suite `voice-transcript-order.test.mjs` — **10/10**: out-of-order fills land in conversation order, the exact reported symptom, unannounced ids, missing ids, unfilled slots never leaking placeholders, replay dedupe, in-place refill, double-announce, reset, and list() immutability. Runnable via `npm run test:voice:transcript-order`.
- Existing suites green: harness unit 15/15, `voice-interviewer` 8/8.
- **Harness baseline is unaffected** — verified the eval harness builds its own fixture transcripts via `toVoiceTranscript` (`app/tests/voice-transcripts/lib/eval-utils.mjs:65`) and never imports client code.

## Verification in dev

Run a session and expand "Full transcript": interviewer turns must never reference facts the candidate hasn't said yet, and the opening should show one greeting. One implementation note worth confirming live: the exact Realtime event names for item announcement are handled with a GA/beta pair (`conversation.item.created` / `conversation.item.added`), following the precedent already used for transcript events in this file — if a future API version renames them, the fallback silently restores today's behavior rather than breaking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PRjXnEuZdGXs9DgSxGJae

---
_Generated by [Claude Code](https://claude.ai/code/session_019PRjXnEuZdGXs9DgSxGJae)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the client path for every voice session’s stored transcript and scorecard input; behavior is well-tested but depends on Realtime item/transcript event shapes with a documented fallback.
> 
> **Overview**
> Fixes voice mock interviews building transcripts in **Realtime event arrival order**, which scrambled dialogue (late user whisper transcripts after assistant lines) for storage, UI, and scorecards.
> 
> Adds **`createTranscriptOrder`** in `js/voice-transcript-order.js`: conversation items reserve ordered slots via `noteItem` / `previous_item_id`, transcripts fill by `item_id`, with dedupe, graceful fallbacks, and **`flushTranscript`** so the last turn isn’t dropped when ending the session. **`voice-interview.js`** wires item-created events, replaces the flat array with the assembler, stops the mic immediately but keeps the data channel open until flush (~1.5s), then posts **`getTranscript()`** to `/complete` and resume.
> 
> **`/complete`** now keeps the **last** 400 turns (`.slice(-400)`) so long interviews retain closing Q&A for scoring, aligned with the byte-overflow tail trim.
> 
> CI and npm add **`voice-transcript-order.test.mjs`** (ordering, flush, edge cases) plus workflow steps for voice unit suites; **`js/package.json`** marks `/js` as ESM for Node imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3dc3c409928e8a8df8240bebe318449cdfd8bfdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->