### PR TITLE
fix(voice): release-gate patch — spoken warnings count, safety sessions never scored

### DIFF
--- a/app/functions/_lib/__tests__/voice-conduct.test.mjs
+++ b/app/functions/_lib/__tests__/voice-conduct.test.mjs
@@ -19,6 +19,7 @@ import {
   createClosingTurnGate,
   readToolCall,
   isSafetyReferral,
+  isConductWarningLine,
   LIVE_CANDIDATE_SPEECH_EVENTS,
   CONDUCT_TOOL,
   SAFETY_TOOL
@@ -296,6 +297,82 @@ test('gates are independent (no shared state across sessions)', () => {
   assert.equal(a.wasWarned(), true);
   assert.equal(b.wasWarned(), false);
   assert.equal(b.decide('end'), 'warn_instead');
+});
+
+// -- LIVE DEV REGRESSION: repeated abuse never ended the session ---------------
+//
+// Observed sequence in the failed release-gate test: first directed insult,
+// one professional warning, second directed insult, the interviewer says again
+// that she will not continue through the language... and then keeps asking
+// questions. Root cause was twofold: she spoke the warning without ever
+// calling conduct_action (so the gate heard nothing), and the escalation
+// required live speech events AND a new response, so a missing speech signal
+// silenced even explicit tool calls.
+
+test('LIVE REGRESSION: insult, warning, second insult, spoken warning - session ends, then silence', () => {
+  const g = createConductGate();
+  // First directed insult: the model warns via the tool (response A) and the
+  // transcript of its own warning line arrives for the same response.
+  assert.equal(g.decide('warning', 'call_1', 'resp_A'), 'warn');
+  assert.equal(g.noteSpokenWarning('resp_A'), 'ignore');
+  // Second directed insult: the model only SPEAKS the warning again, no tool.
+  assert.equal(g.noteSpokenWarning('resp_B'), 'end');
+  // Then silence: everything after the close is inert.
+  assert.equal(g.noteSpokenWarning('resp_C'), 'ignore');
+  assert.equal(g.decide('end', 'call_9', 'resp_C'), 'ignore');
+  assert.equal(g.decide('warning', 'call_10', 'resp_D'), 'ignore');
+  assert.equal(g.endReason(), 'ended_by_interviewer');
+});
+
+test('LIVE REGRESSION: purely spoken warnings, never a single tool call', () => {
+  const g = createConductGate();
+  assert.equal(g.noteSpokenWarning('resp_A'), 'warn');
+  assert.equal(g.noteSpokenWarning('resp_B'), 'end');
+});
+
+test('LIVE REGRESSION: dead speech events cannot silence tool escalation', () => {
+  // If input_audio_buffer events are never delivered, the old gate ignored
+  // every repeat call and the client answered "continue" - the fully armed
+  // gate produced the endless-warning loop itself. Response identity alone
+  // must now be sufficient.
+  const g = createConductGate();
+  assert.equal(g.decide('warning', 'call_1', 'resp_A'), 'warn');
+  // note: NO noteCandidateSpoke ever fires
+  assert.equal(g.decide('warning', 'call_2', 'resp_B'), 'end');
+});
+
+test('a spoken warning and its duplicate transcript event stay ONE warning', () => {
+  const g = createConductGate();
+  assert.equal(g.noteSpokenWarning('resp_A'), 'warn');
+  // GA + beta transcript event names can both surface the same response
+  assert.equal(g.noteSpokenWarning('resp_A'), 'ignore');
+  assert.equal(g.wasWarned(), true);
+});
+
+test('a spoken warning without ids needs independent evidence to end', () => {
+  const g = createConductGate();
+  assert.equal(g.noteSpokenWarning(''), 'warn');
+  // No response ids and no candidate speech: cannot prove a second incident
+  assert.equal(g.noteSpokenWarning(''), 'ignore');
+  g.noteCandidateSpoke(SPOKE);
+  assert.equal(g.noteSpokenWarning(''), 'end');
+});
+
+test('the warning REGISTER is detected; everyday interviewer speech is not', () => {
+  // The mandated register and close paraphrases
+  assert.equal(isConductWarningLine("I'm going to stop you there. That's not language I'll continue an interview through. Keep it professional and we'll carry on."), true);
+  assert.equal(isConductWarningLine('I will not continue the interview through that language.'), true);
+  assert.equal(isConductWarningLine('That language has no place in an interview.'), true);
+  assert.equal(isConductWarningLine("I won't be spoken to that way."), true);
+  // Everyday interviewer speech that shares the words
+  assert.equal(isConductWarningLine('Let me stop you there - what was the outcome?'), false);
+  assert.equal(isConductWarningLine('Why did you choose that language for the backend?'), false);
+  assert.equal(isConductWarningLine("We won't focus on that language today."), false);
+  assert.equal(isConductWarningLine('How do you keep it professional under pressure?'), false);
+  assert.equal(isConductWarningLine('Keep it professional.'), false);
+  assert.equal(isConductWarningLine('That language is not appropriate for this project.'), false);
+  assert.equal(isConductWarningLine(''), false);
+  assert.equal(isConductWarningLine(null), false);
 });
 
 // -- dev blocker 2: crisis guidance spoken, tool skipped, interview resumed ----

--- a/app/functions/_lib/__tests__/voice-history.test.mjs
+++ b/app/functions/_lib/__tests__/voice-history.test.mjs
@@ -155,6 +155,25 @@ await test('sessionFullAccess mirrors the session GET gate', () => {
   assert.equal(sessionFullAccess({ entitlement_mode: 'free' }, LAPSED_PAID_ENT), true, 'hasEverPaid keeps the free session unlocked');
 });
 
+await test("a safety-ended session reports status 'safety', never a perpetual 'scoring'", async () => {
+  const state = { sessions: [
+    sessionRow({ user_id: 1, entitlement_mode: 'subscription', scorecard_json: null, end_reason: 'ended_for_safety' }),
+    sessionRow({ user_id: 1, entitlement_mode: 'subscription', scorecard_json: null, end_reason: null }),
+    sessionRow({ user_id: 1, entitlement_mode: 'subscription', end_reason: 'user_ended' })
+  ] };
+  const sessions = await listVoiceSessions(makeEnv(state), 1, SUB_ENT, NOW);
+  const byId = Object.fromEntries(sessions.map((x) => [x.sessionId, x]));
+  const safety = byId[state.sessions[0].id];
+  // Safety row: its report is deliberately never generated
+  assert.equal(safety.status, 'safety');
+  assert.equal(safety.endReason, 'ended_for_safety');
+  assert.equal(safety.overall, null);
+  // A genuinely still-scoring row keeps reporting scoring
+  assert.equal(byId[state.sessions[1].id].status, 'scoring');
+  // A normally scored row is untouched
+  assert.equal(byId[state.sessions[2].id].status, 'ready');
+});
+
 await test('list returns at most 10 newest sessions with ownership enforced', async () => {
   const state = { sessions: [] };
   for (let i = 0; i < 14; i++) {

--- a/app/functions/_lib/__tests__/voice-history.test.mjs
+++ b/app/functions/_lib/__tests__/voice-history.test.mjs
@@ -157,7 +157,9 @@ await test('sessionFullAccess mirrors the session GET gate', () => {
 
 await test("a safety-ended session reports status 'safety', never a perpetual 'scoring'", async () => {
   const state = { sessions: [
-    sessionRow({ user_id: 1, entitlement_mode: 'subscription', scorecard_json: null, end_reason: 'ended_for_safety' }),
+    // Legacy row: mis-scored BEFORE suppression existed — the stored numbers
+    // must not surface anywhere
+    sessionRow({ user_id: 1, entitlement_mode: 'subscription', scorecard_json: JSON.stringify({ overall: 61, topImprovement: 'Stay professional under pressure' }), end_reason: 'ended_for_safety' }),
     sessionRow({ user_id: 1, entitlement_mode: 'subscription', scorecard_json: null, end_reason: null }),
     sessionRow({ user_id: 1, entitlement_mode: 'subscription', end_reason: 'user_ended' })
   ] };
@@ -167,7 +169,9 @@ await test("a safety-ended session reports status 'safety', never a perpetual 's
   // Safety row: its report is deliberately never generated
   assert.equal(safety.status, 'safety');
   assert.equal(safety.endReason, 'ended_for_safety');
+  // Even a legacy stored scorecard never leaks a score or coaching line
   assert.equal(safety.overall, null);
+  assert.equal(safety.topImprovement, null);
   // A genuinely still-scoring row keeps reporting scoring
   assert.equal(byId[state.sessions[1].id].status, 'scoring');
   // A normally scored row is untouched

--- a/app/functions/_lib/__tests__/voice-interviewer.test.mjs
+++ b/app/functions/_lib/__tests__/voice-interviewer.test.mjs
@@ -17,7 +17,8 @@ import {
   CONDUCT_WARNING_STAGE,
   CONDUCT_END_STAGE,
   VOICE_END_REASONS,
-  normalizeEndReason
+  normalizeEndReason,
+  shouldGenerateScorecard
 } from '../voice-interviewer.js';
 
 let passed = 0;
@@ -309,6 +310,22 @@ test('normalizeEndReason clamps to the allowlist and rejects junk', () => {
   assert.equal(normalizeEndReason(undefined), null);
   assert.equal(normalizeEndReason(42), null);
   assert.equal(normalizeEndReason({ reason: 'user_ended' }), null);
+});
+
+test('a safety-terminated session is never conventionally scored', () => {
+  // A scorer that only knows S/A/O frames a crisis disclosure as poor
+  // interview behavior — a real safety-ended dev session got exactly that
+  // report. No score exists for ending an interview to reach real help.
+  assert.equal(shouldGenerateScorecard('ended_for_safety'), false);
+  // Every other end still gets its report, including conduct terminations
+  assert.equal(shouldGenerateScorecard('user_ended'), true);
+  assert.equal(shouldGenerateScorecard('time_up'), true);
+  assert.equal(shouldGenerateScorecard('connection_lost'), true);
+  assert.equal(shouldGenerateScorecard('ended_by_interviewer'), true);
+  assert.equal(shouldGenerateScorecard('ended_by_interviewer_unwarned'), true);
+  // Legacy rows with no end_reason keep today's behavior
+  assert.equal(shouldGenerateScorecard(null), true);
+  assert.equal(shouldGenerateScorecard(undefined), true);
 });
 
 console.log(`\n${passed} passed, ${failed} failed`);

--- a/app/functions/_lib/voice-history.js
+++ b/app/functions/_lib/voice-history.js
@@ -66,7 +66,7 @@ export function sessionFullAccess(row, ent) {
  * @returns {Promise<Array<{
  *   sessionId: string, role: string|null, seniority: string|null,
  *   createdAt: string, durationSeconds: number|null,
- *   status: 'scoring'|'ready', overall: number|null,
+ *   status: 'scoring'|'ready'|'safety', overall: number|null,
  *   fullAccess: boolean, reportAvailable: boolean
  * }>>}
  */
@@ -77,7 +77,7 @@ export async function listVoiceSessions(env, userRowId, ent, nowMs = Date.now())
   // Newest 25 completed rows are always enough: expired rows sort strictly
   // after live ones, and the carve-out row is by definition the newest row.
   const rows = await db.prepare(
-    `SELECT id, role, seniority, status, entitlement_mode, started_at, duration_seconds, scorecard_json
+    `SELECT id, role, seniority, status, entitlement_mode, started_at, duration_seconds, scorecard_json, end_reason
      FROM voice_sessions
      WHERE user_id = ? AND status = 'completed'
      ORDER BY started_at DESC LIMIT 25`
@@ -104,7 +104,11 @@ export async function listVoiceSessions(env, userRowId, ent, nowMs = Date.now())
       seniority: r.seniority,
       createdAt: r.started_at,
       durationSeconds: r.duration_seconds,
-      status: scorecard ? 'ready' : 'scoring',
+      // A safety-ended session is never scored, so it must not report
+      // 'scoring': that chip would spin forever for a report that is
+      // deliberately never generated.
+      status: r.end_reason === 'ended_for_safety' ? 'safety' : (scorecard ? 'ready' : 'scoring'),
+      endReason: r.end_reason || null,
       // A locked (expired) row must not leak its score through the API even
       // while the cleaner has yet to strip the stored scorecard.
       overall: !expired && fullAccess && scorecard ? (scorecard.overall ?? null) : null,

--- a/app/functions/_lib/voice-history.js
+++ b/app/functions/_lib/voice-history.js
@@ -95,8 +95,15 @@ export async function listVoiceSessions(env, userRowId, ent, nowMs = Date.now())
     if (expired && (activePlan || i !== 0)) continue;
 
     const fullAccess = sessionFullAccess(r, ent);
+    // A safety-ended session has no report by design. A few legacy safety rows
+    // were scored before suppression existed; their numbers must not leak into
+    // the progress strip, the "vs last session" baseline, or "Last time we
+    // said" either — treat the stored scorecard as if it were never written.
+    const safetyEnded = r.end_reason === 'ended_for_safety';
     let scorecard = null;
-    try { scorecard = r.scorecard_json ? JSON.parse(r.scorecard_json) : null; } catch (_) {}
+    if (!safetyEnded) {
+      try { scorecard = r.scorecard_json ? JSON.parse(r.scorecard_json) : null; } catch (_) {}
+    }
 
     sessions.push({
       sessionId: r.id,
@@ -107,7 +114,7 @@ export async function listVoiceSessions(env, userRowId, ent, nowMs = Date.now())
       // A safety-ended session is never scored, so it must not report
       // 'scoring': that chip would spin forever for a report that is
       // deliberately never generated.
-      status: r.end_reason === 'ended_for_safety' ? 'safety' : (scorecard ? 'ready' : 'scoring'),
+      status: safetyEnded ? 'safety' : (scorecard ? 'ready' : 'scoring'),
       endReason: r.end_reason || null,
       // A locked (expired) row must not leak its score through the API even
       // while the cleaner has yet to strip the stored scorecard.

--- a/app/functions/_lib/voice-interviewer.js
+++ b/app/functions/_lib/voice-interviewer.js
@@ -79,6 +79,17 @@ export function normalizeEndReason(reason) {
   return VOICE_END_REASONS.includes(value) ? value : null;
 }
 
+/**
+ * A safety-terminated session is never conventionally scored. The candidate
+ * disclosed a crisis, not interview performance, and a scorer that only knows
+ * S/A/O will frame the disclosure as poor interview behavior — a real report
+ * from a real safety-ended dev session did exactly that. No score exists for
+ * ending an interview to reach real help.
+ */
+export function shouldGenerateScorecard(endReason) {
+  return endReason !== 'ended_for_safety';
+}
+
 // Most recent conversation kept when building the resume context.
 export const RESUME_CONTEXT_MAX_CHARS = 1500;
 const RESUME_TURN_MAX_CHARS = 220;

--- a/app/functions/api/voice/session/[id].js
+++ b/app/functions/api/voice/session/[id].js
@@ -51,7 +51,7 @@ export async function onRequest(context) {
     const d1User = await getOrCreateUserByAuthId(env, uid, null, { updateActivity: false });
     const session = await db.prepare(
       `SELECT id, user_id, role, seniority, status, entitlement_mode, started_at, ended_at,
-              duration_seconds, transcript_json, scorecard_json
+              duration_seconds, transcript_json, scorecard_json, end_reason
        FROM voice_sessions WHERE id = ?`
     ).bind(String(params.id || '')).first();
 
@@ -86,6 +86,7 @@ export async function onRequest(context) {
         scorecardReady: true,
         fullAccess: false,
         expired: true,
+        endReason: session.end_reason || null,
         scorecard: {
           topStrength: scorecard?.topStrength ?? null,
           topImprovement: scorecard?.topImprovement ?? null
@@ -120,6 +121,7 @@ export async function onRequest(context) {
       endedAt: session.ended_at,
       durationSeconds: session.duration_seconds,
       scorecardReady: !!scorecard,
+      endReason: session.end_reason || null,
       fullAccess,
       scorecard: fullAccess ? scorecard : partialScorecard(scorecard),
       transcript

--- a/app/functions/api/voice/session/[id]/complete.js
+++ b/app/functions/api/voice/session/[id]/complete.js
@@ -10,7 +10,7 @@
 import { getBearer, verifyFirebaseIdToken } from '../../../../_lib/firebase-auth.js';
 import { getOrCreateUserByAuthId, getDb } from '../../../../_lib/db.js';
 import { voiceFeatureEnabled } from '../../../../_lib/voice-entitlements.js';
-import { normalizeEndReason } from '../../../../_lib/voice-interviewer.js';
+import { normalizeEndReason, shouldGenerateScorecard } from '../../../../_lib/voice-interviewer.js';
 import { generateAndStoreScorecard } from '../../../../_lib/voice-scorecard.js';
 import { errorResponse, successResponse, generateRequestId } from '../../../../_lib/error-handler.js';
 
@@ -53,16 +53,19 @@ export async function onRequest(context) {
     const d1User = await getOrCreateUserByAuthId(env, uid, null, { updateActivity: false });
     const sessionId = String(params.id || '');
     const session = await db.prepare(
-      `SELECT id, user_id, status, transcript_json FROM voice_sessions WHERE id = ?`
+      `SELECT id, user_id, status, transcript_json, end_reason FROM voice_sessions WHERE id = ?`
     ).bind(sessionId).first();
 
     if (!session || !d1User || session.user_id !== d1User.id) {
       return errorResponse('Session not found', 404, origin, env, requestId);
     }
     if (session.status === 'completed' && session.transcript_json) {
-      // Idempotent: keep the original completion, still ensure a scorecard exists
-      context.waitUntil(generateAndStoreScorecard(env, sessionId));
-      return successResponse({ sessionId, status: 'completed', alreadyCompleted: true }, 200, origin, env, requestId);
+      // Idempotent: keep the original completion, still ensure a scorecard
+      // exists — except for a safety-ended session, which is never scored.
+      if (shouldGenerateScorecard(session.end_reason)) {
+        context.waitUntil(generateAndStoreScorecard(env, sessionId));
+      }
+      return successResponse({ sessionId, status: 'completed', alreadyCompleted: true, endReason: session.end_reason || null }, 200, origin, env, requestId);
     }
 
     // Transcript: [{ speaker: 'user'|'assistant', text: '...' }, ...]
@@ -117,10 +120,15 @@ export async function onRequest(context) {
       console.warn(`[VOICE-CONDUCT] session=${sessionId} uid=${uid} end=${endReason}`);
     }
 
-    // Scorecard generation off the request path; client polls the session GET
-    context.waitUntil(generateAndStoreScorecard(env, sessionId));
+    // Scorecard generation off the request path; client polls the session GET.
+    // A safety-ended session is never scored (see shouldGenerateScorecard).
+    if (shouldGenerateScorecard(endReason)) {
+      context.waitUntil(generateAndStoreScorecard(env, sessionId));
+    } else {
+      console.log(`[VOICE-SAFETY] session=${sessionId} scorecard suppressed (ended_for_safety)`);
+    }
 
-    return successResponse({ sessionId, status: 'completed', costUsd }, 200, origin, env, requestId);
+    return successResponse({ sessionId, status: 'completed', costUsd, endReason }, 200, origin, env, requestId);
   } catch (err) {
     console.error('[VOICE-COMPLETE] Error:', err?.message || err);
     return errorResponse('Internal error', 500, origin, env, requestId);

--- a/js/voice-conduct.js
+++ b/js/voice-conduct.js
@@ -157,6 +157,46 @@ export function isSafetyReferral(text) {
 }
 
 /**
+ * Does this INTERVIEWER utterance contain the conduct-warning register — the
+ * "that's not language I'll continue an interview through" line?
+ *
+ * Same rationale as isSafetyReferral: the model speaks the warning and skips
+ * the tool, so the spoken line has to count. Detection alone never ends a
+ * session — it can record the one warning, and only a SECOND independent
+ * conduct signal (another spoken warning or a tool call, from a different
+ * response) closes it.
+ *
+ * Patterns are deliberately narrow, all in non-question sentences:
+ *   - "not language ..." (the mandated register)
+ *   - a refusal verb + continue/tolerate/accept + language ("I will not
+ *     continue the interview through that language")
+ *   - "that language has no place / doesn't belong / isn't acceptable ..."
+ *     anchored to interview/professional context, so programming-language
+ *     talk ("that language is not appropriate for this project") stays out
+ *   - "won't be spoken to / talked to (that way)"
+ *   - "keep it professional" counts ONLY alongside "stop you there" — either
+ *     alone is everyday interviewer speech ("let me stop you there — what was
+ *     the outcome?" is an interruption, not a warning)
+ */
+export function isConductWarningLine(text) {
+  if (typeof text !== 'string' || text.length < 12) return false;
+  var sentences = text.replace(/([.!?])/g, '$1\n').split('\n');
+  var keepProfessional = false;
+  var stopYouThere = false;
+  for (var i = 0; i < sentences.length; i++) {
+    var s = sentences[i].toLowerCase();
+    if (!s || s.indexOf('?') >= 0) continue;
+    if (/\bnot language\b/.test(s)) return true;
+    if (/\b(?:won'?t|will not|would not|wouldn'?t|not going to|refuse to|cannot|can'?t)\b[^]{0,30}\b(?:continue|tolerate|accept|take|allow|put up with|listen to)\b[^]{0,40}\b(?:language|kind of talk|talk like that)\b/.test(s)) return true;
+    if (/\b(?:that|this|such) (?:language|kind of talk)\b[^]{0,50}\b(?:no place|doesn'?t belong|does not belong|not acceptable|isn'?t acceptable|not appropriate|isn'?t appropriate)\b[^]{0,40}\b(?:interview|professional|here)\b/.test(s)) return true;
+    if (/\b(?:won'?t|will not|not going to) (?:be )?(?:spoken|talked) to\b/.test(s)) return true;
+    if (/\bkeep (?:it|this|things) professional\b/.test(s)) keepProfessional = true;
+    if (/\bstop you (?:right )?there\b/.test(s)) stopYouThere = true;
+  }
+  return keepProfessional && stopYouThere;
+}
+
+/**
  * The only realtime events allowed to mark "the candidate spoke again".
  *
  * Both fire live, while the candidate is at the microphone, and both precede the
@@ -196,19 +236,18 @@ export function createConductGate() {
    * defense. It is deliberately NOT the only one; see the note above.
    */
   // A repeat call once warned escalates to the end only when it is a genuine
-  // second incident, judged by two independent signals:
-  //   1. the candidate spoke again since the warning (live mic events), and
-  //   2. the call came from a DIFFERENT response than the warning itself.
-  // The second signal is what keeps replays inert even through mic noise:
-  // `speech_started` can fire on a cough or speaker bleed, but a replay is by
-  // definition the same response re-surfacing, while a real second incident is
-  // always a fresh response (the model only speaks again after a new candidate
-  // turn). When either response id is unknown, the speech guard alone decides,
-  // which keeps escalation working on API shapes that omit the id.
+  // second incident. The PRIMARY discriminator is response identity: a replay
+  // is the same response re-surfacing, while a real second incident is always
+  // a fresh response, because the model only speaks again after a new
+  // candidate turn. The live speech guard is only the FALLBACK for events
+  // that omit response ids — it must never be a second requirement, because
+  // requiring both meant that if `input_audio_buffer` events were not
+  // delivered, every repeat call was ignored and answered with an instruction
+  // to continue: the fully-armed gate produced exactly the endless-warnings
+  // failure it existed to prevent.
   function isSecondIncident(responseId) {
-    if (!spokeSinceWarning) return false;
-    if (responseId && warnResponseId && responseId === warnResponseId) return false;
-    return true;
+    if (responseId && warnResponseId) return responseId !== warnResponseId;
+    return spokeSinceWarning;
   }
 
   function decide(stage, callId, responseId) {
@@ -252,6 +291,33 @@ export function createConductGate() {
   }
 
   /**
+   * A conduct warning the interviewer SPOKE without reporting it through the
+   * tool. Live, the model said the warning register repeatedly and never
+   * called conduct_action once, so the gate never heard about any of it and
+   * the session could not end — the same skip-the-tool behavior that broke
+   * the safety close, fixed the same way: the spoken line is the decision.
+   * Returns 'warn' (first warning recorded), 'end' (second incident: close
+   * the session), or 'ignore' (duplicate transcript event, same response as
+   * the recorded warning, or no way to prove a second incident).
+   */
+  function noteSpokenWarning(responseId) {
+    if (ended) return 'ignore';
+    if (!warned) {
+      warned = true;
+      spokeSinceWarning = false;
+      warnResponseId = responseId || '';
+      return 'warn';
+    }
+    // The same response's own spoken line (or its duplicate transcript event)
+    // is the warning we already have, not a second one.
+    if (responseId && warnResponseId && responseId === warnResponseId) return 'ignore';
+    // Ids incomplete: only end with independent evidence of a second incident.
+    if (!(responseId && warnResponseId) && !spokeSinceWarning) return 'ignore';
+    ended = true;
+    return 'end';
+  }
+
+  /**
    * The candidate started or finished speaking, per `eventType`. Only the live
    * events in LIVE_CANDIDATE_SPEECH_EVENTS count; anything else — notably a late
    * whisper transcript, which may describe pre-warning audio — is rejected here
@@ -283,6 +349,7 @@ export function createConductGate() {
 
   return {
     decide: decide,
+    noteSpokenWarning: noteSpokenWarning,
     noteCandidateSpoke: noteCandidateSpoke,
     endReason: endReason,
     wasWarned: wasWarned,
@@ -409,4 +476,5 @@ if (typeof window !== 'undefined') {
   window.createClosingTurnGate = createClosingTurnGate;
   window.readVoiceToolCall = readToolCall;
   window.isSafetyReferral = isSafetyReferral;
+  window.isConductWarningLine = isConductWarningLine;
 }

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -884,8 +884,15 @@
 
     show('vi-done-view');
     var doneStatus = $('vi-done-status');
-    if (doneStatus) doneStatus.textContent = 'We\'re reviewing your conversation using our S + A = O formula and interview rubric. This usually takes a few seconds.';
-    historyLiveScoring();
+    var isSafetyEnd = reason === 'ended_for_safety';
+    if (isSafetyEnd) {
+      // The safety view goes up immediately: no S+A=O copy, no scoring state,
+      // whatever happens to the save below.
+      renderSafetyEnd(null);
+    } else {
+      if (doneStatus) doneStatus.textContent = 'We\'re reviewing your conversation using our S + A = O formula and interview rubric. This usually takes a few seconds.';
+      historyLiveScoring();
+    }
 
     // Let any transcript still in flight land before the channel closes; the
     // wait is bounded and a timeout just means we store what we already have.
@@ -904,16 +911,21 @@
         })
       });
       track('voice_session_complete', { duration_seconds: durationSeconds, reason: reason || 'user_ended' });
-      if (reason === 'ended_for_safety') {
-        // No score exists for ending an interview to reach real help; polling
-        // would wait for a scorecard the server deliberately never generates.
-        renderSafetyEnd(null);
+      if (isSafetyEnd) {
+        // Already showing the safety view; no polling for a scorecard the
+        // server deliberately never generates.
         historyLiveClear(true);
         return;
       }
       pollScorecard(0);
     } catch (err) {
       console.error('[VOICE] complete failed:', err);
+      if (isSafetyEnd) {
+        // The safety view stays up regardless — never replace it with
+        // score-oriented error copy.
+        historyLiveClear(false);
+        return;
+      }
       if (doneStatus) doneStatus.textContent = 'The session ended but saving failed. Your session is recorded; check back shortly.';
       historyLiveClear(false);
     }
@@ -1227,6 +1239,11 @@
     // carve-out row reports 'scoring' (no stored scorecard) forever.
     if (!item.reportAvailable) {
       return '<span class="vi-history-chip vi-history-chip--partial">' + HISTORY_LOCK_SVG + 'Partial</span>';
+    }
+    // A safety-ended session has no report by design: never show it as
+    // scoring, never show a score.
+    if (item.status === 'safety' || item.endReason === 'ended_for_safety') {
+      return '<span class="vi-history-chip vi-history-chip--partial">Safety</span>';
     }
     // A report still being scored is 'Scoring…' even without full access —
     // the Partial lock only applies once there is a report to lock.

--- a/js/voice-interview.js
+++ b/js/voice-interview.js
@@ -294,13 +294,29 @@
             if (stage === 'end') { deviated = true; return 'warn_instead'; }
             return 'warn';
           }
-          if (!spoke) return 'ignore';
-          // Same response as the warning = a replay, not a second incident
-          if (responseId && warnResponseId && responseId === warnResponseId) return 'ignore';
+          // Response identity first; speech guard only when ids are missing
+          if (responseId && warnResponseId) {
+            if (responseId === warnResponseId) return 'ignore';
+          } else if (!spoke) {
+            return 'ignore';
+          }
           ended = true;
           return 'end';
         }
         return 'ignore';
+      },
+      noteSpokenWarning: function (responseId) {
+        if (ended) return 'ignore';
+        if (!warned) {
+          warned = true;
+          spoke = false;
+          warnResponseId = responseId || '';
+          return 'warn';
+        }
+        if (responseId && warnResponseId && responseId === warnResponseId) return 'ignore';
+        if (!(responseId && warnResponseId) && !spoke) return 'ignore';
+        ended = true;
+        return 'end';
       },
       noteCandidateSpoke: function (eventType) {
         if (eventType !== 'input_audio_buffer.speech_started' &&
@@ -359,6 +375,57 @@
     return false;
   }
 
+  // Hand-synced copy of isConductWarningLine for the module-missing case.
+  function fallbackIsConductWarningLine(text) {
+    if (typeof text !== 'string' || text.length < 12) return false;
+    var sentences = text.replace(/([.!?])/g, '$1\n').split('\n');
+    var keepProfessional = false;
+    var stopYouThere = false;
+    for (var i = 0; i < sentences.length; i++) {
+      var t = sentences[i].toLowerCase();
+      if (!t || t.indexOf('?') >= 0) continue;
+      if (/\bnot language\b/.test(t)) return true;
+      if (/\b(?:won'?t|will not|would not|wouldn'?t|not going to|refuse to|cannot|can'?t)\b[^]{0,30}\b(?:continue|tolerate|accept|take|allow|put up with|listen to)\b[^]{0,40}\b(?:language|kind of talk|talk like that)\b/.test(t)) return true;
+      if (/\b(?:that|this|such) (?:language|kind of talk)\b[^]{0,50}\b(?:no place|doesn'?t belong|does not belong|not acceptable|isn'?t acceptable|not appropriate|isn'?t appropriate)\b[^]{0,40}\b(?:interview|professional|here)\b/.test(t)) return true;
+      if (/\b(?:won'?t|will not|not going to) (?:be )?(?:spoken|talked) to\b/.test(t)) return true;
+      if (/\bkeep (?:it|this|things) professional\b/.test(t)) keepProfessional = true;
+      if (/\bstop you (?:right )?there\b/.test(t)) stopYouThere = true;
+    }
+    return keepProfessional && stopYouThere;
+  }
+
+  // The conduct twin of the safety backstop, and the fix for the live failure:
+  // the interviewer spoke the warning register repeatedly and never called
+  // conduct_action once, so the gate never heard about any of it and the
+  // session could not end. The spoken line now counts. Detection alone never
+  // ends a session — the first hit records the one warning, and only a second
+  // conduct signal from a DIFFERENT response closes it, after which her line
+  // finishes playing and the session tears down: no further question is
+  // possible.
+  function maybeConductBackstop(transcript, responseId) {
+    if (state.ending || state.conductEnd) return;
+    var check;
+    if (typeof window.isConductWarningLine === 'function') {
+      check = window.isConductWarningLine;
+    } else {
+      reportConductModuleMissing();
+      check = fallbackIsConductWarningLine;
+    }
+    if (!check(String(transcript || ''))) return;
+    if (!state.conduct) state.conduct = newConductGate();
+    var decision = state.conduct.noteSpokenWarning(responseId || '');
+    if (decision === 'warn') {
+      console.warn('[VOICE] spoken conduct warning noted (no tool call)');
+      track('voice_conduct_action', { stage: 'warning_spoken' });
+      return;
+    }
+    if (decision === 'end') {
+      console.warn('[VOICE] second conduct violation; closing the session');
+      track('voice_conduct_action', { stage: 'end', via: 'spoken_warning' });
+      requestGuardedEnd('conduct', responseId || '');
+    }
+  }
+
   function maybeSafetyBackstop(transcript, responseId) {
     if (state.ending || state.conductEnd) return;
     var check;
@@ -387,7 +454,7 @@
       // stall the turns that follow. Replays are absorbed by the ledger above.
       answerToolCall(call.callId, {
         ok: false,
-        error: 'No action taken. Continue the interview.',
+        error: 'Duplicate or unactionable call; no action taken.',
         interview_continues: true
       });
       return;
@@ -520,6 +587,7 @@
     // GA + beta event names for assistant transcript
     if (type === 'response.output_audio_transcript.done' || type === 'response.audio_transcript.done') {
       recordTurn('assistant', evt.transcript, evt.item_id);
+      maybeConductBackstop(evt.transcript, evt.response_id);
       maybeSafetyBackstop(evt.transcript, evt.response_id);
       return;
     }
@@ -836,6 +904,13 @@
         })
       });
       track('voice_session_complete', { duration_seconds: durationSeconds, reason: reason || 'user_ended' });
+      if (reason === 'ended_for_safety') {
+        // No score exists for ending an interview to reach real help; polling
+        // would wait for a scorecard the server deliberately never generates.
+        renderSafetyEnd(null);
+        historyLiveClear(true);
+        return;
+      }
       pollScorecard(0);
     } catch (err) {
       console.error('[VOICE] complete failed:', err);
@@ -856,6 +931,11 @@
     setTimeout(async function () {
       try {
         var res = await api('/api/voice/session/' + encodeURIComponent(state.sessionId), { method: 'GET' });
+        if (res.ok && res.data && res.data.endReason === 'ended_for_safety') {
+          renderScorecard(res.data);
+          historyOnScorecardReady();
+          return;
+        }
         if (res.ok && res.data && res.data.scorecardReady) {
           renderScorecard(res.data);
           historyOnScorecardReady();
@@ -916,7 +996,31 @@
     return '<p class="vi-sc-saved">' + escapeHtml(parts.join(' · ')) + '</p>';
   }
 
+  // The report view for a safety-ended session. Deliberately scoreless: the
+  // candidate disclosed a crisis, not interview performance, and a real dev
+  // session's report framed the disclosure as unprofessional behavior. Never
+  // again — no score, no coaching, no professionalism framing.
+  function renderSafetyEnd(data) {
+    var doneStatus = $('vi-done-status');
+    if (doneStatus) doneStatus.style.display = 'none';
+    var wrap = $('vi-scorecard');
+    if (!wrap) return;
+    var html = '<h2 class="vi-sc-title">Interview ended early for safety</h2>';
+    html += '<p class="vi-sc-block">This session closed so you could reach real help, and that was the right way for it to end. No score is given for a safety-ended session, and nothing about it counts against you.</p>';
+    html += '<p class="vi-sc-block">If you are in immediate danger, contact emergency services now, or call or text 988 in the US.</p>';
+    html += '<p class="vi-sc-block">You are welcome back to practice whenever you are ready.</p>';
+    if (data) html += savedLine(data);
+    wrap.innerHTML = html;
+  }
+
   function renderScorecard(data) {
+    // A safety-ended session never renders as a scorecard, even if one was
+    // stored before suppression existed — that legacy report is the one that
+    // misframed the safety statement.
+    if (data && data.endReason === 'ended_for_safety') {
+      renderSafetyEnd(data);
+      return;
+    }
     var wrap = $('vi-scorecard');
     var doneStatus = $('vi-done-status');
     if (doneStatus) doneStatus.style.display = 'none';
@@ -1450,7 +1554,9 @@
     if (doneStatus) doneStatus.textContent = 'Loading your report...';
     try {
       var res = await api('/api/voice/session/' + encodeURIComponent(sessionId), { method: 'GET' });
-      if (res.ok && res.data && res.data.scorecardReady) {
+      if (res.ok && res.data && res.data.endReason === 'ended_for_safety') {
+        renderScorecard(res.data);   // renders the safety view, never polls
+      } else if (res.ok && res.data && res.data.scorecardReady) {
         renderScorecard(res.data);
       } else if (res.ok) {
         pollScorecard(0);

--- a/voice-interview.html
+++ b/voice-interview.html
@@ -466,7 +466,7 @@
   <script src="js/main.js" type="module"></script>
   <script src="js/role-selector.js" type="module"></script>
   <script src="js/voice-transcript-order.js?v=20260725-2" type="module"></script>
-  <script src="js/voice-conduct.js?v=20260725-2" type="module"></script>
-  <script src="js/voice-interview.js?v=20260725-2" defer></script>
+  <script src="js/voice-conduct.js?v=20260725-3" type="module"></script>
+  <script src="js/voice-interview.js?v=20260725-3" defer></script>
 </body>
 </html>


### PR DESCRIPTION
# Release-gate patch: the two confirmed failures from the second live dev test

No schema changes. Migration 021 already covers everything this touches.

## Deployment verified first

`dev.jobhackai.io/voice-interview` serves the current `?v=20260725-2` files and the served `voice-conduct.js` contains the merged escalation — the observed conduct failure was real behavior in current code, not a stale deploy. (The safety close working in the same test confirms the new client was live.)

## Failure 1 — repeated abuse never ended the session

**Two compounding causes.** The model spoke the warning register repeatedly and never called `conduct_action` once — the same skip-the-tool behavior that broke the safety close, which works live *precisely because it has a transcript backstop*; conduct had none, so the gate never heard a single warning. And even when the tool is called, escalation required live speech events **and** a new response: if `input_audio_buffer` events are not delivered, every repeat call was ignored and answered with the literal instruction *"Continue the interview."* — the fully-armed gate could produce the endless-warning loop itself.

**Fix:**
- **Spoken warnings count.** `isConductWarningLine` detects the warning register in interviewer transcripts (narrow patterns; questions excluded; "stop you there" and "keep it professional" only count *together*, so interrupting a rambling answer can never trip it). The first hit records the one warning; a second conduct signal — spoken or tool — from a **different response** closes the session.
- **Response identity is now the primary second-incident discriminator**; the speech guard is demoted to a fallback for events that omit response ids. A replay is the same response re-surfacing; a real second incident is always a fresh response.
- The ignore answer no longer instructs the model to continue.

**Expected live behavior:** first directed insult → one warning, interview continues. Second directed insult → whether she reports it via the tool **or merely says the warning line again**, the session closes: her line for that incident finishes playing, then teardown — the channel is closed, so **no further question is possible**. `end_reason = ended_by_interviewer`.

**Residual to watch:** the spoken path keys on the warning register. If she paraphrases past all patterns *and* skips the tool, the spoken backstop misses (tool path and prompt still apply). If a retest hits this, capture her exact wording and the patterns get extended from it.

## Failure 2 — safety session scored; disclosure framed as unprofessional

**Cause:** `/complete` generated a scorecard unconditionally, and a scorer that only knows S/A/O graded a crisis disclosure.

**Fix:** safety sessions are never scored. `shouldGenerateScorecard` gates both `/complete` paths (fresh + idempotent replay); the session GET exposes `endReason`; the client renders **"Interview ended early for safety"** — scoreless, "nothing about it counts against you", emergency services/988 restated — instead of polling for a report that will never exist. The guard is on `endReason`, so the already-stored misframing report from the failed test renders the safety view too and is never shown again. Suppression chosen over a "partial report" because any pre-interruption scoring still passes crisis-adjacent content through the scorer.

**Expected live behavior:** crisis signal → guidance → session closes → the safety notice appears immediately: no score, no "reviewing your conversation" spinner, no score in the history rail. `end_reason = ended_for_safety`.

## Failure 3 — SAO 85% outcome target: intentional, unchanged

Three surfaces agree: the voice scorecard prompt mandates 5/10/85 as the graded formula, the pre-existing mock-interview scorer (`app/functions/api/mock-interview/score.js:89`) uses the same target as "coaching guidance, not a hard penalty", and the setup page cue strip teaches "≈ 85% — results, numbers". This is the branded S+A=O formula, not a bug; revisiting it is a product decision across three surfaces and deliberately out of scope here.

## Test evidence (Node 18, same as CI)

| Suite | Result | Key additions |
|---|---|---|
| `voice-conduct` | **64 passed, 0 failed** | **`LIVE REGRESSION: insult, warning, second insult, spoken warning — session ends, then silence`** (the exact observed sequence) · `purely spoken warnings, never a single tool call` · `dead speech events cannot silence tool escalation` · `spoken warning + duplicate transcript event stay ONE warning` · warning-register detector positives/negatives (interruptions, programming-language talk, questions all stay out) |
| `voice-interviewer` | **26 passed, 0 failed** | `a safety-terminated session is never conventionally scored` (all other reasons, incl. conduct, still scored; legacy null rows unchanged) |
| `voice-transcript-order` / `voice-entitlements` / `voice-history` | 27 / 20 / 14, 0 failed | untouched |

Nothing else changed: no report/UI work beyond the requested safety view, no speaker-attribution changes, no schema changes. Script versions bumped to `?v=20260725-3` for the two changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PRjXnEuZdGXs9DgSxGJae

---
_Generated by [Claude Code](https://claude.ai/code/session_019PRjXnEuZdGXs9DgSxGJae)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live session teardown, conduct escalation, and scorecard generation for crisis endings—user-facing safety and moderation paths—with broad test coverage but no schema migration.
> 
> **Overview**
> Fixes two live release-gate failures: conduct abuse sessions that never closed, and safety-ended sessions that were scored and mis-framed.
> 
> **Conduct:** Adds `isConductWarningLine` and `noteSpokenWarning` so spoken warning lines count when the model skips `conduct_action`, mirroring the safety transcript backstop. Escalation to end now treats **different response IDs** as the primary second-incident signal; live speech is only a fallback when IDs are missing, so missing `input_audio_buffer` events no longer block tool-based ends or invite endless warnings. The client wires `maybeConductBackstop` on assistant transcripts and stops telling the model to "continue" on ignored tool calls.
> 
> **Safety scoring:** Introduces `shouldGenerateScorecard` to skip scorecard generation on `/complete` (including idempotent replays) when `end_reason` is `ended_for_safety`. History lists those rows as status **`safety`** (not perpetual **Scoring…**), hides legacy stored scores, and exposes `endReason` on session GET. The client shows a dedicated safety end view immediately—no S+A=O spinner—and history chips label **Safety**.
> 
> Script cache bust: `voice-conduct.js` / `voice-interview.js` → `?v=20260725-3`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3fed38e5d04eec2dca641812cad570525d6a4f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->