### PR TITLE
fix(roles): visible role dropdown with real keyboard support

### DIFF
--- a/.github/workflows/test-ats-scoring.yml
+++ b/.github/workflows/test-ats-scoring.yml
@@ -10,6 +10,7 @@ on:
       # without these paths they could break untested.
       - 'js/voice-transcript-order.js'
       - 'js/voice-conduct.js'
+      - 'js/role-selector.js'
       - 'js/package.json'
   pull_request:
     branches: [main, dev0]
@@ -20,6 +21,7 @@ on:
       # without these paths they could break untested.
       - 'js/voice-transcript-order.js'
       - 'js/voice-conduct.js'
+      - 'js/role-selector.js'
       - 'js/package.json'
 
 jobs:
@@ -71,6 +73,10 @@ jobs:
       - name: Run voice conduct gate tests
         working-directory: app/functions/_lib/__tests__
         run: node voice-conduct.test.mjs
+
+      - name: Run role selector helper tests
+        working-directory: app/functions/_lib/__tests__
+        run: node role-selector.test.mjs
 
       - name: Run voice entitlement tests
         working-directory: app/functions/_lib/__tests__

--- a/app/functions/_lib/__tests__/role-selector.test.mjs
+++ b/app/functions/_lib/__tests__/role-selector.test.mjs
@@ -1,0 +1,82 @@
+// Role selector helper test suite (standalone, no framework)
+// Run: node app/functions/_lib/__tests__/role-selector.test.mjs
+//
+// The dropdown itself is DOM-bound and verified manually; these cover the
+// pure pieces the fix extracted so they stay testable: the suggestion
+// filter, the match highlighting (with HTML escaping), and the category
+// label. Keyboard navigation and positioning live in the browser component.
+
+import assert from 'node:assert/strict';
+import {
+  filterRoles,
+  escapeHtmlText,
+  highlightRoleMatch,
+  prettyCategory
+} from '../../../../js/role-selector.js';
+
+let passed = 0;
+let failed = 0;
+function test(name, fn) {
+  try { fn(); passed++; console.log(`  ✓ ${name}`); }
+  catch (err) { failed++; console.error(`  ✗ ${name}\n    ${err.message}`); }
+}
+
+const ROLES = [
+  { name: 'Software Engineer', category: 'software_engineering' },
+  { name: 'Product Manager', category: 'product_management' },
+  { name: 'Product Owner', category: 'product_management' },
+  { name: 'Data Engineer', category: 'data_engineering' },
+  { name: 'Machine Learning Engineer', category: 'ml_engineering' }
+];
+
+test('filterRoles matches case-insensitive substrings anywhere in the name', () => {
+  assert.deepEqual(filterRoles(ROLES, 'product', 8).map((r) => r.name),
+    ['Product Manager', 'Product Owner']);
+  assert.deepEqual(filterRoles(ROLES, 'ENGINEER', 8).map((r) => r.name),
+    ['Software Engineer', 'Data Engineer', 'Machine Learning Engineer']);
+  assert.deepEqual(filterRoles(ROLES, 'learning', 8).map((r) => r.name),
+    ['Machine Learning Engineer']);
+});
+
+test('filterRoles caps at maxResults', () => {
+  assert.equal(filterRoles(ROLES, 'engineer', 2).length, 2);
+});
+
+test('filterRoles tolerates junk input without throwing', () => {
+  assert.deepEqual(filterRoles(ROLES, '', 8), []);
+  assert.deepEqual(filterRoles(ROLES, '   ', 8), []);
+  assert.deepEqual(filterRoles(null, 'product', 8), []);
+  assert.deepEqual(filterRoles([{ nope: true }, null], 'product', 8), []);
+});
+
+test('highlightRoleMatch wraps the matched span in <strong>', () => {
+  assert.equal(highlightRoleMatch('Product Manager', 'duct'),
+    'Pro<strong>duct</strong> Manager');
+  // Case preserved from the role name, matched case-insensitively
+  assert.equal(highlightRoleMatch('Product Manager', 'PRODUCT'),
+    '<strong>Product</strong> Manager');
+});
+
+test('highlightRoleMatch escapes HTML in both role text and query', () => {
+  // A role name containing markup-significant characters renders inert
+  assert.equal(highlightRoleMatch('R&D <Lead>', 'lead'),
+    'R&amp;D &lt;<strong>Lead</strong>&gt;');
+  // A query that matches nothing still comes back fully escaped
+  assert.equal(highlightRoleMatch('<script>alert(1)</script>', 'zzz'),
+    '&lt;script&gt;alert(1)&lt;/script&gt;');
+});
+
+test('escapeHtmlText covers the five specials and rejects non-strings', () => {
+  assert.equal(escapeHtmlText(`&<>"'`), '&amp;&lt;&gt;&quot;&#39;');
+  assert.equal(escapeHtmlText(null), '');
+  assert.equal(escapeHtmlText(42), '');
+});
+
+test('prettyCategory turns snake_case into readable text', () => {
+  assert.equal(prettyCategory('software_engineering'), 'software engineering');
+  assert.equal(prettyCategory('general'), 'general');
+  assert.equal(prettyCategory(null), '');
+});
+
+console.log(`\n${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/js/role-selector.js
+++ b/js/role-selector.js
@@ -43,6 +43,50 @@ function unbindRoleSelectorDocumentListenersIfUnused() {
   roleSelectorDocumentListenersBound = false;
 }
 
+// ---- Pure helpers (exported for Node tests; no DOM dependencies) ----
+
+/** Case-insensitive substring filter over role names, capped at maxResults. */
+export function filterRoles(roles, rawQuery, maxResults) {
+  const query = String(rawQuery || '').toLowerCase().trim();
+  if (!query) return [];
+  return (roles || [])
+    .filter((role) => role && typeof role.name === 'string' && role.name.toLowerCase().includes(query))
+    .slice(0, maxResults);
+}
+
+/** HTML-escape without a DOM, so highlighting is testable in Node. */
+export function escapeHtmlText(text) {
+  if (typeof text !== 'string') return '';
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+/**
+ * Wrap the matched span in <strong>, escaping each part separately so entity
+ * encoding cannot shift the match position.
+ */
+export function highlightRoleMatch(text, query) {
+  const safeText = typeof text === 'string' ? text : '';
+  const trimmed = String(query || '').trim();
+  if (!trimmed) return escapeHtmlText(safeText);
+  const index = safeText.toLowerCase().indexOf(trimmed.toLowerCase());
+  if (index === -1) return escapeHtmlText(safeText);
+  const before = safeText.substring(0, index);
+  const match = safeText.substring(index, index + trimmed.length);
+  const after = safeText.substring(index + trimmed.length);
+  return `${escapeHtmlText(before)}<strong>${escapeHtmlText(match)}</strong>${escapeHtmlText(after)}`;
+}
+
+/** "software_engineering" -> "software engineering" for the category line. */
+export function prettyCategory(category) {
+  if (typeof category !== 'string') return '';
+  return category.replace(/_/g, ' ').trim();
+}
+
 /**
  * Role Selector Component
  * Loads roles from /api/roles endpoint with fallback to pre-seeded list
@@ -60,6 +104,8 @@ export class RoleSelector {
     this.roles = [];
     this.recentSelections = this.loadRecentSelections();
     this.dropdown = null;
+    this.activeIndex = -1;
+    this.optionEls = [];
     this.blurHideTimeout = null;
     this.isDestroyed = false;
     this.handleDocumentPointerDown = this.handleDocumentPointerDown.bind(this);
@@ -88,17 +134,34 @@ export class RoleSelector {
 
   createDropdown() {
     if (!this.input || !this.input.parentNode) return;
+
+    // The dropdown is absolutely positioned against its nearest positioned
+    // ancestor. Pages that wrap the input in a position:relative container get
+    // it beneath the field; pages that do not (the voice interview page's
+    // plain .vi-field) had the dropdown anchor to some distant ancestor and
+    // render nowhere near the input - suggestions existed but were effectively
+    // invisible. Make the parent the positioning context ourselves, so the
+    // component works on every page without page CSS knowing about it.
+    const parent = this.input.parentNode;
+    try {
+      if (parent instanceof Element && getComputedStyle(parent).position === 'static') {
+        parent.style.position = 'relative';
+      }
+    } catch (_) { /* getComputedStyle can throw on detached nodes; harmless */ }
+
     this.dropdown = document.createElement('div');
     this.dropdown.className = 'role-selector-dropdown';
+    this.dropdown.setAttribute('role', 'listbox');
+    if (this.input.id) this.dropdown.id = this.input.id + '-listbox';
     this.dropdown.style.cssText = `
       position: absolute;
       top: 100%;
       left: 0;
       right: 0;
       background: #fff;
-      border: 1px solid #E5E7EB;
-      border-radius: 8px;
-      box-shadow: 0 4px 16px rgba(0, 0, 0, 0.1);
+      border: 1px solid #CBD5E1;
+      border-radius: 10px;
+      box-shadow: 0 10px 28px rgba(15, 23, 42, 0.18);
       max-height: 300px;
       overflow-y: auto;
       z-index: 1000;
@@ -200,13 +263,61 @@ export class RoleSelector {
 
   handleInputKeyDown(event) {
     if (this.isDestroyed) return;
-    if (event.key === 'ArrowDown' || event.key === 'ArrowUp' || event.key === 'Enter') {
+    const open = this.isDropdownOpen();
+
+    if (event.key === 'ArrowDown') {
+      // Closed + enough characters: ArrowDown opens the suggestions
+      if (!open) {
+        if (this.input && this.input.value.trim().length >= this.options.minChars) {
+          event.preventDefault();
+          this.handleInput(this.input.value);
+          this.setActive(0);
+        }
+        return;
+      }
       event.preventDefault();
-      this.handleKeyboard(event.key);
+      this.setActive(this.activeIndex + 1);
+      return;
+    }
+    if (event.key === 'ArrowUp') {
+      if (!open) return;
+      event.preventDefault();
+      this.setActive(this.activeIndex <= 0 ? this.optionEls.length - 1 : this.activeIndex - 1);
+      return;
+    }
+    if (event.key === 'Enter') {
+      // Only claim Enter while the list is open; otherwise the page keeps it
+      if (!open || this.optionEls.length === 0) return;
+      event.preventDefault();
+      const target = this.optionEls[this.activeIndex >= 0 ? this.activeIndex : 0];
+      if (target) target.click();
       return;
     }
     if (event.key === 'Escape') {
       this.hideDropdown();
+    }
+  }
+
+  isDropdownOpen() {
+    return !!(this.dropdown && this.dropdown.style.display !== 'none');
+  }
+
+  // One active option, shared by hover and arrow keys, wrapping at both ends.
+  setActive(index) {
+    if (this.isDestroyed || this.optionEls.length === 0) return;
+    const count = this.optionEls.length;
+    const next = ((index % count) + count) % count;
+    this.activeIndex = next;
+    for (let i = 0; i < count; i++) {
+      const el = this.optionEls[i];
+      const active = i === next;
+      el.style.background = active ? '#E8F0FE' : (el.dataset.baseBg || '#fff');
+      el.setAttribute('aria-selected', active ? 'true' : 'false');
+    }
+    const activeEl = this.optionEls[next];
+    if (activeEl) {
+      if (activeEl.id && this.input) this.input.setAttribute('aria-activedescendant', activeEl.id);
+      if (typeof activeEl.scrollIntoView === 'function') activeEl.scrollIntoView({ block: 'nearest' });
     }
   }
 
@@ -235,9 +346,7 @@ export class RoleSelector {
       return;
     }
 
-    const matches = this.roles
-      .filter((role) => role.name.toLowerCase().includes(query))
-      .slice(0, this.options.maxResults);
+    const matches = filterRoles(this.roles, query, this.options.maxResults);
 
     if (matches.length > 0 || this.options.showCustomOption) {
       this.showDropdown(matches, value);
@@ -251,100 +360,78 @@ export class RoleSelector {
     const query = rawQuery.trim();
     this.dropdown.innerHTML = '';
     this.dropdown.style.display = 'block';
+    this.optionEls = [];
+    this.activeIndex = -1;
+    if (this.input) {
+      this.input.setAttribute('aria-expanded', 'true');
+      this.input.removeAttribute('aria-activedescendant');
+    }
 
-    matches.forEach((role, index) => {
+    const idBase = (this.input && this.input.id ? this.input.id : 'role') + '-option-';
+    const addOption = (el) => {
+      const index = this.optionEls.length;
+      el.id = idBase + index;
+      el.setAttribute('role', 'option');
+      el.setAttribute('aria-selected', 'false');
+      // Hover and arrow keys share one active state, so what the mouse
+      // highlights is exactly what Enter would pick.
+      el.addEventListener('mouseover', () => this.setActive(index));
+      this.optionEls.push(el);
+      this.dropdown.appendChild(el);
+    };
+
+    matches.forEach((role) => {
       const optionDiv = document.createElement('div');
       optionDiv.className = 'role-option';
       optionDiv.dataset.role = role.name;
-      optionDiv.dataset.index = String(index);
+      optionDiv.dataset.baseBg = '#fff';
       optionDiv.style.cssText = `
         padding: 0.75rem 1rem;
         cursor: pointer;
         border-bottom: 1px solid #F3F4F6;
         transition: background 0.15s;
+        background: #fff;
       `;
 
-      optionDiv.addEventListener('mouseover', () => {
-        optionDiv.style.background = '#F9FAFB';
-      });
-      optionDiv.addEventListener('mouseout', () => {
-        optionDiv.style.background = '#fff';
-      });
-
       const nameDiv = document.createElement('div');
-      nameDiv.style.cssText = 'font-weight: 500; color: #1F2937;';
-      nameDiv.innerHTML = this.highlightMatch(role.name, query);
+      nameDiv.style.cssText = 'font-weight: 600; color: #111827; font-size: 1rem;';
+      nameDiv.innerHTML = highlightRoleMatch(role.name, query);
       optionDiv.appendChild(nameDiv);
 
-      if (role.category) {
+      const categoryLabel = prettyCategory(role.category);
+      if (categoryLabel) {
         const categoryDiv = document.createElement('div');
-        categoryDiv.style.cssText = 'font-size: 0.875rem; color: #6B7280; margin-top: 0.25rem;';
-        categoryDiv.textContent = role.category;
+        categoryDiv.style.cssText = 'font-size: 0.85rem; color: #4B5563; margin-top: 0.2rem;';
+        categoryDiv.textContent = categoryLabel;
         optionDiv.appendChild(categoryDiv);
       }
 
       optionDiv.addEventListener('click', () => {
-        this.selectRole(optionDiv.dataset.role === 'custom' ? query : optionDiv.dataset.role);
+        this.selectRole(optionDiv.dataset.role);
       });
 
-      this.dropdown.appendChild(optionDiv);
+      addOption(optionDiv);
     });
 
     if (this.options.showCustomOption) {
       const customDiv = document.createElement('div');
       customDiv.className = 'role-option role-custom';
       customDiv.dataset.role = 'custom';
+      customDiv.dataset.baseBg = '#F9FAFB';
       customDiv.style.cssText = `
         padding: 0.75rem 1rem;
         cursor: pointer;
         background: #F9FAFB;
         border-top: 2px solid #E5E7EB;
         font-style: italic;
-        color: #6B7280;
+        color: #4B5563;
       `;
-      customDiv.addEventListener('mouseover', () => {
-        customDiv.style.background = '#F3F4F6';
-      });
-      customDiv.addEventListener('mouseout', () => {
-        customDiv.style.background = '#F9FAFB';
-      });
       customDiv.textContent = `Use "${query}" as custom role`;
       customDiv.addEventListener('click', () => {
         this.selectRole(query);
       });
-      this.dropdown.appendChild(customDiv);
+      addOption(customDiv);
     }
-  }
-
-  highlightMatch(text, query) {
-    if (!query) {
-      return this.escapeHtml(text);
-    }
-
-    // Find match position in original text (case-insensitive)
-    const lowerText = text.toLowerCase();
-    const lowerQuery = query.toLowerCase();
-    const index = lowerText.indexOf(lowerQuery);
-    
-    if (index === -1) {
-      return this.escapeHtml(text);
-    }
-
-    // Split original text at match position, then escape each part separately
-    // This ensures correct highlighting even if text contains HTML entities
-    // We split first, then escape, to avoid position shifts from HTML entity encoding
-    const before = text.substring(0, index);
-    const match = text.substring(index, index + query.length);
-    const after = text.substring(index + query.length);
-
-    return `${this.escapeHtml(before)}<strong>${this.escapeHtml(match)}</strong>${this.escapeHtml(after)}`;
-  }
-
-  escapeHtml(text) {
-    if (typeof text !== 'string') return '';
-    const div = document.createElement('div');
-    div.textContent = text;
-    return div.innerHTML;
   }
 
   selectRole(roleName) {
@@ -406,15 +493,11 @@ export class RoleSelector {
     if (this.dropdown) {
       this.dropdown.style.display = 'none';
     }
-  }
-
-  handleKeyboard(key) {
-    if (this.isDestroyed || !this.dropdown) return;
-    const options = this.dropdown.querySelectorAll('.role-option');
-    if (options.length === 0) return;
-
-    if (key === 'Enter') {
-      options[0].click();
+    this.optionEls = [];
+    this.activeIndex = -1;
+    if (this.input) {
+      this.input.setAttribute('aria-expanded', 'false');
+      this.input.removeAttribute('aria-activedescendant');
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:voice:transcripts:unit": "node app/tests/voice-transcripts/unit.test.mjs",
     "test:voice:interviewer": "node app/functions/_lib/__tests__/voice-interviewer.test.mjs",
     "test:voice:transcript-order": "node app/functions/_lib/__tests__/voice-transcript-order.test.mjs",
-    "test:voice:conduct": "node app/functions/_lib/__tests__/voice-conduct.test.mjs"
+    "test:voice:conduct": "node app/functions/_lib/__tests__/voice-conduct.test.mjs",
+    "test:role-selector": "node app/functions/_lib/__tests__/role-selector.test.mjs"
   }
 }

--- a/voice-interview.html
+++ b/voice-interview.html
@@ -464,7 +464,7 @@
   <script src="js/universal-logout.js?v=20260208-1" defer></script>
   <script src="js/analytics.js" type="module"></script>
   <script src="js/main.js" type="module"></script>
-  <script src="js/role-selector.js" type="module"></script>
+  <script src="js/role-selector.js?v=20260726-1" type="module"></script>
   <script src="js/voice-transcript-order.js?v=20260725-2" type="module"></script>
   <script src="js/voice-conduct.js?v=20260725-3" type="module"></script>
   <script src="js/voice-interview.js?v=20260725-3" defer></script>


### PR DESCRIPTION
# Role autocomplete: visible, navigable, still free-text friendly

The Role field on the voice interview page behaved as freeform input even though suggestions existed internally. Two defects in the shared `RoleSelector`, both fixed in the component so every page benefits without page CSS changes.

## Why it was invisible

The dropdown is `position: absolute` and inserted into the input's parent — but positioning only works if some ancestor is positioned. `mock-interview.html` happens to wrap its input in `position: relative`, so it worked there; the voice page's plain `.vi-field` does not, so the dropdown anchored to a distant ancestor and rendered nowhere near the input. **Fix:** the component now makes its parent the positioning context itself (guarded — only when the parent is `static`), so it sits directly beneath the field on every page.

## Keyboard support was a stub

`ArrowUp`/`ArrowDown` were `preventDefault`'ed and did **nothing**; `Enter` always clicked the first option, and was swallowed even with the list closed. Now:

- **ArrowDown / ArrowUp** move a real active option, wrapping at both ends, scrolled into view; ArrowDown opens the list when it's closed and the input has ≥2 characters
- **Enter** selects the active option (first, if none yet) and is only claimed while the list is open — the page keeps Enter otherwise
- **Escape** closes the list (input-level and document-level)
- Hover and arrow keys share **one active state**, so what the mouse highlights is exactly what Enter picks
- `role="listbox"` / `role="option"`, `aria-expanded`, `aria-selected`, and `aria-activedescendant` are wired for screen readers

## Visuals

Stronger surface (clearer `#CBD5E1` border, deeper shadow, 10px radius), role name weighted up (`600`, `#111827`), category line readable — `software engineering`, not `software_engineering` — in legible gray, active option highlighted `#E8F0FE`. The **custom free-text option is unchanged** ("Use "…" as custom role") and participates in keyboard navigation as the last option.

## Changed files

| File | Change |
|---|---|
| `js/role-selector.js` | positioning fix, keyboard navigation, active state, aria, surface; filter/highlight/category extracted as pure exports |
| `app/functions/_lib/__tests__/role-selector.test.mjs` | **new** — 7 tests over the pure helpers |
| `voice-interview.html` | one line: cache-bust `js/role-selector.js?v=20260726-1` |
| `package.json` | `test:role-selector` script |
| `.github/workflows/test-ats-scoring.yml` | `js/role-selector.js` path filter + test step |

Deliberately untouched: conduct/safety logic, scoring formula, history behavior, pricing, and the other five pages that load this component (they pick the fix up on their normal cache cycle; only the voice page's tag is version-bumped).

## Tested

- New suite on Node 18 (same as CI): **role-selector 7/7** — case-insensitive substring filter with `maxResults` cap and junk tolerance; `<strong>` highlighting with HTML escaping on both text and query (`R&D <Lead>` renders inert); category prettifying.
- Full regression run on Node 18: voice-conduct 64, voice-interviewer 26, voice-transcript-order 27, voice-entitlements 20, voice-history 15 — all passing, all untouched.
- `node --check` on the component; DOM behavior (positioning, arrow keys, hover) is browser-only and covered by the Dev verification below.

## Dev verification steps

1. Hard-refresh `dev.jobhackai.io/voice-interview` (role-selector is now `?v=20260726-1`).
2. Type `pro` in the Role field → a bordered, shadowed dropdown appears **directly beneath the field** with role names (match bolded) and readable category lines, plus `Use "pro" as custom role` at the bottom.
3. **ArrowDown** twice → highlight visibly moves; **ArrowUp** wraps to the bottom from the top; **Enter** fills the field with the highlighted role and closes the list.
4. **Escape** closes the list; clicking anywhere outside closes it; hovering an option highlights the same way the arrows do.
5. Free text: type `Underwater Basket Weaver`, pick the custom option (mouse or arrows+Enter) → the field keeps the exact text; starting the interview works as before.
6. Regression sweep on one other page (e.g. `mock-interview`) → dropdown still appears correctly there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019PRjXnEuZdGXs9DgSxGJae

---
_Generated by [Claude Code](https://claude.ai/code/session_019PRjXnEuZdGXs9DgSxGJae)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Front-end UX in a shared autocomplete component with tested escaping and no backend or auth changes; main risk is layout side effects from forcing `position: relative` on input parents.
> 
> **Overview**
> Fixes the shared **RoleSelector** so suggestions appear under the field on pages without a positioned wrapper (e.g. voice interview) by setting the input parent to `position: relative` when it is `static`.
> 
> **Keyboard and a11y:** Replaces the stub that blocked arrows and always picked the first row with real list navigation (wrap, scroll-into-view, ArrowDown opens when ≥2 chars), **Enter** only while open, shared hover/active state, and listbox/option ARIA.
> 
> **Logic and safety:** Pulls filtering, DOM-free HTML escaping, match highlighting, and category labels into exported pure helpers; dropdown styling and readable categories are updated. Adds a **7-test** Node suite plus CI/`test:role-selector`; voice interview cache-busts the script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47e70a2a1ce7efa6ed9ea57170e5eed2cb4a2a14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->